### PR TITLE
fix(maintainer): rename dispatch mode upgrade-only → upgrade

### DIFF
--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -20,7 +20,7 @@ on:
         required: false
         default: "full"
         type: choice
-        options: [full, pr-only, issue-only, upgrade-only, dry-run]
+        options: [full, pr-only, issue-only, upgrade, dry-run]
 
 # Prevent concurrent caretaker runs so each run sees the up-to-date memory
 # store written by the previous run.


### PR DESCRIPTION
Caretaker's `RunMode` enum defines the upgrade mode value as `"upgrade"`:

```python
class RunMode(StrEnum):
    ...
    UPGRADE_ONLY = "upgrade"
```

This repo's `maintainer.yml` still advertises `upgrade-only` in the `workflow_dispatch` input's `choice` options, so a manual dispatch with that value passes a mode string caretaker doesn't accept (CLI exits with an invalid-enum error, which self-heal then files as an issue).

Fix: rename to `upgrade` so the dropdown stays in sync with the enum.

Upstream template fix: https://github.com/ianlintner/caretaker/pull/423

🤖 Generated with [Claude Code](https://claude.com/claude-code)