### PR TITLE
Add build info and fullscreen play mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,15 @@ interface NavItem {
   label: string;
 }
 
+interface BuildInfo {
+  buildNumber: string;
+  commitSha: string;
+  shortCommit: string;
+  githubUrl: string;
+}
+
+declare const __SFT_BUILD_INFO__: BuildInfo;
+
 const NAV_ITEMS: NavItem[] = [
   { id: "overview", label: "Overview" },
   { id: "command-deck", label: "Command Deck" },
@@ -56,6 +65,24 @@ const NAV_ITEMS: NavItem[] = [
 ];
 
 let activeGame: Phaser.Game | null = null;
+const BUILD_INFO = __SFT_BUILD_INFO__;
+
+function escapeHtml(value: string): string {
+  const div = document.createElement("div");
+  div.textContent = value;
+  return div.innerHTML;
+}
+
+function renderBuildLink(className: string): string {
+  const label = `Build ${BUILD_INFO.buildNumber} / ${BUILD_INFO.shortCommit}`;
+  const safeLabel = escapeHtml(label);
+
+  if (!BUILD_INFO.githubUrl) {
+    return `<span class="${className}">${safeLabel}</span>`;
+  }
+
+  return `<a class="${className}" href="${escapeHtml(BUILD_INFO.githubUrl)}" target="_blank" rel="noreferrer noopener">${safeLabel}</a>`;
+}
 
 function renderNavLinks(): string {
   return NAV_ITEMS.map(
@@ -282,7 +309,7 @@ function renderSite(): void {
         <section id="overview" class="section hero hero--full-bleed">
           <div class="hero-shell">
             <div class="hero-stage hero-stage--full">
-              <div class="game-frame game-frame--hero">
+              <div class="game-frame game-frame--hero" data-game-frame>
                 <div class="game-frame__hud">
                   <div class="game-frame__cluster">
                     <span class="signal-light signal-light--teal"></span>
@@ -291,8 +318,9 @@ function renderSite(): void {
                     <span>Bridge View</span>
                   </div>
                   <div class="game-frame__status">
-                    <span>Interactive Build</span>
-                    <span>Ready for Launch</span>
+                    ${renderBuildLink("build-chip")}
+                    <span class="launch-state">Ready for Launch</span>
+                    <button class="game-frame__control" type="button" data-fullscreen-toggle aria-pressed="false">Full Screen</button>
                   </div>
                 </div>
 
@@ -537,7 +565,7 @@ function renderSite(): void {
 
       <footer class="footer">
         <p class="footer-note">
-          <strong>Star Freight Tycoon</strong> — playable web build, strategy manual, in-site wiki, and portrait QA tooling in one documentation-driven interface. <span id="site-year"></span>
+          <strong>Star Freight Tycoon</strong> — playable web build, strategy manual, in-site wiki, and portrait QA tooling in one documentation-driven interface. <span id="site-year"></span> · ${renderBuildLink("footer-build-link")}
         </p>
       </footer>
     </div>
@@ -658,6 +686,54 @@ function updateFooterYear(): void {
   }
 }
 
+function resizeGameToViewport(): void {
+  if (!activeGame) {
+    return;
+  }
+
+  const size = calculateGameSize();
+  updateLayout(size.width, size.height);
+  activeGame.scale.resize(size.width, size.height);
+  activeGame.scale.refresh();
+}
+
+function setupFullscreenControl(): void {
+  const frame = document.querySelector<HTMLElement>("[data-game-frame]");
+  const toggle = document.querySelector<HTMLButtonElement>(
+    "[data-fullscreen-toggle]",
+  );
+
+  if (!frame || !toggle) {
+    return;
+  }
+
+  if (!document.fullscreenEnabled || !frame.requestFullscreen) {
+    toggle.hidden = true;
+    return;
+  }
+
+  const syncButton = (): void => {
+    const isFullscreen = document.fullscreenElement === frame;
+    toggle.textContent = isFullscreen ? "Exit Full Screen" : "Full Screen";
+    toggle.setAttribute("aria-pressed", String(isFullscreen));
+    frame.classList.toggle("is-browser-fullscreen", isFullscreen);
+    window.requestAnimationFrame(resizeGameToViewport);
+  };
+
+  toggle.addEventListener("click", () => {
+    const request = document.fullscreenElement === frame
+      ? document.exitFullscreen()
+      : frame.requestFullscreen({ navigationUI: "hide" });
+
+    request.catch((error: unknown) => {
+      console.warn("Fullscreen request failed", error);
+    });
+  });
+
+  document.addEventListener("fullscreenchange", syncButton);
+  syncButton();
+}
+
 function mountGame(): void {
   if (activeGame) {
     return;
@@ -719,11 +795,7 @@ function mountGame(): void {
   window.addEventListener("resize", () => {
     if (resizeTimer) clearTimeout(resizeTimer);
     resizeTimer = setTimeout(() => {
-      if (!activeGame) return;
-      const size = calculateGameSize();
-      updateLayout(size.width, size.height);
-      activeGame.scale.resize(size.width, size.height);
-      activeGame.scale.refresh();
+      resizeGameToViewport();
     }, 250);
   });
 }
@@ -734,6 +806,7 @@ setupSectionObserver();
 setupAccordions();
 updateFooterYear();
 mountGame();
+setupFullscreenControl();
 
 if (import.meta.hot) {
   import.meta.hot.dispose(() => {

--- a/src/site.css
+++ b/src/site.css
@@ -639,16 +639,80 @@ canvas {
 .game-frame__status {
   display: inline-flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.55rem;
 }
 
 .game-frame__cluster span,
 .game-frame__status span,
+.game-frame__status a,
 .frame-caption__meta {
   color: var(--text-soft);
   font-size: 0.72rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
+}
+
+.build-chip,
+.footer-build-link {
+  color: var(--accent);
+}
+
+.build-chip:hover,
+.build-chip:focus-visible,
+.footer-build-link:hover,
+.footer-build-link:focus-visible {
+  color: var(--text);
+}
+
+.game-frame__control {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.55rem;
+  padding: 0.15rem 0.55rem;
+  border: 1px solid rgba(110, 255, 235, 0.34);
+  border-radius: 999px;
+  background: rgba(8, 15, 30, 0.72);
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+}
+
+.game-frame__control:hover,
+.game-frame__control:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(110, 255, 235, 0.72);
+  background: rgba(18, 35, 66, 0.92);
+  color: var(--text);
+}
+
+.game-frame:fullscreen {
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  border: 0;
+  border-radius: 0;
+  background: #03060c;
+}
+
+.game-frame:fullscreen .game-frame__screen,
+.game-frame.is-browser-fullscreen .game-frame__screen {
+  padding: 0.2rem;
+}
+
+.game-frame:fullscreen .viewport,
+.game-frame.is-browser-fullscreen .viewport {
+  height: 100%;
+  border-radius: 0;
 }
 
 .signal-light {
@@ -1219,7 +1283,8 @@ details[open] summary::after {
     padding: 0.2rem 0.5rem;
   }
 
-  .game-frame__hud .game-frame__status {
+  .game-frame__hud .build-chip,
+  .game-frame__hud .launch-state {
     display: none;
   }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,43 @@
 import { defineConfig } from "vite";
 import path from "path";
+import { execSync } from "node:child_process";
+
+function readGitValue(command: string): string | undefined {
+  try {
+    return execSync(command, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] })
+      .trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeGitHubRemote(remote: string | undefined): string | undefined {
+  if (!remote) {
+    return undefined;
+  }
+
+  const sshMatch = /^git@github\.com:(.+?)(?:\.git)?$/.exec(remote);
+  if (sshMatch) {
+    return `https://github.com/${sshMatch[1]}`;
+  }
+
+  if (remote.startsWith("https://github.com/")) {
+    return remote.replace(/\.git$/, "");
+  }
+
+  return undefined;
+}
+
+const commitSha = process.env.GITHUB_SHA ?? readGitValue("git rev-parse HEAD") ?? "unknown";
+const shortCommit = commitSha === "unknown" ? "unknown" : commitSha.slice(0, 7);
+const buildNumber = process.env.GITHUB_RUN_NUMBER ?? process.env.BUILD_NUMBER ?? "local";
+const repository = process.env.GITHUB_REPOSITORY;
+const githubBaseUrl = repository
+  ? `${process.env.GITHUB_SERVER_URL ?? "https://github.com"}/${repository}`
+  : normalizeGitHubRemote(readGitValue("git config --get remote.origin.url"));
+const commitUrl = githubBaseUrl && commitSha !== "unknown"
+  ? `${githubBaseUrl}/commit/${commitSha}`
+  : githubBaseUrl;
 
 export default defineConfig({
   // "/" = absolute paths; required for Azure Static Web Apps custom domain.
@@ -13,6 +51,14 @@ export default defineConfig({
         "packages/spacebiz-ui/src/index.ts",
       ),
     },
+  },
+  define: {
+    __SFT_BUILD_INFO__: JSON.stringify({
+      buildNumber,
+      commitSha,
+      shortCommit,
+      githubUrl: commitUrl ?? "",
+    }),
   },
   build: {
     target: "esnext",


### PR DESCRIPTION
## Summary
- Inject Vite build metadata from GitHub Actions or local git and surface build number plus commit link in the game frame and footer.
- Add a browser fullscreen toggle for the playable game frame with Phaser scale refresh on fullscreen and resize changes.
- Keep the fullscreen control visible on small screens while trimming nonessential HUD metadata.

## Verification
- npm run check