### PR TITLE
fix(claude): fall back to ANTHROPIC_API_KEY when OAuth token missing

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Allow the caretaker bot to trigger this workflow via @claude mentions
           allowed_bots: 'the-care-taker'


### PR DESCRIPTION
The Claude Code workflow only referenced `CLAUDE_CODE_OAUTH_TOKEN`; when that secret wasn't set, runs failed with empty credentials (see run 24912136216). Adding `anthropic_api_key` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)