### PR TITLE
feat(ci): add Claude Code workflow to handle @claude review handoffs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,43 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Allow the caretaker bot to trigger this workflow via @claude mentions
+          allowed_bots: 'the-care-taker'
+
+          additional_permissions: |
+            actions: read


### PR DESCRIPTION
## Summary

- Adds `claude.yml` GitHub Actions workflow that listens for `@claude` mentions on issues and PRs
- Mirrors the identical workflow already working in the caretaker repo
- Allows `the-care-taker` bot to trigger it (so caretaker's `ClaudeCodeExecutor` handoffs work)

## Root cause

Caretaker's `PRReviewerAgent` was posting `@claude` review handoff comments on PRs #15, #21, and #22, but space-tycoon had no workflow listening for `@claude` mentions. The comments just sat unanswered.

## Prerequisite

The `CLAUDE_CODE_OAUTH_TOKEN` secret must be set in this repo's settings (Settings → Secrets → Actions). If you have it set in the caretaker repo already, add the same token here.

## Test plan

- [ ] Merge this PR
- [ ] Add `CLAUDE_CODE_OAUTH_TOKEN` secret if not already present
- [ ] Comment `@claude please review this PR` on any open PR — should trigger the workflow and get a response

🤖 Generated with [Claude Code](https://claude.ai/code)