### PR TITLE
fix(ci): add checks:write and security_events:read to Caretaker workflow

### DIFF
--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -32,6 +32,8 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  checks: write
+  security_events: read
 
 jobs:
   maintain:


### PR DESCRIPTION
## Summary

- Adds `checks: write` permission so the code-review agent can post check runs on PRs (this was why no code reviews were ever posted)
- Adds `security_events: read` so the security agent can read code-scanning and secret-scanning alerts

## Root cause

Issue #19 identified that the `GITHUB_TOKEN` was missing these scopes, causing the affected agents to silently skip their work every run.

Fixes #19

## Test plan

- [ ] Caretaker workflow passes after merge
- [ ] Issue #19 is auto-closed by caretaker on next run (it re-opens if scope still missing)
- [ ] Next PR opened should receive a code review check run from caretaker

🤖 Generated with [Claude Code](https://claude.ai/code)