### PR TITLE
feat(routes): map-first endpoint picker in Route Builder

### DIFF
--- a/src/ui/RouteBuilderPanel.ts
+++ b/src/ui/RouteBuilderPanel.ts
@@ -26,7 +26,7 @@ import {
 import { getLayout } from "./Layout.ts";
 import { Button } from "./Button.ts";
 import { Label } from "./Label.ts";
-import { MiniMap } from "./MiniMap.ts";
+import { RoutePickerMap } from "./RoutePickerMap.ts";
 import { Panel } from "./Panel.ts";
 import { DEPTH_MODAL } from "./DepthLayers.ts";
 import type { SceneUiDirector } from "./SceneUiDirector.ts";
@@ -136,7 +136,9 @@ class RouteBuilderPanel {
   private cargoIcon!: Phaser.GameObjects.Image;
   private fieldLabels = new Map<FieldKey, Label>();
   private fieldValues = new Map<FieldKey, Label>();
-  private miniMap: MiniMap | null = null;
+  private pickerMap: RoutePickerMap | null = null;
+  private nextClickSlot: "origin" | "destination" = "origin";
+  private hoveredPlanetId: string | null = null;
   // Market Intel labels
   private mktOriginPriceValue!: Label;
   private mktDestPriceValue!: Label;
@@ -158,8 +160,9 @@ class RouteBuilderPanel {
 
     const L = getLayout();
     // Clamp panel size to viewport so it never overflows on smaller screens.
-    // Reserve margin for the side gutters and overlay framing.
-    this.panelWidth = Math.min(620, Math.max(420, L.gameWidth - 64));
+    // Wider than the legacy modal so the interactive picker map can live in
+    // a right column without crowding the field selectors on the left.
+    this.panelWidth = Math.min(900, Math.max(420, L.gameWidth - 64));
     this.panelHeight = Math.min(720, Math.max(500, L.gameHeight - 80));
     this.panelX = Math.floor((L.gameWidth - this.panelWidth) / 2);
     this.panelY = Math.floor((L.gameHeight - this.panelHeight) / 2);
@@ -297,22 +300,44 @@ class RouteBuilderPanel {
     rowY += 22;
     this.mktSaturationValue = this.createSummaryLabel(content.x, rowY);
 
-    // Mini-map: positioned bottom-right, above the confirm buttons
-    const miniMapWidth = 160;
-    const miniMapHeight = 120;
-    const miniMapX = this.panelX + this.panelWidth - miniMapWidth - 16;
-    const miniMapY = this.panelY + this.panelHeight - miniMapHeight - 58;
-    this.miniMap = new MiniMap({
+    // Interactive picker map: right column. The left column holds the field
+    // selectors (origin/dest/cargo/ship) which extend to roughly x=520; the
+    // map starts at x≈540 and runs to the inside edge of the panel.
+    const pickerMapPadding = 16;
+    const pickerColumnLeft = 540;
+    const pickerMapWidth = Math.max(
+      220,
+      this.panelWidth - pickerColumnLeft - pickerMapPadding,
+    );
+    const pickerMapHeight = Math.min(360, this.panelHeight - 220);
+    const pickerMapX = this.panelX + pickerColumnLeft;
+    const pickerMapY = this.panelY + content.y + 70;
+    this.pickerMap = new RoutePickerMap({
       scene,
-      x: miniMapX,
-      y: miniMapY,
-      width: miniMapWidth,
-      height: miniMapHeight,
+      x: pickerMapX,
+      y: pickerMapY,
+      width: pickerMapWidth,
+      height: pickerMapHeight,
       depth: DEPTH_MODAL,
+      onPlanetClick: (planetId) => this.handlePlanetClick(planetId),
+      onPlanetHover: (planetId) => {
+        this.hoveredPlanetId = planetId;
+        this.refreshPickerMap();
+      },
     });
-    for (const obj of this.miniMap.getGameObjects()) {
+    for (const obj of this.pickerMap.getGameObjects()) {
       layer.track(obj);
     }
+    const pickerHint = new Label(scene, {
+      x: pickerMapX,
+      y: pickerMapY - 18,
+      text: "Click a planet to set origin → click another for destination",
+      style: "caption",
+      color: getTheme().colors.textDim,
+      maxWidth: pickerMapWidth,
+    });
+    pickerHint.setDepth(DEPTH_MODAL);
+    layer.track(pickerHint);
 
     const confirmButton = new Button(scene, {
       x: this.panelX + content.x,
@@ -627,47 +652,58 @@ class RouteBuilderPanel {
       value?.setLabelColor(isActive ? theme.colors.text : theme.colors.accent);
     }
 
-    this.updateMiniMap();
+    this.refreshPickerMap();
   }
 
-  private updateMiniMap(): void {
-    if (!this.miniMap) return;
-
+  private refreshPickerMap(): void {
+    if (!this.pickerMap) return;
+    const state = gameStore.getState();
     const origin = this.getSelectedOrigin();
     const destination = this.getSelectedDestination();
-    const state = gameStore.getState();
+    this.pickerMap.draw({
+      systems: state.galaxy.systems,
+      planets: state.galaxy.planets,
+      activeRoutes: state.activeRoutes,
+      originPlanetId: origin?.id ?? null,
+      destinationPlanetId: destination?.id ?? null,
+      cargoType: this.getSelectedCargo(),
+      hoveredPlanetId: this.hoveredPlanetId,
+    });
+  }
 
-    if (!origin || !destination || origin.id === destination.id) {
-      this.miniMap.drawEmpty();
+  private handlePlanetClick(planetId: string): void {
+    const planetIndex = this.planets.findIndex((p) => p.id === planetId);
+    if (planetIndex < 0) return;
+
+    if (this.options.lockOrigin) {
+      // Origin is locked — clicks only set destination
+      if (planetIndex !== this.originIndex) {
+        this.destinationIndex = planetIndex;
+      }
+      this.refreshUi();
       return;
     }
 
-    const isInterSystem = origin.systemId !== destination.systemId;
-
-    if (isInterSystem) {
-      this.miniMap.drawGalaxyRoute(
-        state.galaxy.systems,
-        origin.systemId,
-        destination.systemId,
-        state.activeRoutes,
-        state.galaxy.planets,
-      );
+    if (this.nextClickSlot === "origin") {
+      this.originIndex = planetIndex;
+      // Ensure destination is different
+      if (this.destinationIndex === this.originIndex) {
+        this.destinationIndex = wrapIndex(
+          this.originIndex + 1,
+          this.planets.length,
+        );
+      }
+      this.nextClickSlot = "destination";
     } else {
-      const system = state.galaxy.systems.find((s) => s.id === origin.systemId);
-      if (!system) {
-        this.miniMap.drawEmpty();
+      if (planetIndex === this.originIndex) {
+        // Clicking origin again resets — treat next click as origin
+        this.nextClickSlot = "origin";
         return;
       }
-      const systemPlanets = state.galaxy.planets.filter(
-        (p) => p.systemId === system.id,
-      );
-      this.miniMap.drawSystemRoute(
-        system,
-        systemPlanets,
-        origin.id,
-        destination.id,
-      );
+      this.destinationIndex = planetIndex;
+      this.nextClickSlot = "origin";
     }
+    this.refreshUi();
   }
 
   private buildPreview(): {

--- a/src/ui/RoutePickerMap.ts
+++ b/src/ui/RoutePickerMap.ts
@@ -1,0 +1,370 @@
+import * as Phaser from "phaser";
+import type {
+  StarSystem,
+  Planet,
+  ActiveRoute,
+  PlanetType,
+  CargoType as CargoTypeValue,
+} from "../data/types.ts";
+import { PLANET_CARGO_PROFILES } from "../data/constants.ts";
+import { getTheme } from "./Theme.ts";
+
+const PLANET_TYPE_COLORS: Record<PlanetType, number> = {
+  terran: 0x4b86d6,
+  industrial: 0x9b8870,
+  mining: 0x8b8e97,
+  agricultural: 0x68b45a,
+  hubStation: 0xf6b04f,
+  resort: 0xff7fd3,
+  research: 0x73ddff,
+};
+
+const PLANET_ZONE_RANK: Record<PlanetType, number> = {
+  mining: 0,
+  industrial: 1,
+  terran: 2,
+  agricultural: 3,
+  research: 4,
+  resort: 5,
+  hubStation: 6,
+};
+
+export interface RoutePickerMapConfig {
+  scene: Phaser.Scene;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  depth: number;
+  onPlanetClick?: (planetId: string) => void;
+  onPlanetHover?: (planetId: string | null) => void;
+}
+
+export interface RoutePickerDrawOptions {
+  systems: StarSystem[];
+  planets: Planet[];
+  activeRoutes: ActiveRoute[];
+  originPlanetId: string | null;
+  destinationPlanetId: string | null;
+  cargoType: CargoTypeValue | null;
+  hoveredPlanetId?: string | null;
+}
+
+interface PlanetHit {
+  id: string;
+  mx: number;
+  my: number;
+  r: number;
+}
+
+export class RoutePickerMap {
+  private readonly scene: Phaser.Scene;
+  private readonly x: number;
+  private readonly y: number;
+  private readonly width: number;
+  private readonly height: number;
+  private readonly depth: number;
+  private readonly graphics: Phaser.GameObjects.Graphics;
+  private readonly hitZone: Phaser.GameObjects.Zone;
+  private hoverLabel: Phaser.GameObjects.Text;
+  private planetHits: PlanetHit[] = [];
+  private planetById = new Map<string, Planet>();
+  private currentHover: string | null = null;
+  private readonly onPlanetClick?: (planetId: string) => void;
+  private readonly onPlanetHover?: (planetId: string | null) => void;
+
+  constructor(config: RoutePickerMapConfig) {
+    this.scene = config.scene;
+    this.x = config.x;
+    this.y = config.y;
+    this.width = config.width;
+    this.height = config.height;
+    this.depth = config.depth;
+    this.onPlanetClick = config.onPlanetClick;
+    this.onPlanetHover = config.onPlanetHover;
+
+    this.graphics = this.scene.add.graphics();
+    this.graphics.setDepth(this.depth);
+
+    const theme = getTheme();
+    this.hoverLabel = this.scene.add.text(
+      this.x + this.width / 2,
+      this.y + this.height - 4,
+      "",
+      {
+        fontSize: `${theme.fonts.caption.size}px`,
+        fontFamily: theme.fonts.caption.family,
+        color: "#ffffff",
+        stroke: "#000000",
+        strokeThickness: 2,
+      },
+    );
+    this.hoverLabel.setOrigin(0.5, 1);
+    this.hoverLabel.setDepth(this.depth + 1);
+
+    this.hitZone = this.scene.add.zone(
+      this.x + this.width / 2,
+      this.y + this.height / 2,
+      this.width,
+      this.height,
+    );
+    this.hitZone.setOrigin(0.5);
+    this.hitZone.setDepth(this.depth + 2);
+    this.hitZone.setInteractive();
+
+    this.hitZone.on(
+      "pointermove",
+      (pointer: Phaser.Input.Pointer) => {
+        const planetId = this.findPlanetAt(pointer.worldX, pointer.worldY);
+        if (planetId !== this.currentHover) {
+          this.currentHover = planetId;
+          this.updateHoverLabel(planetId);
+          this.onPlanetHover?.(planetId);
+        }
+      },
+    );
+    this.hitZone.on("pointerout", () => {
+      if (this.currentHover !== null) {
+        this.currentHover = null;
+        this.updateHoverLabel(null);
+        this.onPlanetHover?.(null);
+      }
+    });
+    this.hitZone.on("pointerup", (pointer: Phaser.Input.Pointer) => {
+      const planetId = this.findPlanetAt(pointer.worldX, pointer.worldY);
+      if (planetId) {
+        this.onPlanetClick?.(planetId);
+      }
+    });
+
+    this.drawBackground();
+  }
+
+  /**
+   * Render the galaxy with all systems + their planets.
+   * Plants are clickable. If cargoType is set, planet halos scale with
+   * demand-match (or production-match) for that cargo.
+   */
+  draw(opts: RoutePickerDrawOptions): void {
+    this.graphics.clear();
+    this.drawBackground();
+    this.planetHits = [];
+    this.planetById.clear();
+    for (const p of opts.planets) this.planetById.set(p.id, p);
+
+    if (opts.systems.length === 0) return;
+
+    const theme = getTheme();
+    const padding = 14;
+    const innerX = this.x + padding;
+    const innerY = this.y + padding;
+    const innerW = this.width - padding * 2;
+    const innerH = this.height - padding * 2;
+
+    // Bounding box of systems
+    let minSX = Infinity,
+      maxSX = -Infinity,
+      minSY = Infinity,
+      maxSY = -Infinity;
+    for (const sys of opts.systems) {
+      if (sys.x < minSX) minSX = sys.x;
+      if (sys.x > maxSX) maxSX = sys.x;
+      if (sys.y < minSY) minSY = sys.y;
+      if (sys.y > maxSY) maxSY = sys.y;
+    }
+    const rangeX = maxSX - minSX || 1;
+    const rangeY = maxSY - minSY || 1;
+
+    const mapSystem = (sx: number, sy: number) => ({
+      mx: innerX + ((sx - minSX) / rangeX) * innerW,
+      my: innerY + ((sy - minSY) / rangeY) * innerH,
+    });
+
+    // Compute system screen positions
+    const sysPos = new Map<string, { mx: number; my: number }>();
+    for (const sys of opts.systems) sysPos.set(sys.id, mapSystem(sys.x, sys.y));
+
+    // Group planets by system, sort using same rule as MiniMap/SystemMapScene
+    const planetsBySystem = new Map<string, Planet[]>();
+    for (const p of opts.planets) {
+      const arr = planetsBySystem.get(p.systemId) ?? [];
+      arr.push(p);
+      planetsBySystem.set(p.systemId, arr);
+    }
+    for (const list of planetsBySystem.values()) {
+      list.sort((a, b) => {
+        const z = PLANET_ZONE_RANK[a.type] - PLANET_ZONE_RANK[b.type];
+        if (z !== 0) return z;
+        const pop = b.population - a.population;
+        if (pop !== 0) return pop;
+        return a.id.localeCompare(b.id);
+      });
+    }
+
+    // Compute planet screen positions: small orbit offsets around each star.
+    const planetScreenPos = new Map<string, { mx: number; my: number }>();
+    const orbitRadius = 7;
+    for (const sys of opts.systems) {
+      const center = sysPos.get(sys.id)!;
+      const list = planetsBySystem.get(sys.id) ?? [];
+      const seedAngle = (hashString(sys.id) % 360) * (Math.PI / 180);
+      for (let i = 0; i < list.length; i++) {
+        const angle = seedAngle + (i / Math.max(1, list.length)) * Math.PI * 2;
+        const r = orbitRadius + (i % 2) * 2;
+        const mx = center.mx + Math.cos(angle) * r;
+        const my = center.my + Math.sin(angle) * r;
+        planetScreenPos.set(list[i].id, { mx, my });
+      }
+    }
+
+    // Draw existing active routes as dim lines (planet → planet)
+    this.graphics.lineStyle(1, theme.colors.accent, 0.12);
+    for (const route of opts.activeRoutes) {
+      const a = planetScreenPos.get(route.originPlanetId);
+      const b = planetScreenPos.get(route.destinationPlanetId);
+      if (!a || !b) continue;
+      this.graphics.beginPath();
+      this.graphics.moveTo(a.mx, a.my);
+      this.graphics.lineTo(b.mx, b.my);
+      this.graphics.strokePath();
+    }
+
+    // Draw star centers (dim)
+    for (const sys of opts.systems) {
+      const p = sysPos.get(sys.id)!;
+      this.graphics.fillStyle(sys.starColor, 0.55);
+      this.graphics.fillCircle(p.mx, p.my, 1.4);
+    }
+
+    // Draw planets — base dot + optional demand halo + selection highlight
+    const hits: PlanetHit[] = [];
+    for (const planet of opts.planets) {
+      const pos = planetScreenPos.get(planet.id);
+      if (!pos) continue;
+
+      const baseColor = PLANET_TYPE_COLORS[planet.type] ?? 0xcccccc;
+      const isOrigin = planet.id === opts.originPlanetId;
+      const isDest = planet.id === opts.destinationPlanetId;
+      const isHover = planet.id === opts.hoveredPlanetId;
+
+      // Demand halo when cargo selected
+      if (opts.cargoType) {
+        const intensity = demandIntensity(planet.type, opts.cargoType);
+        if (intensity > 0) {
+          this.graphics.fillStyle(theme.colors.profit, 0.18 * intensity);
+          this.graphics.fillCircle(pos.mx, pos.my, 5 + 2 * intensity);
+        }
+      }
+
+      // Selection rings
+      if (isOrigin) {
+        this.graphics.lineStyle(2, theme.colors.profit, 0.95);
+        this.graphics.strokeCircle(pos.mx, pos.my, 5);
+      } else if (isDest) {
+        this.graphics.lineStyle(2, theme.colors.warning, 0.95);
+        this.graphics.strokeCircle(pos.mx, pos.my, 5);
+      } else if (isHover) {
+        this.graphics.lineStyle(1, theme.colors.accent, 0.7);
+        this.graphics.strokeCircle(pos.mx, pos.my, 4);
+      }
+
+      // Planet dot
+      this.graphics.fillStyle(baseColor, isOrigin || isDest ? 1.0 : 0.85);
+      this.graphics.fillCircle(pos.mx, pos.my, 2.3);
+
+      hits.push({ id: planet.id, mx: pos.mx, my: pos.my, r: 6 });
+    }
+
+    // Draw the proposed route line (origin → destination) if both set
+    if (opts.originPlanetId && opts.destinationPlanetId) {
+      const a = planetScreenPos.get(opts.originPlanetId);
+      const b = planetScreenPos.get(opts.destinationPlanetId);
+      if (a && b) {
+        this.graphics.lineStyle(
+          2,
+          opts.cargoType ? theme.colors.accent : theme.colors.text,
+          0.85,
+        );
+        this.graphics.beginPath();
+        this.graphics.moveTo(a.mx, a.my);
+        this.graphics.lineTo(b.mx, b.my);
+        this.graphics.strokePath();
+      }
+    }
+
+    this.planetHits = hits;
+    this.updateHoverLabel(this.currentHover);
+  }
+
+  /** Find planet under a world-space point, or null. */
+  findPlanetAt(worldX: number, worldY: number): string | null {
+    let bestId: string | null = null;
+    let bestDist = Infinity;
+    for (const hit of this.planetHits) {
+      const dx = hit.mx - worldX;
+      const dy = hit.my - worldY;
+      const d = Math.sqrt(dx * dx + dy * dy);
+      if (d < hit.r && d < bestDist) {
+        bestDist = d;
+        bestId = hit.id;
+      }
+    }
+    return bestId;
+  }
+
+  destroy(): void {
+    this.graphics.destroy();
+    this.hitZone.destroy();
+    this.hoverLabel.destroy();
+  }
+
+  getGameObjects(): Phaser.GameObjects.GameObject[] {
+    return [this.graphics, this.hoverLabel, this.hitZone];
+  }
+
+  private drawBackground(): void {
+    const theme = getTheme();
+    this.graphics.fillStyle(theme.colors.background, 0.7);
+    this.graphics.fillRect(this.x, this.y, this.width, this.height);
+    this.graphics.lineStyle(1, theme.colors.panelBorder, 0.5);
+    this.graphics.strokeRect(this.x, this.y, this.width, this.height);
+  }
+
+  private updateHoverLabel(planetId: string | null): void {
+    if (!planetId) {
+      this.hoverLabel.setText("");
+      return;
+    }
+    const planet = this.planetById.get(planetId);
+    if (!planet) {
+      this.hoverLabel.setText("");
+      return;
+    }
+    this.hoverLabel.setText(`${planet.name} (${planet.type})`);
+  }
+}
+
+/**
+ * Demand intensity (0..1) for a cargo type at a planet of the given type.
+ * 1.0 = strong demand, 0.6 = strong production, 0 = no fit.
+ * For Passengers we treat all planets as moderate demand.
+ */
+function demandIntensity(
+  planetType: PlanetType,
+  cargoType: CargoTypeValue,
+): number {
+  if (cargoType === "passengers") return 0.5;
+  const profile = PLANET_CARGO_PROFILES[planetType];
+  if (!profile) return 0;
+  if (profile.demands.includes(cargoType as never)) return 1.0;
+  if (profile.produces.includes(cargoType as never)) return 0.6;
+  return 0;
+}
+
+function hashString(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}


### PR DESCRIPTION
## Summary

The Custom Route modal previously required players to navigate origin and destination through arrow-key chevrons over an opaque planet list, with no spatial sense of where endpoints actually were in the galaxy. The mini-map in the corner only updated *after* both ends were chosen, so it confirmed rather than guided the choice.

This PR replaces the corner mini-map with a large **interactive picker map** occupying the right column of the modal. Click a planet to set origin, click another to set destination — clicks alternate between the two slots. The map also shows existing routes (dimmed) and **demand-heat halos** around planets that produce or demand the currently selected cargo, giving players a spatial read on where a given cargo will sell.

## Changes

- **New** `src/ui/RoutePickerMap.ts` — galaxy-scale view with all planets clustered around their stars. Planet hit-testing, hover labels, and a `draw()` entry point that takes selection state + cargo for demand visualization.
- `RouteBuilderPanel` widens to 900px (clamped to viewport) and lays the picker map on the right column at ~344×360, with an instructional caption (\"Click a planet to set origin → click another for destination\") and a click-cycle that alternates origin/destination. Keyboard chevron navigation is preserved for accessibility / keyboard-only users.
- Demand-heat halos use `PLANET_CARGO_PROFILES` from `constants.ts`, so the visual signal stays in sync with simulation logic.

## Verification

- `npm run test` — 730/730 pass.
- Live in-game QA via `window.__sft` driving the live RoutesScene:
  - Click cycle alternated between origin and destination across distinct planets at distinct coordinates (Zela-1 → Thoan-8 → Talar-2 → Syn-2 → Fen-4 → Uraos → …).
  - Cargo filter propagation from #38 still works in the new modal (Tech filter → Cargo: Technology, hint caption renders).
  - Hover labels populate when the cursor passes over planets.

## Test plan

- [ ] Pull the branch, `npm install`, `npm run dev`.
- [ ] New game → Routes → click any cargo filter → click **Custom Route…**.
- [ ] Map appears on the right of the modal with all stars/planets visible.
- [ ] Click a planet → it becomes the origin (cyan ring). Click another → it becomes the destination (warning ring) and a route line connects them.
- [ ] Clicking the same origin planet twice should reset the click cycle without setting it as destination.
- [ ] Switch cargo (chevrons or Cargo dropdown when added) → planet halos light up around producers/consumers of the selected cargo.

Note: the pre-existing 9 Phaser 4 typing errors on `main` (`tsc --noEmit` failures from the Phaser 3→4 migration in #36) are unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)