### PR TITLE
ci(deploy): drop PR trigger from Azure SWA deploy workflow

### DIFF
--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -1,11 +1,12 @@
 name: Deploy to Azure Static Web Apps
 
+# Production deploys only. Quality gates for PRs live in ci.yml so this
+# workflow doesn't run on pull_request events at all — the Azure SWA Free
+# tier caps preview environments at 3, and PR previews here weren't being
+# used for review (ci.yml is the gate). Removing the pull_request trigger
+# avoids the recurring "max staging environments" failure on every PR.
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
     branches:
       - main
   workflow_dispatch:
@@ -18,8 +19,6 @@ jobs:
   build-and-deploy:
     name: Build & Deploy
     runs-on: ubuntu-latest
-    # Skip the deploy step on closed PRs (Azure SWA handles preview cleanup)
-    if: github.event_name != 'pull_request' || github.event.action != 'closed'
 
     steps:
       - name: Checkout
@@ -57,16 +56,3 @@ jobs:
           app_location: "dist"
           output_location: ""
           skip_app_build: true
-
-  # Close pull-request preview environments
-  close-pr-preview:
-    name: Close PR Preview
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-
-    steps:
-      - name: Close Azure SWA staging environment
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
-          action: close


### PR DESCRIPTION
## Summary

Stops the Azure SWA deploy workflow from firing on PRs. Every PR's preview deploy has been failing for weeks with "max staging environments" — the Free tier caps preview environments at 3, and orphan envs from previously closed PRs have exhausted the quota.

## Why this is safe

- **Quality gates for PRs already run in [`ci.yml`](.github/workflows/ci.yml)** (typecheck + tests + build), so the duplicate run in this workflow added no real value.
- **Production deploys (`push: main`) are unaffected** — same job, same secrets, same destination.
- **PR previews weren't being used for review**, so removing them costs nothing.

## Changes

- Drop the `pull_request` trigger.
- Keep `push: main` and `workflow_dispatch`.
- Remove the now-unreachable `close-pr-preview` job.

## Test plan

- [x] YAML still valid (workflow file passes lint visually)
- [ ] After merge: confirm next PR doesn't trigger this workflow (only ci.yml)
- [ ] After merge: confirm `push: main` still triggers a production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)