### PR TITLE
chore(deps): upgrade Phaser 3 → Phaser 4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,9 @@
 
 ## Project
 
-Sci-fi trading/tycoon game built with Phaser 3 + TypeScript, bundled with Vite 8, tested with Vitest 4, Node 22.
+Sci-fi trading/tycoon game built with Phaser 4 + TypeScript, bundled with Vite 8, tested with Vitest 4, Node 22.
+
+Phaser 4 has named exports only (no default export). Always use `import * as Phaser from "phaser"`. For masks, use the v4 filter API — `gameObject.filters?.internal.addMask(maskShape)` — not `setMask()`/`createGeometryMask()`, which Phaser 4 logs as deprecated under WebGL.
 
 ## Quick Reference
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "phaser": "^3.90.0"
+        "phaser": "^4.0.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -3705,13 +3705,13 @@
       "license": "MIT"
     },
     "node_modules/phaser": {
-      "version": "3.90.0",
-      "resolved": "https://registry.npmjs.org/phaser/-/phaser-3.90.0.tgz",
-      "integrity": "sha512-/cziz/5ZIn02uDkC9RzN8VF9x3Gs3XdFFf9nkiMEQT3p7hQlWuyjy4QWosU802qqno2YSLn2BfqwOKLv/sSVfQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/phaser/-/phaser-4.0.0.tgz",
+      "integrity": "sha512-f9oYpu3/UymB5JJDZRqOsNQm5FkMMC7u8eL8yQuqGAa54wTbgE2QbTOn70vgvlOVuYeQcw2mOQ52PpJHBSBkfQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "eventemitter3": "^5.0.1"
+        "eventemitter3": "^5.0.4"
       }
     },
     "node_modules/picocolors": {
@@ -4646,7 +4646,7 @@
       "name": "@spacebiz/ui",
       "version": "1.0.0",
       "peerDependencies": {
-        "phaser": "^3.90.0"
+        "phaser": "^4.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
-    "phaser": "^3.90.0"
+    "phaser": "^4.0.0"
   }
 }

--- a/packages/spacebiz-ui/package.json
+++ b/packages/spacebiz-ui/package.json
@@ -2,13 +2,13 @@
   "name": "@spacebiz/ui",
   "version": "1.0.0",
   "private": true,
-  "description": "Reusable Phaser 3 UI component library for Space Freight Tycoon",
+  "description": "Reusable Phaser UI component library for Space Freight Tycoon",
   "type": "module",
   "main": "src/index.ts",
   "exports": {
     ".": "./src/index.ts"
   },
   "peerDependencies": {
-    "phaser": "^3.90.0"
+    "phaser": "^4.0.0"
   }
 }

--- a/packages/spacebiz-ui/src/AmbientFX.ts
+++ b/packages/spacebiz-ui/src/AmbientFX.ts
@@ -4,7 +4,7 @@
  * All helpers return the created Tween so callers can stop it manually.
  * Use registerAmbientCleanup() to auto-stop a batch of tweens on scene shutdown.
  */
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 
 // ─── Config interfaces ─────────────────────────────────────────────────────
 

--- a/packages/spacebiz-ui/src/Button.ts
+++ b/packages/spacebiz-ui/src/Button.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import { playUiSfx } from "./UiSound.ts";
 import { autoButtonWidth, fitTextWithEllipsis } from "./TextMetrics.ts";

--- a/packages/spacebiz-ui/src/DataTable.ts
+++ b/packages/spacebiz-ui/src/DataTable.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import { playUiSfx } from "./UiSound.ts";
 
@@ -94,8 +94,7 @@ export class DataTable extends Phaser.GameObjects.Container {
       config.height - this.headerHeight,
     );
     this.maskShape.setPosition(config.x, config.y);
-    const mask = this.maskShape.createGeometryMask();
-    this.bodyContainer.setMask(mask);
+    this.bodyContainer.filters?.internal.addMask(this.maskShape);
 
     // Scroll indicator (visual-only, not interactive)
     const trackHeight = config.height - this.headerHeight;

--- a/packages/spacebiz-ui/src/Dropdown.ts
+++ b/packages/spacebiz-ui/src/Dropdown.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import { playUiSfx } from "./UiSound.ts";
 

--- a/packages/spacebiz-ui/src/FloatingText.ts
+++ b/packages/spacebiz-ui/src/FloatingText.ts
@@ -7,7 +7,7 @@
  *
  * The object self-destructs after the animation completes; no cleanup needed.
  */
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme } from "./Theme.ts";
 
 export interface FloatingTextConfig {

--- a/packages/spacebiz-ui/src/IconButton.ts
+++ b/packages/spacebiz-ui/src/IconButton.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import { playUiSfx } from "./UiSound.ts";
 

--- a/packages/spacebiz-ui/src/InfoCard.ts
+++ b/packages/spacebiz-ui/src/InfoCard.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import { StatRow } from "./StatRow.ts";
 

--- a/packages/spacebiz-ui/src/Label.ts
+++ b/packages/spacebiz-ui/src/Label.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 
 export type LabelStyle = "heading" | "body" | "caption" | "value";

--- a/packages/spacebiz-ui/src/MilestoneOverlay.ts
+++ b/packages/spacebiz-ui/src/MilestoneOverlay.ts
@@ -11,7 +11,7 @@
  * Usage:
  *   MilestoneOverlay.show(scene, "profit_streak", "🔥 4-Turn Streak!", "Keep it up!");
  */
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import { fitFontSize } from "./TextMetrics.ts";
 

--- a/packages/spacebiz-ui/src/Modal.ts
+++ b/packages/spacebiz-ui/src/Modal.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import { autoButtonWidth } from "./TextMetrics.ts";
 import { registerWidget } from "./WidgetHooks.ts";

--- a/packages/spacebiz-ui/src/Panel.ts
+++ b/packages/spacebiz-ui/src/Panel.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 
 export interface PanelConfig {

--- a/packages/spacebiz-ui/src/ProgressBar.ts
+++ b/packages/spacebiz-ui/src/ProgressBar.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 
 export interface ProgressBarConfig {

--- a/packages/spacebiz-ui/src/SceneUiDirector.ts
+++ b/packages/spacebiz-ui/src/SceneUiDirector.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { DEPTH_MODAL } from "./DepthLayers.ts";
 
 export interface SceneUiLayerOptions {

--- a/packages/spacebiz-ui/src/ScrollableList.ts
+++ b/packages/spacebiz-ui/src/ScrollableList.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme } from "./Theme.ts";
 
 export interface ScrollableListConfig {
@@ -38,15 +38,14 @@ export class ScrollableList extends Phaser.GameObjects.Container {
     this.listConfig = config;
     this.keyboardNavigationEnabled = config.keyboardNavigation ?? false;
 
-    // Clipping mask
+    // Clipping mask (Phaser 4 Mask filter)
     this.maskGraphics = scene.make.graphics({});
     this.maskGraphics.fillStyle(0xffffff);
     this.maskGraphics.fillRect(0, 0, config.width, config.height);
     this.maskGraphics.setPosition(config.x, config.y);
-    const mask = this.maskGraphics.createGeometryMask();
 
     this.contentContainer = scene.add.container(0, 0);
-    this.contentContainer.setMask(mask);
+    this.contentContainer.filters?.internal.addMask(this.maskGraphics);
     this.add(this.contentContainer);
 
     // Wheel capture area (kept behind list content so it doesn't block row clicks)

--- a/packages/spacebiz-ui/src/Starfield.ts
+++ b/packages/spacebiz-ui/src/Starfield.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { lerpColor, getTheme } from "./Theme.ts";
 import { addTwinkleTween, registerAmbientCleanup } from "./AmbientFX.ts";
 

--- a/packages/spacebiz-ui/src/StatRow.ts
+++ b/packages/spacebiz-ui/src/StatRow.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 
 export interface StatRowConfig {

--- a/packages/spacebiz-ui/src/StatusBadge.ts
+++ b/packages/spacebiz-ui/src/StatusBadge.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import { addPulseTween } from "./AmbientFX.ts";
 

--- a/packages/spacebiz-ui/src/TabGroup.ts
+++ b/packages/spacebiz-ui/src/TabGroup.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import { playUiSfx } from "./UiSound.ts";
 

--- a/packages/spacebiz-ui/src/TextMetrics.ts
+++ b/packages/spacebiz-ui/src/TextMetrics.ts
@@ -4,7 +4,7 @@
  * All functions create a temporary off-screen Phaser.Text, measure it,
  * then destroy it immediately so there is zero rendering cost.
  */
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 
 export interface TextSize {
   width: number;

--- a/packages/spacebiz-ui/src/Tooltip.ts
+++ b/packages/spacebiz-ui/src/Tooltip.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 
 export interface TooltipConfig {

--- a/packages/spacebiz-ui/src/WidgetHooks.ts
+++ b/packages/spacebiz-ui/src/WidgetHooks.ts
@@ -1,4 +1,4 @@
-import type Phaser from "phaser";
+import type * as Phaser from "phaser";
 
 export type WidgetKind =
   | "button"

--- a/src/audio/AudioDirector.ts
+++ b/src/audio/AudioDirector.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import {
   DEFAULT_AUDIO_SETTINGS,
   loadAudioSettings,

--- a/src/game/PortraitLoader.ts
+++ b/src/game/PortraitLoader.ts
@@ -17,7 +17,7 @@
  * for the lifetime of the game instance.
  */
 
-import type Phaser from "phaser";
+import type * as Phaser from "phaser";
 import {
   CEO_PORTRAITS,
   getPortraitTextureKey,

--- a/src/game/config.ts
+++ b/src/game/config.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { BASE_HEIGHT, MIN_WIDTH, MAX_WIDTH, updateLayout } from "@spacebiz/ui";
 
 export { BASE_HEIGHT, MIN_WIDTH, MAX_WIDTH };
@@ -37,6 +37,7 @@ export function createGameConfig(
     height: size.height,
     parent: "game-container",
     backgroundColor: "#0a0a1a",
+    roundPixels: true,
     scale: {
       mode: Phaser.Scale.FIT,
       autoCenter: Phaser.Scale.CENTER_BOTH,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import "./site.css";
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { createGameConfig, calculateGameSize } from "./game/config.ts";
 import { updateLayout } from "./ui/Layout.ts";
 import { BootScene } from "./scenes/BootScene.ts";

--- a/src/scenes/AISandboxScene.ts
+++ b/src/scenes/AISandboxScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import {
   getTheme,
   Button,
@@ -496,6 +496,10 @@ export class AISandboxScene extends Phaser.Scene {
   // ── UI Update ────────────────────────────────────────────────
 
   private updateUI(turnLog: TurnLog): void {
+    // Guard against post-shutdown turn events: Phaser 4 throws when setText
+    // hits a Frame whose backing data was already destroyed. cleanup() flips
+    // `running` to false on shutdown — bail before touching any GameObject.
+    if (!this.running || !this.scene?.isActive()) return;
     // Turn counter + progress — single source of truth (drive bar from turns)
     this.turnLabel.setText(`Turn ${this.currentTurn} / ${this.maxTurns}`);
     if (this.maxTurns > 0) {

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import type { ThemeConfig } from "../ui/index.ts";
 import {
   getTheme,

--- a/src/scenes/CompetitionScene.ts
+++ b/src/scenes/CompetitionScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import type { AICompany } from "../data/types.ts";
 import {

--- a/src/scenes/ContractsScene.ts
+++ b/src/scenes/ContractsScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import { ContractStatus, ContractType } from "../data/types.ts";
 import type {

--- a/src/scenes/DilemmaScene.ts
+++ b/src/scenes/DilemmaScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import {
   getTheme,

--- a/src/scenes/EmpireScene.ts
+++ b/src/scenes/EmpireScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import type { DiplomaticRelation, Empire } from "../data/types.ts";
 import {

--- a/src/scenes/FinanceScene.ts
+++ b/src/scenes/FinanceScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import type { Loan } from "../data/types.ts";
 import {
@@ -105,11 +105,11 @@ export class FinanceScene extends Phaser.Scene {
       .setOrigin(0.5, 0.5)
       .setDepth(10);
     fitImageCover(ceoImg, pSize, pSize);
-    // Round mask
+    // Round mask (Phaser 4 Mask filter)
     const ceoMask = this.add
       .circle(pX, pY, pSize / 2, 0xffffff)
       .setVisible(false);
-    ceoImg.setMask(ceoMask.createGeometryMask());
+    ceoImg.filters?.internal.addMask(ceoMask);
     // Border
     this.add
       .circle(pX, pY, pSize / 2 + 1)

--- a/src/scenes/FleetScene.ts
+++ b/src/scenes/FleetScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import { ShipClass } from "../data/types.ts";
 import type { Ship, ShipClass as ShipClassType } from "../data/types.ts";

--- a/src/scenes/GalaxyMapScene.ts
+++ b/src/scenes/GalaxyMapScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import {
   createStarfield,

--- a/src/scenes/GalaxySetupScene.ts
+++ b/src/scenes/GalaxySetupScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import {
   createStarfield,
   Panel,
@@ -164,7 +164,7 @@ export class GalaxySetupScene extends Phaser.Scene {
       portraitSize / 2,
     );
     this.portraitMask.setVisible(false);
-    this.portraitImage.setMask(this.portraitMask.createGeometryMask());
+    this.portraitImage.filters?.internal.addMask(this.portraitMask);
 
     // Accent border ring
     this.add

--- a/src/scenes/GameHUDScene.ts
+++ b/src/scenes/GameHUDScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import {
   Button,
   Label,
@@ -179,11 +179,11 @@ export class GameHUDScene extends Phaser.Scene {
       .image(hudPortraitX, hudPortraitY, initialKey)
       .setOrigin(0.5, 0.5);
     fitImageCover(portraitImg, portraitSize, portraitSize);
-    // Round mask
+    // Round mask (Phaser 4 Mask filter)
     const hudMask = this.add
       .circle(hudPortraitX, hudPortraitY, portraitSize / 2, 0xffffff)
       .setVisible(false);
-    portraitImg.setMask(hudMask.createGeometryMask());
+    portraitImg.filters?.internal.addMask(hudMask);
     // Subtle border ring
     this.add
       .circle(hudPortraitX, hudPortraitY, portraitSize / 2 + 1)

--- a/src/scenes/GameOverScene.ts
+++ b/src/scenes/GameOverScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import {
   getTheme,

--- a/src/scenes/MainMenuScene.ts
+++ b/src/scenes/MainMenuScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import {
   addFloatTween,
   addPulseTween,

--- a/src/scenes/MarketScene.ts
+++ b/src/scenes/MarketScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import { CargoType } from "../data/types.ts";
 import type { CargoType as CargoTypeValue } from "../data/types.ts";

--- a/src/scenes/PlanetDetailScene.ts
+++ b/src/scenes/PlanetDetailScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import { CargoType } from "../data/types.ts";
 import type { Planet, CargoMarketEntry } from "../data/types.ts";

--- a/src/scenes/RoutesScene.ts
+++ b/src/scenes/RoutesScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import { CargoType } from "../data/types.ts";
 import type { CargoType as CargoTypeValue } from "../data/types.ts";

--- a/src/scenes/SandboxSetupScene.ts
+++ b/src/scenes/SandboxSetupScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import {
   createStarfield,
   Panel,

--- a/src/scenes/SimPlaybackScene.ts
+++ b/src/scenes/SimPlaybackScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import { simulateTurn } from "../game/simulation/TurnSimulator.ts";
 import { SeededRNG } from "../utils/SeededRNG.ts";

--- a/src/scenes/SimSummaryScene.ts
+++ b/src/scenes/SimSummaryScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import {
   getTheme,
   colorToString,

--- a/src/scenes/StationBuilderScene.ts
+++ b/src/scenes/StationBuilderScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import type { HubRoom, HubRoomType, StationHub } from "../data/types.ts";
 import {

--- a/src/scenes/SystemMapScene.ts
+++ b/src/scenes/SystemMapScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import type { ActiveRoute, GameState, Planet, PlanetType, Ship } from "../data/types.ts";
 import {

--- a/src/scenes/TechTreeScene.ts
+++ b/src/scenes/TechTreeScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import { TechBranch } from "../data/types.ts";
 import type {

--- a/src/scenes/TurnReportScene.ts
+++ b/src/scenes/TurnReportScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import {
   getTheme,

--- a/src/testing/TestAPI.ts
+++ b/src/testing/TestAPI.ts
@@ -1,4 +1,4 @@
-import type Phaser from "phaser";
+import type * as Phaser from "phaser";
 import type {
   GameStateSnapshot,
   SceneInfo,

--- a/src/testing/WidgetRegistry.ts
+++ b/src/testing/WidgetRegistry.ts
@@ -1,4 +1,4 @@
-import type Phaser from "phaser";
+import type * as Phaser from "phaser";
 import type {
   WidgetRegistration,
   WidgetHookFn,

--- a/src/testing/__tests__/WidgetRegistry.test.ts
+++ b/src/testing/__tests__/WidgetRegistry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { WidgetRegistry } from "../WidgetRegistry";
-import type Phaser from "phaser";
+import type * as Phaser from "phaser";
 
 /**
  * Minimal scene stub. WidgetRegistry only reads `scene.events` (for lifecycle),

--- a/src/testing/actions.ts
+++ b/src/testing/actions.ts
@@ -1,4 +1,4 @@
-import type Phaser from "phaser";
+import type * as Phaser from "phaser";
 import { SftTestError } from "./types.ts";
 import type { ClickResult } from "./types.ts";
 import { widgetRegistry } from "./WidgetRegistry.ts";

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,4 +1,4 @@
-import type Phaser from "phaser";
+import type * as Phaser from "phaser";
 import { setWidgetHook } from "../../packages/spacebiz-ui/src/WidgetHooks.ts";
 import { widgetRegistry } from "./WidgetRegistry.ts";
 import { createTestAPI } from "./TestAPI.ts";

--- a/src/testing/snapshot.ts
+++ b/src/testing/snapshot.ts
@@ -1,4 +1,4 @@
-import type Phaser from "phaser";
+import type * as Phaser from "phaser";
 import type { GameStateSnapshot, SceneInfo } from "./types.ts";
 import { gameStore } from "../data/GameStore.ts";
 

--- a/src/ui/AdviserPanel.ts
+++ b/src/ui/AdviserPanel.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import {
   getMoodAccentColor,

--- a/src/ui/AdviserPortrait.ts
+++ b/src/ui/AdviserPortrait.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import type { AdviserMood } from "../data/types.ts";
 import { getTheme } from "./Theme.ts";
 import type { PortraitExpression } from "./PortraitExpression.ts";

--- a/src/ui/EmpireBorders.ts
+++ b/src/ui/EmpireBorders.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import type { StarSystem, Empire } from "../data/types.ts";
 import { addPulseTween, getTheme } from "@spacebiz/ui";
 

--- a/src/ui/EmpireFlagGenerator.ts
+++ b/src/ui/EmpireFlagGenerator.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { SeededRNG } from "../utils/SeededRNG.ts";
 
 /**
@@ -192,9 +192,11 @@ export function generateEmpireFlags(
     gfx.clear();
     drawFlagPattern(gfx, pattern, primary, secondary, accent);
 
-    // Render to a texture
+    // Render to a texture. Phaser 4 buffers draw commands; render() must run
+    // before saveTexture() captures the result.
     const rt = scene.add.renderTexture(0, 0, FLAG_W, FLAG_H).setVisible(false);
     rt.draw(gfx);
+    rt.render();
     rt.saveTexture(texKey);
     rt.destroy();
   }

--- a/src/ui/LoadingOverlay.ts
+++ b/src/ui/LoadingOverlay.ts
@@ -21,7 +21,7 @@
  *   overlay.hide();
  */
 
-import type Phaser from "phaser";
+import type * as Phaser from "phaser";
 
 export interface LoadingOverlayOptions {
   /** Text shown below the bar. Defaults to "Loading…" */

--- a/src/ui/MiniMap.ts
+++ b/src/ui/MiniMap.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import type {
   StarSystem,
   Planet,

--- a/src/ui/PortraitGenerator.ts
+++ b/src/ui/PortraitGenerator.ts
@@ -1,4 +1,4 @@
-import type Phaser from "phaser";
+import type * as Phaser from "phaser";
 import { SeededRNG } from "../utils/SeededRNG.ts";
 import type { EventCategory, PlanetType, ShipClass } from "../data/types.ts";
 import { getTheme, lerpColor } from "./Theme.ts";

--- a/src/ui/PortraitPanel.ts
+++ b/src/ui/PortraitPanel.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { Panel } from "./Panel.ts";
 import { Label } from "./Label.ts";
 import { getTheme } from "./Theme.ts";
@@ -44,6 +44,7 @@ export interface PortraitPanelConfig {
 export class PortraitPanel extends Phaser.GameObjects.Container {
   private panel: Panel;
   private portraitGraphics: Phaser.GameObjects.Graphics;
+  private portraitMaskShape!: Phaser.GameObjects.Graphics;
   private portraitImage: Phaser.GameObjects.Image | null = null;
   private nameLabel: Label;
   private statLabels: Label[];
@@ -86,17 +87,16 @@ export class PortraitPanel extends Phaser.GameObjects.Container {
     // Created on demand in updatePortrait when a loaded texture is available
     this.portraitImage = null;
 
-    // Geometry mask to clip portrait within panel bounds
-    const maskShape = scene.make.graphics({});
-    maskShape.fillStyle(0xffffff, 1);
-    maskShape.fillRect(
+    // Geometry mask to clip portrait within panel bounds (Phaser 4 Mask filter)
+    this.portraitMaskShape = scene.make.graphics({});
+    this.portraitMaskShape.fillStyle(0xffffff, 1);
+    this.portraitMaskShape.fillRect(
       config.x + theme.spacing.sm,
       config.y + theme.spacing.sm,
       this.portraitWidth,
       this.portraitHeight,
     );
-    const mask = new Phaser.Display.Masks.GeometryMask(scene, maskShape);
-    this.portraitGraphics.setMask(mask);
+    this.portraitGraphics.filters?.internal.addMask(this.portraitMaskShape);
 
     // Name label — below portrait area, centered, heading + accent
     const nameLabelY =
@@ -114,11 +114,11 @@ export class PortraitPanel extends Phaser.GameObjects.Container {
     scene.children.remove(this.nameLabel);
     this.add(this.nameLabel);
 
-    // Clip all content (stats, name, portrait) to panel bounds
+    // Clip all content (stats, name, portrait) to panel bounds (Phaser 4 Mask filter)
     const clipShape = scene.make.graphics({});
     clipShape.fillStyle(0xffffff, 1);
     clipShape.fillRect(config.x, config.y, this.panelWidth, panelHeight);
-    this.setMask(clipShape.createGeometryMask());
+    this.filters?.internal.addMask(clipShape);
 
     scene.add.existing(this);
   }
@@ -154,7 +154,7 @@ export class PortraitPanel extends Phaser.GameObjects.Container {
           theme.spacing.sm + this.portraitHeight / 2,
           texKey,
         );
-        this.portraitImage.setMask(this.portraitGraphics.mask!);
+        this.portraitImage.filters?.internal.addMask(this.portraitMaskShape);
         this.add(this.portraitImage);
       } else {
         this.portraitImage.setTexture(texKey);

--- a/src/ui/RouteBuilderPanel.ts
+++ b/src/ui/RouteBuilderPanel.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
 import { SHIP_TEMPLATES } from "../data/constants.ts";
 import { CargoType } from "../data/types.ts";

--- a/src/ui/TutorialOverlay.ts
+++ b/src/ui/TutorialOverlay.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import { Button } from "./Button.ts";
 import { drawRexPortrait } from "./AdviserPortrait.ts";

--- a/styleguide/main.ts
+++ b/styleguide/main.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import { StyleguideBootScene } from "./scenes/StyleguideBootScene.ts";
 import { StyleguideScene } from "./scenes/StyleguideScene.ts";
 import { getLayout } from "@spacebiz/ui";

--- a/styleguide/scenes/StyleguideBootScene.ts
+++ b/styleguide/scenes/StyleguideBootScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import type { ThemeConfig } from "@spacebiz/ui";
 import { getTheme, lerpColor, generateCargoIcons } from "@spacebiz/ui";
 

--- a/styleguide/scenes/StyleguideScene.ts
+++ b/styleguide/scenes/StyleguideScene.ts
@@ -1,4 +1,4 @@
-import Phaser from "phaser";
+import * as Phaser from "phaser";
 import {
   getTheme,
   colorToString,


### PR DESCRIPTION
## Summary

- Bumps `phaser` from `^3.90.0` to `^4.0.0`. v4 is a ground-up WebGL renderer rebuild (RenderNode arch replacing pipelines), a unified Filter system (FX + Masks merged), `Geom.Point` removed in favor of `Vector2`, and several behavioral defaults flipped.
- Ports the codebase to the v4 surface, plus fixes two issues surfaced during QA that the official migration guide did not flag.
- Project memory: [Phaser 3 → 4 migration guide](https://github.com/phaserjs/phaser/blob/master/changelog/v4/4.0/MIGRATION-GUIDE.md).

## What changed

**Planned (per the migration guide)**
- [`src/game/config.ts`](src/game/config.ts): `roundPixels: true`. v4's default flipped to `false`; this preserves v3 pixel-snapping for HUD / Labels / Graphics borders that would otherwise sub-pixel-blur.
- [`src/ui/EmpireFlagGenerator.ts`](src/ui/EmpireFlagGenerator.ts): explicit `rt.render()` between `draw()` and `saveTexture()`. v4 buffers RenderTexture draw commands instead of executing immediately.

**Surfaced during QA, not in the migration guide**
- **Default ESM export removed.** `import Phaser from "phaser"` fails at runtime in v4. Rewrote 66 files to `import * as Phaser from "phaser"` (`src/`, `packages/spacebiz-ui/`, and the `styleguide/` Vite entry).
- **`setMask` / `createGeometryMask` deprecated under WebGL** (logs a warning every frame — 40+ per scene). Migrated 6 sites to the v4 filter API `gameObject.filters?.internal.addMask(maskShape)`:
  - [`PortraitPanel.ts`](src/ui/PortraitPanel.ts) (×3, including a shared mask reference now stored as a class field)
  - [`ScrollableList.ts`](packages/spacebiz-ui/src/ScrollableList.ts), [`DataTable.ts`](packages/spacebiz-ui/src/DataTable.ts)
  - [`GameHUDScene.ts:186`](src/scenes/GameHUDScene.ts), [`FinanceScene.ts:112`](src/scenes/FinanceScene.ts), [`GalaxySetupScene.ts:167`](src/scenes/GalaxySetupScene.ts)
- **Latent post-shutdown race in AISandboxScene**, now fatal under v4. Async sim turns called `Label.setText` after scene shutdown, hitting `Frame.data.drawImage = null`. Phaser 3 silently tolerated this; v4 strict-checks Frame state on Text updates. Added a `running && scene.isActive()` guard at [`AISandboxScene.ts:498`](src/scenes/AISandboxScene.ts).

**Other**
- `packages/spacebiz-ui/package.json`: peer dep widened to `^4.0.0`.
- `CLAUDE.md`: noted the import convention (`import * as Phaser`) and the filter API for masks.

## Bundle delta

| Chunk | Before | After | Δ raw | Δ gzip |
|---|---|---|---|---|
| `main.js` | 542.97 kB | 542.30 kB | -0.67 kB | -0.03 kB |
| `AdviserPortrait.js` (Phaser) | 1,287.59 kB | 1,440.58 kB | **+152.99 kB** | **+31.82 kB** |

The +153 kB raw / +32 kB gzip on the Phaser-containing chunk is the cost of v4's renderer rebuild + unified Filter system.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` — 50 files / 723 tests pass without modification (game logic is pure-function so no Phaser stubs needed)
- [x] `npm run build` — production bundle builds cleanly
- [x] Manual scene tour via the in-page QA API (`window.__sft.goToScene(...)`): walked all 14 navigable scenes (Galaxy/System/Fleet/Routes/Contracts/TechTree/Finance/Market/StationBuilder/Empire/Competition/TurnReport/GameOver/SandboxSetup/MainMenu) — **0 console errors, 0 setMask warnings**
- [x] AI sandbox flow that previously triggered `runAsync error` mid-sim now completes cleanly when navigating away
- [ ] Reviewer: visual diff against `main` for portrait masking (round-clip on HUD CEO portrait, finance portrait, galaxy setup portrait) — the filter API rewrite is the highest-risk visual change

## Notes for reviewer

- The default-import → namespace-import change is mechanical (single regex applied across 66 files). Worth scanning a few to confirm nothing got mangled.
- The `filters?.internal.addMask(...)` calls use optional chaining because Phaser's `.d.ts` types `filters` as `FiltersInternalExternal | null` — the value is non-null in practice for our usage, but the optional chain is defensive against scenes that haven't fully initialized.
- `DilemmaScene` was not visited by the QA tour — the test API doesn't have a button-driven entry point for it. Manual smoke recommended if you suspect dilemma-specific rendering paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)