### PR TITLE
docs: refresh README + homepage with manual-style voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,98 +2,137 @@
 
 <img width="512" alt="cargo" src="https://github.com/user-attachments/assets/ab5101f7-1d86-456c-9fa2-6f9821a846f9" />
 
-A browser-based, turn-driven space trading and fleet management game built with **TypeScript**, **Phaser**, and **Vite**.
+> **GREETINGS, CAPTAIN.** A freshly-printed corporate charter, two starter
+> hulls, and a quarterly P&L stand between you and a galaxy of cargo waiting
+> to be moved. Welcome to **Star Freight Tycoon** — a browser-based, turn-driven
+> space-trade sim built in **TypeScript**, **Phaser 4**, and **Vite**.
 
-You run a growing freight company in a living galaxy: buy low, sell high, expand your fleet, optimize routes, survive market swings, and chase the high score.
+Buy low, sell high, expand your fleet, optimize routes, weather the market
+swings, and climb the high-score table — across procedurally generated
+galaxies. It's the spiritual lovechild of **Aerobiz Supersonic**,
+**Master of Orion 2**, and **Transport Tycoon**, with the build pipeline of
+2026 and the operating manual energy of 1996.
 
-## Features
+## What's in the box
 
-- Procedurally generated galaxy and market setup
-- Turn simulation with economy updates and events
-- Fleet, routes, and finance management scenes
-- Retro-inspired UI and audio systems
-- Strong unit test coverage across core game systems
+- **Procedural galaxies** with seeded RNG — same seed, same map, every time.
+- **Hybrid turn loop** — Plan → Simulate → Review. Set your routes, hit
+  *End Quarter*, watch the simulation play out, then read the report.
+- **Living economy** — planet types produce and demand; saturate a market
+  and prices crater; events shake everything up.
+- **Rival AI empires** with named CEOs, portraits, and competing fleets.
+- **Mid-quarter dilemmas** — narrative choices with success-rate scaling
+  and AI-generated story beats.
+- **Save / load** — autosaves to localStorage every turn; full state
+  resume across browser refreshes.
+- **Phaser-canvas-only UI** — no DOM overlays. Reusable component library
+  with theme primitives, scrollable lists, data tables, modals, tooltips.
+- **In-app QA console** — `window.__sft` lets you script the game from
+  devtools, Playwright, or an MCP-driven agent. See
+  [`docs/qa/console-api.md`](docs/qa/console-api.md).
 
-## Tech Stack
+## Tech stack
 
-- **Engine/UI:** Phaser 3
-- **Language:** TypeScript
-- **Build Tool:** Vite
-- **Testing:** Vitest
+| Layer        | Choice                                                              |
+| ------------ | ------------------------------------------------------------------- |
+| Engine       | **Phaser 4** (WebGL renderer, RenderNode arch, unified Filter API)  |
+| Language     | TypeScript (strict, `verbatimModuleSyntax`, `erasableSyntaxOnly`)   |
+| Bundler      | Vite 8                                                              |
+| Tests        | Vitest 4 — **723 tests across 50 files**, all pure-function         |
+| Runtime      | Node 22+, npm 10+                                                   |
+| Optional MCP | `@spacebiz/qa-mcp` — drive the running game from an LLM agent       |
 
-## Getting Started
-
-### Prerequisites
-
-- Node.js 22+
-- npm 10+
-
-### Install
-
-```bash
-npm ci
-```
-
-### Run locally
-
-```bash
-npm run dev
-```
-
-### Build
-
-```bash
-npm run build
-```
-
-### Run tests
+## Getting started
 
 ```bash
-npm run test
+npm ci              # install (uses workspaces; pulls @spacebiz/ui too)
+npm run dev         # localhost:5173
+npm run typecheck   # strict TS, no unused locals/params
+npm run test        # vitest
+npm run build       # tsc && vite build
+npm run check       # all three CI gates back-to-back
 ```
 
-## Quality Gates (CI)
+`npm run optimize-assets` regenerates the WebP/PNG portrait set under
+`public/portraits/` from the high-res sources in `assets-source/`. See the
+[asset pipeline notes in `CLAUDE.md`](CLAUDE.md) before adding new portraits.
 
-On pull requests and pushes to `main`, CI runs:
+## Project layout
 
-1. Type checking (`npm run typecheck`)
-2. Unit tests (`npm run test`)
-3. Production build (`npm run build`)
+```
+src/
+├── scenes/            # 23 Phaser scenes (one screen each)
+│   ├── BootScene, MainMenuScene, GalaxySetupScene
+│   ├── GalaxyMapScene, SystemMapScene, PlanetDetailScene
+│   ├── FleetScene, RoutesScene, ContractsScene, MarketScene
+│   ├── TechTreeScene, FinanceScene, StationBuilderScene
+│   ├── EmpireScene, CompetitionScene
+│   ├── DilemmaScene, SimPlaybackScene, TurnReportScene
+│   └── GameOverScene, SimSummaryScene, AISandboxScene, …
+├── game/              # simulation, save, portrait loader, scoring
+├── data/              # GameStore (state + EventEmitter), constants, types
+├── ui/                # game-specific widgets (PortraitPanel, MiniMap, …)
+├── audio/             # AudioDirector + retro-pop SFX hooks
+├── generation/        # procedural galaxy + market generation
+├── testing/           # window.__sft QA façade (DEV + ?debug=1 in prod)
+└── siteContent.ts     # homepage manual + cheat sheets
 
+packages/
+├── spacebiz-ui/       # 28-file Phaser UI component library (@spacebiz/ui)
+└── spacebiz-qa-mcp/   # optional MCP server for agent-driven QA
 
-GitHub Pages deployment also enforces these gates before publish.
+styleguide/            # visual styleguide app — separate Vite entry
+docs/plans/            # design + implementation plans (dated artifacts)
+docs/qa/console-api.md # QA façade reference
+```
+
+## CI gates
+
+CI runs Node 22 on Ubuntu and enforces three gates on every push:
+
+1. `npm run typecheck` — strict TS, no unused locals/params.
+2. `npm run test` — full Vitest run.
+3. `npm run build` — production bundle.
+
+GitHub Pages deployment also runs these gates before publishing.
 
 ## Deployment
 
-This repository is configured to deploy automatically to **GitHub Pages** from `main` using GitHub Actions.
+Auto-deploys to **GitHub Pages** from `main` via Actions. First time:
 
-If this is your first time enabling Pages for the repo:
+1. **Settings → Pages** → Source: **GitHub Actions**.
+2. Push to `main` (or trigger the deploy workflow manually).
 
-1. Open **Settings → Pages**.
-2. Set **Source** to **GitHub Actions**.
-3. Push to `main` (or manually run the deploy workflow).
+## Conventions worth knowing
 
-## Project Structure
-
-- `src/scenes/` – game scenes and flow
-- `src/game/` – simulation, economy, events, fleet, routes, scoring
-- `src/generation/` – world/market/name generation
-- `src/ui/` – reusable UI components and theme primitives
-- `src/data/` – game state store, constants, shared types
+- Game state lives in `src/data/GameStore.ts` (singleton, plain objects + EventEmitter).
+- Game logic is **pure** — every simulation function is testable without Phaser.
+- Deterministic RNG via `src/utils/SeededRNG.ts`.
+- No TS enums; use `as const` objects (the tsconfig forbids enums).
+- Phaser is imported as `import * as Phaser from "phaser"` (v4 dropped the
+  default export).
+- For masks, use the v4 filter API:
+  `gameObject.filters?.internal.addMask(maskShape)` — not `setMask()`.
 
 ## Contributing
 
-Contributions are welcome! If you’d like to help:
+PRs welcome. Keep simulation logic deterministic. Add or update Vitest
+coverage for non-visual systems. Run `npm run check` before pushing.
 
+```
 1. Fork the repo
-2. Create a feature branch
-3. Add or update tests for your changes
-4. Open a PR
-
-Please keep gameplay logic deterministic where possible and maintain/expand test coverage for non-visual systems.
+2. Branch off main
+3. Add tests with your changes
+4. Open a PR — CI will run all three gates
+```
 
 ## License
 
-No license file has been added yet.
+No license file yet. If this project should be open source, MIT is a
+reasonable default for indie game projects.
 
-If you want this to be fully open source, add a license (MIT is a common choice for indie game projects).
+---
+
+> *"Profit is just gravity in disguise. Find a producer, find a buyer,
+> point the ship between them, and let the universe do the rest."*
+> — Apocryphal, attributed to every freight captain who ever lived.

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Star Freight Tycoon is a turn-driven sci-fi freight management game with a playable home page, strategy manual, help center, and AI asset disclosure."
+      content="Star Freight Tycoon — a turn-driven space-trade sim built in Phaser 4. Playable bridge, full operations manual, in-site wiki, and honest production notes on a single scroll."
     />
     <meta name="author" content="Ian Lintner" />
     <meta name="robots" content="index,follow" />
@@ -15,7 +15,7 @@
     <meta property="og:title" content="Star Freight Tycoon" />
     <meta
       property="og:description"
-      content="Build a galactic freight empire in a turn-driven space business sim with a playable homepage, strategy manual, and cinematic sci-fi presentation."
+      content="Build a galactic freight empire in a turn-driven space business sim. Aerobiz Supersonic meets Master of Orion 2, in your browser, with the manual baked in."
     />
     <meta
       property="og:image"
@@ -30,7 +30,7 @@
     <meta name="twitter:title" content="Star Freight Tycoon" />
     <meta
       name="twitter:description"
-      content="Build routes, manage fleets, and grow a space freight company in this turn-driven galactic tycoon sim."
+      content="Build routes, manage fleets, and grow a galactic freight empire — turn by turn, quarter by quarter. Bridge, manual, and wiki on one page."
     />
     <meta
       name="twitter:image"

--- a/public/wiki/index.html
+++ b/public/wiki/index.html
@@ -63,8 +63,8 @@
     </style>
   </head>
   <body>
-    <h1>Star Freight Tycoon Wiki</h1>
-    <p>Reference hub for CEOs, empire leaders, ships, and QA sheets.</p>
+    <h1>Star Freight Tycoon — Codex</h1>
+    <p>Reference hub for the people, empires, and hulls of the galaxy. Plus the QA sheets if you came for the receipts.</p>
     <div class="grid">
       <a href="./ceos.html"
         ><strong>CEO Directory</strong

--- a/src/main.ts
+++ b/src/main.ts
@@ -281,7 +281,7 @@ function renderSite(): void {
           <span class="brand__mark">SF</span>
           <span class="brand__text">
             <span class="brand__title">Star Freight Tycoon</span>
-            <span class="brand__subtitle">Trade lanes, quarter reports, and long-horizon strategy.</span>
+            <span class="brand__subtitle">Trade lanes, quarterly P&Ls, and the slow art of empire.</span>
           </span>
         </a>
 
@@ -333,18 +333,18 @@ function renderSite(): void {
 
               <div class="frame-caption frame-caption--hero">
                 <p>
-                  The game now owns the top of the page as a true hero banner, while the briefings, manual, and disclosures dock neatly underneath it.
+                  Captain on deck. Charters drawn, hulls fueled, market open.
                 </p>
-                <span class="frame-caption__meta">Phaser 3 • TypeScript • Vite</span>
+                <span class="frame-caption__meta">Phaser 4 • TypeScript • Vite</span>
               </div>
             </div>
 
             <div class="hero-copy-wrap panel-surface">
               <div class="hero-copy hero-copy--full">
-                <span class="kicker">Playable Home Screen</span>
-                <h1>Operate a freight empire from a live, playable command interface.</h1>
+                <span class="kicker">Cleared for Launch</span>
+                <h1>Run a freight empire across a procedural galaxy.</h1>
                 <p>
-                  The website is designed as an operational hub: a playable build at the top, then strategy documentation, encyclopedia-style references, and transparent production notes.
+                  Buy low, sell high, expand the fleet, weather the events. Twenty quarters to build something that lasts.
                 </p>
 
                 <div class="hero-actions">
@@ -355,21 +355,21 @@ function renderSite(): void {
 
                 <div class="hero-badges">
                   <article class="badge">
-                    <span>Game Loop</span>
+                    <span>Loop</span>
                     <strong>Plan → Simulate → Review</strong>
                   </article>
                   <article class="badge">
                     <span>Systems</span>
-                    <strong>Economy, routes, fleets, events</strong>
+                    <strong>Routes, fleets, contracts, dilemmas, AI rivals</strong>
                   </article>
                   <article class="badge">
-                    <span>Style</span>
-                    <strong>Retro-futurist control room presentation</strong>
+                    <span>Vibes</span>
+                    <strong>Retro command-deck — Aerobiz meets MOO2</strong>
                   </article>
                 </div>
 
                 <div class="hero-metrics">
-                  <h2 class="hero-metrics__title">Current mission profile</h2>
+                  <h2 class="hero-metrics__title">Mission briefing</h2>
                   <div class="metrics-grid">
                     ${renderHeroMetrics()}
                   </div>
@@ -382,12 +382,9 @@ function renderSite(): void {
         <section id="command-deck" class="section panel-surface">
           <div class="section-head">
             <div>
-              <span class="kicker">Site Menu</span>
-              <h2>Clear navigation for gameplay, documentation, and review.</h2>
+              <span class="kicker">Command Deck</span>
+              <h2>Pick a heading.</h2>
             </div>
-            <p>
-              Navigation is intentionally direct: sticky section menu, active section indicators, and collapsible briefings for quick scanning.
-            </p>
           </div>
 
           <div class="command-layout">
@@ -396,30 +393,27 @@ function renderSite(): void {
             </div>
 
             <div class="copy-block">
-              <h3 class="panel-title">Command shortcuts</h3>
-              <p>
-                Use these shortcuts to move between gameplay, documentation, and visual reference material without context switching.
-              </p>
+              <h3 class="panel-title">Quick warps</h3>
               <div class="quick-links">
                 <a class="quick-link" href="#overview">
-                  <strong>Return to bridge</strong>
-                  <span>Snap back to the framed playable build.</span>
+                  <strong>Back to the bridge</strong>
+                  <span>Hands on the controls.</span>
                 </a>
                 <a class="quick-link" href="#manual">
                   <strong>Operations manual</strong>
-                  <span>See the campaign loop, starter loadout, planets, and cargo logic.</span>
+                  <span>Opening moves, cargo logic, expansion timing.</span>
                 </a>
                 <a class="quick-link" href="#help">
-                  <strong>Quick help</strong>
-                  <span>Open concise strategy panels and the operational FAQ.</span>
+                  <strong>Strategy panels</strong>
+                  <span>Mid-run answers when something's off.</span>
                 </a>
                 <a class="quick-link" href="#ai-disclosure">
                   <strong>Production notes</strong>
-                  <span>Review the disclosure for AI-assisted music and visual material usage.</span>
+                  <span>Receipts and credits.</span>
                 </a>
                 <a class="quick-link" href="#wiki">
-                  <strong>Game wiki</strong>
-                  <span>Browse CEOs, leaders, and ship classes in one indexed section.</span>
+                  <strong>Codex</strong>
+                  <span>CEOs, empire leaders, every ship class.</span>
                 </a>
               </div>
             </div>
@@ -429,12 +423,9 @@ function renderSite(): void {
         <section id="manual" class="section panel-surface">
           <div class="section-head">
             <div>
-              <span class="kicker">Gameplay Manual</span>
-              <h2>Everything you need to play without opening a second tab.</h2>
+              <span class="kicker">Operations Manual</span>
+              <h2>Six chapters between you and a profitable run.</h2>
             </div>
-            <p>
-              Start here for the complete loop: opening setup, route economics, expansion timing, and risk control.
-            </p>
           </div>
 
           <div class="manual-layout">
@@ -463,12 +454,9 @@ function renderSite(): void {
         <section id="wiki" class="section panel-surface">
           <div class="section-head">
             <div>
-              <span class="kicker">Game Wiki</span>
-              <h2>Dedicated reference pages for characters, leaders, and ships.</h2>
+              <span class="kicker">Codex</span>
+              <h2>CEOs, empire leaders, every ship in the catalog.</h2>
             </div>
-            <p>
-              The homepage now stays compact while full wiki pages open separately for deeper reading and QA workflows.
-            </p>
           </div>
 
           <div class="qa-grid">
@@ -480,11 +468,8 @@ function renderSite(): void {
           <div class="section-head">
             <div>
               <span class="kicker">Portrait QA</span>
-              <h2>Dedicated compact galleries for art and agent QA workflows.</h2>
+              <h2>Compact galleries for fast art review.</h2>
             </div>
-            <p>
-              Open these standalone pages to review full portrait sets quickly. They are optimized for scanning, mismatch spotting, and prompt iteration loops.
-            </p>
           </div>
 
           <div class="qa-grid">
@@ -495,12 +480,9 @@ function renderSite(): void {
         <section id="help" class="section panel-surface">
           <div class="section-head">
             <div>
-              <span class="kicker">Help & Strategy</span>
-              <h2>Fast strategic answers for mid-run decision points.</h2>
+              <span class="kicker">Strategy Tips</span>
+              <h2>Fast answers for the decisions that actually swing a run.</h2>
             </div>
-            <p>
-              These panels focus on practical decisions: opening routes, fleet expansion timing, and recovery patterns after weak turns.
-            </p>
           </div>
 
           <div class="help-layout">
@@ -510,9 +492,6 @@ function renderSite(): void {
 
             <div class="help-panel">
               <h3>Fast answers</h3>
-              <p>
-                If you are already mid-run, this FAQ is the shortest route back to confidence.
-              </p>
               <div class="faq-list">
                 ${renderFaqItems()}
               </div>
@@ -523,12 +502,9 @@ function renderSite(): void {
         <section id="ai-disclosure" class="section panel-surface">
           <div class="section-head">
             <div>
-              <span class="kicker">AI Disclosure</span>
-              <h2>Clear credits and production notes, right where players can find them.</h2>
+              <span class="kicker">Production Notes</span>
+              <h2>Receipts, credits, and an honest map of who made what.</h2>
             </div>
-            <p>
-              The site explicitly discloses AI-assisted music and visual materials while keeping authorship, editing, and implementation responsibility plainly human and easy to understand.
-            </p>
           </div>
 
           <div class="disclosure-grid">
@@ -537,25 +513,19 @@ function renderSite(): void {
 
           <div class="footer-layout" style="margin-top: 1rem;">
             <div class="footer-panel">
-              <h3>Why this structure works</h3>
-              <p>
-                The site keeps the build playable while surfacing strategy docs, wiki content, QA galleries, and transparent credits in a single reliable flow.
-              </p>
-            </div>
-            <div class="footer-panel">
               <h3>Quick links</h3>
               <div class="footer-links">
                 <a class="quick-link" href="#overview">
-                  <strong>Play view</strong>
-                  <span>Back to the framed build.</span>
+                  <strong>Bridge</strong>
+                  <span>Take the controls.</span>
                 </a>
                 <a class="quick-link" href="#manual">
                   <strong>Manual</strong>
-                  <span>Full loop and cheat sheets.</span>
+                  <span>Loop, hulls, cheat sheets.</span>
                 </a>
                 <a class="quick-link" href="#portrait-qa">
                   <strong>Portrait QA</strong>
-                  <span>Open compact gallery pages for visual review.</span>
+                  <span>Compact art galleries.</span>
                 </a>
               </div>
             </div>
@@ -565,7 +535,7 @@ function renderSite(): void {
 
       <footer class="footer">
         <p class="footer-note">
-          <strong>Star Freight Tycoon</strong> — playable web build, strategy manual, in-site wiki, and portrait QA tooling in one documentation-driven interface. <span id="site-year"></span> · ${renderBuildLink("footer-build-link")}
+          <strong>Star Freight Tycoon</strong> <span id="site-year"></span> · ${renderBuildLink("footer-build-link")}
         </p>
       </footer>
     </div>

--- a/src/siteContent.ts
+++ b/src/siteContent.ts
@@ -78,42 +78,45 @@ function labelFor(value: string): string {
 
 export const HERO_METRICS: HeroMetric[] = [
   {
-    label: "Opening Capital",
+    label: "Seed Capital",
     value: formatCurrency(STARTING_CASH),
-    detail: "Starting treasury available at campaign launch.",
+    detail:
+      "Your treasury at launch. Every credit gets spent or invested — the galaxy doesn't run on hope.",
   },
   {
-    label: "Campaign Length",
-    value: `${MAX_TURNS} turns`,
-    detail: "Fixed-length run where each quarter contributes to final score.",
+    label: "Mission Length",
+    value: `${MAX_TURNS} quarters`,
+    detail:
+      "A fixed-length run. Survive the clock and your ledger writes the ending.",
   },
   {
-    label: "Starter Fleet",
+    label: "Starting Hangar",
     value: STARTER_SHIPS.map((ship) => ship.name).join(" + "),
-    detail: "Initial ships provided to establish the first route network.",
+    detail:
+      "Two reliable hulls to launch the first lanes. You'll outgrow them — that's the point.",
   },
 ];
 
 export const FEATURE_CARDS: FeatureCard[] = [
   {
     eyebrow: "GALACTIC TRADE",
-    title: "Build and scale a multi-route transport company",
-    body: "Manage routes, allocate ships, and grow from a local operator into a sector-wide logistics business.",
+    title: "From local hauler to sector-wide hauler-of-haulers",
+    body: "Stitch together routes, assign hulls, and watch the network compound. Every lane is a tiny business; together they're an empire.",
   },
   {
     eyebrow: "DYNAMIC ECONOMY",
-    title: "Model supply, demand, and route saturation",
-    body: "Planet profiles drive production and demand. Profitable routes emerge from matching exporters to importers over time.",
+    title: "Supply, demand, and the cold math of saturation",
+    body: "Planet profiles produce what they have and crave what they lack. Find a mismatch, point a ship at it, and ride the spread until the market catches on.",
   },
   {
-    eyebrow: "TURN SIMULATION",
-    title: "Resolve each quarter with full operational accounting",
-    body: "Every turn processes revenue, fuel burn, maintenance, market movement, and events into a detailed report.",
+    eyebrow: "QUARTERLY SIMULATION",
+    title: "Set the orders, hit End Quarter, watch it play",
+    body: "Every turn cashes out trips, fuel, maintenance, contracts, and events into one tidy P&L. The report tells you exactly which lanes are heroes and which are loafing.",
   },
   {
-    eyebrow: "RETRO COMMAND DECK",
-    title: "Playable home screen with integrated documentation",
-    body: "The website combines the live build, manual, strategic reference, and production notes in a single operator-focused interface.",
+    eyebrow: "RIVAL EMPIRES",
+    title: "AI competitors with names, faces, and fleets of their own",
+    body: "Empires expand alongside you, claim systems, and sometimes drag you into a mid-quarter dilemma. Stay sharp — the galaxy is not just an economy puzzle.",
   },
 ];
 
@@ -121,163 +124,164 @@ export const MANUAL_SECTIONS: GuideSection[] = [
   {
     title: "1. Pick your first foothold",
     summary:
-      "A new run generates a procedural galaxy and gives you three possible starting systems to choose from.",
+      "Each new run rolls a procedural galaxy and offers a small slate of opening systems. Where you plant the flag shapes the next ten quarters.",
     bullets: [
-      `You begin with ${formatCurrency(STARTING_CASH)} in cash and ${STARTER_SHIPS.length} starter ships.`,
-      "Prioritize starts with multiple nearby planet types to keep routing options open.",
-      "Use early turns to validate local demand before specializing.",
+      `Day one: ${formatCurrency(STARTING_CASH)} in the bank and ${STARTER_SHIPS.length} hulls in the hangar — make them count.`,
+      "Look for systems with two or three different planet types within a short hop. Variety is leverage.",
+      "Spend the first quarter or two confirming demand. Don't fall in love with a route until the report agrees with you.",
     ],
   },
   {
-    title: "2. Match exporters with importers",
+    title: "2. Read the galaxy like a trader",
     summary:
-      "The most reliable profits come from moving goods toward worlds that demand them and away from worlds that produce them.",
+      "Profit is a sentence with two halves: where something is cheap, and where someone will pay for it. Your job is matching them.",
     bullets: [
-      "Mining worlds usually export raw materials and hazmat.",
-      "Agricultural worlds are dependable food producers.",
-      "Industrial, Terran, Hub Station, Research, and Resort worlds are often high-demand destinations.",
+      "Mining worlds spit out raw materials and the occasional drum of hazmat. Move it before the locals do.",
+      "Agricultural belts are food factories — predictable, low-drama, often the backbone of an early book.",
+      "Industrial, Terran, Hub, Research, and Resort worlds are the buyers. They'll take what you bring if the price is right.",
     ],
   },
   {
-    title: "3. Assign the right ship to the route",
+    title: "3. Right hull, right lane",
     summary:
-      "Passenger lanes, mixed cargo, and bulk freight all reward different ship classes and timing decisions.",
+      "Every ship class has a sweet spot. The art is matching tonnage and speed to what the route actually wants — not what looks coolest in the hangar.",
     bullets: [
-      "Cargo Shuttle provides low-cost early freight capacity.",
-      "Passenger Shuttle performs best on high-demand population corridors.",
-      "High-speed hulls increase route frequency; high-capacity hulls require careful market targeting.",
+      "Cargo Shuttles are the workhorses of the early book — cheap to operate, easy to replace.",
+      "Passenger Shuttles thrive on dense population corridors where speed beats volume.",
+      "Big haulers need big lanes. Don't park a freighter on a route that can't fill it.",
     ],
   },
   {
-    title: "4. End the turn and read the report",
+    title: "4. End the quarter, read the ledger",
     summary:
-      "Once routes are assigned, the simulation resolves revenue, fuel burn, maintenance, and event outcomes.",
+      "When the orders are in, hit End Quarter. Trips fly, fuel burns, events fire, and the report drops on your desk. Read it.",
     bullets: [
-      "Use turn reports to rank route performance and identify low-margin operations.",
-      "Monitor fuel price shifts and events that can rapidly change route viability.",
-      "Apply report insights immediately by reassigning ships or adjusting cargo focus.",
+      "The lane-by-lane breakdown is your scoreboard. Weak performers stand out fast.",
+      "Watch fuel and event modifiers — a quarter of cheap fuel can mask a route that's about to crater.",
+      "React the same turn. Reassign ships, swap cargo, kill a dead lane. Don't wait three quarters to admit something isn't working.",
     ],
   },
   {
-    title: "5. Manage wear, debt, and market saturation",
+    title: "5. Wear, debt, and the limits of a good market",
     summary:
-      "Profit is not just about top-line revenue; it is about surviving the ugly little costs between turns.",
+      "Top-line revenue is loud; the costs that bury you are quiet. Reliability, interest, and market saturation are the silent killers.",
     bullets: [
-      "Condition decays over time, and unreliable ships are more likely to break down.",
-      "Loans can accelerate expansion, but weak routes turn debt into a liability.",
-      "Repeatedly hammering the same market can saturate prices, so diversify before margins collapse.",
+      "Hulls wear down. Skip maintenance long enough and they break down on the worst possible quarter.",
+      "Loans buy speed — sometimes worth it, often not. A weak route plus debt is a story that ends in bankruptcy.",
+      "Hammer the same lane forever and prices fall. Diversify before margins do.",
     ],
   },
   {
-    title: "6. Finish strong before the campaign clock runs out",
-    summary: `A standard run lasts ${MAX_TURNS} turns, so your late-game score reflects both expansion and discipline.`,
+    title: "6. Stick the landing",
+    summary: `A campaign runs ${MAX_TURNS} quarters. Late-game scores reward operators who balance expansion with discipline.`,
     bullets: [
-      "Maintain a cash buffer to absorb adverse events without forced retrenchment.",
-      "Upgrade only when the new ship unlocks better throughput, better route coverage, or both.",
-      "Consistent late-game cash flow generally outperforms high-risk final-turn gambles.",
+      "Keep a cash cushion. The final stretch is when bad events love to show up.",
+      "Upgrade only when a new hull unlocks throughput or coverage you're already short on.",
+      "Boring, steady cash flow beats Hail-Mary speculation almost every time. Almost.",
     ],
   },
 ];
 
 export const HELP_TOPICS: GuideSection[] = [
   {
-    title: "Early-game checklist",
+    title: "Rookie checklist",
     summary:
-      "If you are starting fresh, this sequence gives you the least painful path to competence.",
+      "Brand new? Skip the existential questions and run this sequence. It gets you to competent in two or three quarters.",
     bullets: [
-      "Choose a start with at least one obvious producer world and one obvious buyer nearby.",
-      "Stabilize one profitable route before opening additional lanes.",
-      "Use the first report to compare freight and passenger contribution.",
+      "Pick an opening with at least one obvious producer and one obvious buyer within a hop.",
+      "Get one route printing money before you open a second. Confirmed beats theoretical.",
+      "Read the first report end-to-end. Freight and passengers play different games — find out which one your start prefers.",
     ],
   },
   {
-    title: "How to read a market quickly",
+    title: "Reading a market in 30 seconds",
     summary:
-      "Think in pairs: where is something abundant, and where will people pay to see it arrive?",
+      "Think in pairs. Where is the stuff cheap and plentiful, and where will somebody pay to see it arrive? That's the whole sport.",
     bullets: [
-      "Export from planets whose identity naturally aligns with the cargo type.",
-      "Import to planets whose profile shows demand for that cargo category.",
-      "When margins fall, rotate cargo mix or destination before losses compound.",
+      "Export from worlds whose profile screams 'we have too much of this.'",
+      "Import to worlds whose profile says 'we need this and we'll pay.'",
+      "When a margin starts shrinking, rotate cargo or destination before it bleeds out.",
     ],
   },
   {
-    title: "When to buy more ships",
+    title: "When to actually buy a ship",
     summary:
-      "Expansion works best once your current route book already proves there is demand for extra lift.",
+      "More hulls feel like progress. They're a liability until they have a job. Don't buy without a lane in mind.",
     bullets: [
-      "Expand when a newly purchased ship has an immediate profitable assignment.",
-      "Delay purchases if maintenance and fuel are already squeezing your margin.",
-      "Specialized hulls are strongest when their route purpose is obvious before you spend the money.",
+      "Buy when there's a profitable assignment ready on day one.",
+      "Hold off if fuel and maintenance are already chewing through margin.",
+      "Specialty hulls (high speed, high tonnage, passenger-focused) shine when the route's purpose is already obvious.",
     ],
   },
   {
-    title: "How to recover from a bad quarter",
-    summary: "The fix is usually operational clarity, not panic clicking.",
+    title: "Pulling out of a tailspin",
+    summary:
+      "Bad quarters happen. The fix is almost never panic-clicking — it's a quiet hour with the route report.",
     bullets: [
-      "Audit route-level performance first; weak lanes are often the primary cause.",
-      "Reduce exposure to event-hit routes and re-establish stable core margins.",
-      "Use debt only with a clear plan for earnings recovery.",
+      "Sort lanes by margin. The bottom three are usually the story.",
+      "Mothball or repath routes that just got hit by a bad event. Don't pretend it didn't happen.",
+      "Borrow only with a written plan for how earnings come back. 'I'll figure it out' is not a plan.",
     ],
   },
 ];
 
 export const FAQ_ITEMS: FaqItem[] = [
   {
-    question: "Is Star Freight Tycoon real-time?",
+    question: "Is this real-time?",
     answer:
-      "No. It is a turn-driven management sim. You set plans, then the quarter resolves and reports results.",
+      "No. It's a turn-driven management sim. You set the plan, hit End Quarter, and the simulation plays out. Plenty of time to think between moves — exactly like the classics.",
   },
   {
-    question: "What should I transport first?",
+    question: "What should I haul first?",
     answer:
-      "Start with the clearest producer-to-consumer route in your opening region. Food, raw materials, and passengers are usually reliable early signals.",
+      "Whatever the local map screams loudest about. Food, raw materials, and passengers are the most reliable early signals. The first quarter is for confirming the obvious — not chasing the exotic.",
   },
   {
-    question: "Why did a good route stop paying well?",
+    question: "My route used to print money. Why's it dying?",
     answer:
-      "Typically due to saturation, trend shifts, fuel changes, or events. Rebalancing routes usually restores performance faster than repetition.",
+      "Usually saturation, a trend shift, a fuel spike, or an event. The fix is almost always rebalancing — new cargo, new destination, or both. Repetition without diagnosis just digs the hole deeper.",
   },
   {
-    question: "Should I specialize or diversify?",
+    question: "Specialize or diversify?",
     answer:
-      "Start focused, then diversify once your core loop is stable. Controlled expansion is safer than broad early experimentation.",
+      "Specialize first. Get one or two routes humming. Diversify once your core loop is stable and you have cash to absorb a misfire. Spreading thin early just turns into a dozen unprofitable lanes.",
   },
   {
-    question: "Can I play without reading the full manual?",
+    question: "Do I need to read the manual?",
     answer:
-      "Yes. The homepage includes a quick-start path and the help section covers common strategic decisions.",
+      "Nope. The homepage has a quick-start, the in-game help is short, and the report after every quarter is honestly the best teacher in the game. The manual is here when you want it, not because you have to.",
   },
 ];
 
 export const DISCLOSURE_CARDS: DisclosureCard[] = [
   {
-    title: "AI-assisted music and visual materials",
+    title: "AI-assisted art, music, and concept work",
     summary:
-      "This project discloses where AI-assisted assets were used in music, concept work, or promotional visuals.",
+      "Some visuals, soundscapes, and concept frames started as AI output. We say so on the box because it's the right thing to do.",
     bullets: [
-      "AI output is used as draft material and reviewed before inclusion.",
-      "Assets may be revised or replaced as production quality improves.",
-      "Disclosure is presented directly on the site for transparency.",
+      "AI output is treated as draft material — reviewed, edited, often replaced.",
+      "Assets get upgraded as production quality improves; this isn't the final cover art.",
+      "Disclosure lives on the site itself so nothing's hiding behind a marketing page.",
     ],
   },
   {
-    title: "Human-authored game design and implementation",
+    title: "Game design and code: written by hand",
     summary:
-      "Core mechanics, systems code, balancing decisions, and final implementation remain developer-authored and curated.",
+      "Mechanics, simulation, balance, and the way scenes click together are developer-authored. AI helps; it doesn't drive.",
     bullets: [
-      "Procedural generation, economy logic, scene flow, and simulation behavior are implemented in the game codebase.",
-      "AI assistance does not replace testing, iteration, or creative direction.",
-      "Site documentation reflects implemented gameplay systems rather than concept-only messaging.",
+      "Procedural galaxies, economy math, scene flow, and turn resolution are implemented in the codebase — not summoned from a prompt.",
+      "Assistance accelerates work; it doesn't replace testing, iteration, or creative direction.",
+      "Documentation describes systems that actually exist — no vaporware bullet points.",
     ],
   },
   {
-    title: "Why disclose it this clearly?",
+    title: "Why the receipts?",
     summary:
-      "Clear production notes improve trust and make project provenance easier to understand.",
+      "Indie studios used to print credits on the back of the cartridge. This is the 2026 version of that — minus the cartridge.",
     bullets: [
-      "Players can distinguish authored systems from assisted presentation assets.",
-      "Version-to-version asset updates are easier to track.",
-      "Transparent attribution supports long-term project credibility.",
+      "Players deserve to know which parts are authored and which were assisted.",
+      "Version-over-version asset updates stay legible over time.",
+      "Transparency is a feature. So is being able to point at the source code.",
     ],
   },
 ];
@@ -302,7 +306,7 @@ export const PLANET_CHEAT_SHEET: CheatSheetCard[] = Object.entries(
   bullets: [
     `Produces: ${profile.produces.map(labelFor).join(", ") || "No primary exports"}`,
     `Demands: ${profile.demands.map(labelFor).join(", ") || "Low structured demand"}`,
-    "Use this as a routing heuristic, then verify live market prices before committing ships.",
+    "Use this as a starting heuristic — then trust the live market screen over the cheat sheet.",
   ],
 }));
 
@@ -312,10 +316,10 @@ export const CARGO_CHEAT_SHEET: CheatSheetCard[] = Object.entries(
   title: labelFor(cargoType),
   caption: `Base market price: ${formatCurrency(price)}`,
   bullets: [
-    "Actual returns change with supply, demand, saturation, and event modifiers.",
-    "Compare destination demand with origin abundance before assigning a route.",
+    "Real returns swing with supply, demand, saturation, and event modifiers — base price is just the starting line.",
+    "Always pair origin abundance with destination demand. One without the other is a hobby, not a business.",
     cargoType === CargoType.Passengers
-      ? "Passenger capacity matters more than freight volume here, so pick the right hull."
-      : "Freight routes improve when a ship can carry enough volume to justify its operating costs.",
+      ? "Passengers care about seats, not tonnage — match the hull to the lane."
+      : "Volume vs. operating cost is the whole equation. Don't haul air.",
   ],
 }));


### PR DESCRIPTION
## Summary

Bring docs in sync with the post–Phaser-4 codebase and rewrite the homepage copy in a tighter, in-world voice — Aerobiz Supersonic meets Master of Orion 2, minus the marketing throat-clearing.

## What changed

**[README.md](README.md)**
- Rewrites the front matter as a manual-style intro (greeting, lineage callouts to Aerobiz / MOO2 / Transport Tycoon).
- Tech-stack table now lists Phaser 4 with the actual scene/test counts (23 scenes, 723 tests across 50 files).
- Adds a layout map (`src/scenes`, `src/game`, `packages/`, `styleguide/`, `docs/`) and the conventions worth knowing (namespace import, filter-API mask convention).
- Closes with an in-character epigraph.

**[src/siteContent.ts](src/siteContent.ts)** (drives the playable home page)
- Hero metrics, feature cards, six manual chapters, four help topics, five FAQs, and three disclosure cards rewritten with concrete in-world voice.
- Replaces the meta "BRIDGE VIEW" feature card (it was about the page itself) with one about rival AI empires + dilemmas — actual gameplay.

**[src/main.ts](src/main.ts)** (homepage shell)
- Cuts every section subtitle that only rephrased its `<h2>` (Operations Manual, Codex, Portrait QA, Strategy Tips, Production Notes). Heading + cards/content. No filler in between.
- Removes the meta "Why this structure works" footer panel.
- Tightens quick-link sublines into action phrases.
- Hero copy is now just the game pitch: *"Buy low, sell high, expand the fleet, weather the events. Twenty quarters to build something that lasts."* — no commentary on the page describing itself.
- Footer-note simplified to title + year + build link (no marketing strapline).

**[index.html](index.html)**
- `og:description`, `twitter:description`, and meta `description` refreshed for Phaser 4 + Aerobiz / MOO2 lineage.

**[public/wiki/index.html](public/wiki/index.html)**
- Renamed the wiki landing page to "Codex"; tighter intro line.

## Editorial principles applied

1. **Headings stand alone** — if a `<p>` only rephrased the `<h2>`, it got cut.
2. **No commentary about the page** — copy talks about the game, not about the website that's describing the game.
3. **Cards and content do the talking** — section frames are minimal so the actual material (manual chapters, FAQ items, disclosure cards) is what you read.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` — 723 tests pass
- [x] `npm run build` — production bundle builds
- [x] Dev server: homepage renders the new copy, footer shows title + year + build link, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)