### PR TITLE
feat(routes): pause/resume active routes without delete-and-recreate

### DIFF
--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -539,6 +539,13 @@ export interface ActiveRoute {
   distance: number;
   assignedShipIds: string[];
   cargoType: CargoType | null;
+  /**
+   * If true, the route is paused: the simulator skips revenue and fuel for
+   * this route while the slot and license fee remain. Players resume from the
+   * Edit Route panel. Default falsy (active) for backwards compatibility with
+   * older saves.
+   */
+  paused?: boolean;
 }
 
 export interface GameEvent {

--- a/src/game/routes/RouteManager.ts
+++ b/src/game/routes/RouteManager.ts
@@ -595,6 +595,24 @@ export function deleteRoute(
   return { fleet: updatedFleet, routes: updatedRoutes };
 }
 
+export function setRoutePaused(
+  routeId: string,
+  paused: boolean,
+  routes: ActiveRoute[],
+): ActiveRoute[] {
+  return routes.map((r) => (r.id === routeId ? { ...r, paused } : r));
+}
+
+export function setRouteCargo(
+  routeId: string,
+  newCargo: ActiveRoute["cargoType"],
+  routes: ActiveRoute[],
+): ActiveRoute[] {
+  return routes.map((r) =>
+    r.id === routeId ? { ...r, cargoType: newCargo } : r,
+  );
+}
+
 /**
  * Estimate revenue for a route+ship for one turn.
  * Matches the TurnSimulator formula: applies calculatePrice, distancePremium,

--- a/src/game/routes/__tests__/RoutePause.test.ts
+++ b/src/game/routes/__tests__/RoutePause.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { setRoutePaused, setRouteCargo } from "../RouteManager.ts";
+import { CargoType } from "../../../data/types.ts";
+import type { ActiveRoute } from "../../../data/types.ts";
+
+const baseRoute: ActiveRoute = {
+  id: "r1",
+  originPlanetId: "p-origin",
+  destinationPlanetId: "p-dest",
+  distance: 50,
+  assignedShipIds: ["s1"],
+  cargoType: CargoType.Technology,
+};
+
+describe("setRoutePaused", () => {
+  it("sets paused=true on the matching route only", () => {
+    const routes = [baseRoute, { ...baseRoute, id: "r2" }];
+    const result = setRoutePaused("r1", true, routes);
+    expect(result.find((r) => r.id === "r1")?.paused).toBe(true);
+    expect(result.find((r) => r.id === "r2")?.paused).toBeUndefined();
+  });
+
+  it("returns a new array (does not mutate)", () => {
+    const routes = [baseRoute];
+    const result = setRoutePaused("r1", true, routes);
+    expect(result).not.toBe(routes);
+    expect(routes[0].paused).toBeUndefined();
+  });
+
+  it("can resume by setting paused=false", () => {
+    const routes = [{ ...baseRoute, paused: true }];
+    const result = setRoutePaused("r1", false, routes);
+    expect(result[0].paused).toBe(false);
+  });
+
+  it("returns routes unchanged when routeId does not match", () => {
+    const routes = [baseRoute];
+    const result = setRoutePaused("missing", true, routes);
+    expect(result[0].paused).toBeUndefined();
+  });
+});
+
+describe("setRouteCargo", () => {
+  it("updates cargoType on the matching route", () => {
+    const routes = [baseRoute];
+    const result = setRouteCargo("r1", CargoType.Luxury, routes);
+    expect(result[0].cargoType).toBe(CargoType.Luxury);
+  });
+
+  it("preserves other fields", () => {
+    const routes = [baseRoute];
+    const result = setRouteCargo("r1", CargoType.Food, routes);
+    expect(result[0].id).toBe(baseRoute.id);
+    expect(result[0].assignedShipIds).toEqual(baseRoute.assignedShipIds);
+    expect(result[0].distance).toBe(baseRoute.distance);
+  });
+
+  it("can clear cargo by passing null", () => {
+    const routes = [baseRoute];
+    const result = setRouteCargo("r1", null, routes);
+    expect(result[0].cargoType).toBeNull();
+  });
+});

--- a/src/game/simulation/TurnSimulator.ts
+++ b/src/game/simulation/TurnSimulator.ts
@@ -348,6 +348,13 @@ export function simulateTurn(state: GameState, rng: SeededRNG): GameState {
   const fuelMultiplier = getFuelMultiplier(nextState);
 
   for (const route of nextState.activeRoutes) {
+    // Player-paused routes skip the simulation entirely — no revenue, no fuel
+    // burn, no mothball fee. The slot and license fee stay paid so the route
+    // can be resumed without re-buying the slot.
+    if (route.paused) {
+      continue;
+    }
+
     // Check if route is grounded by events (embargo, blockade, etc.)
     const grounded = isRouteGrounded(
       route,

--- a/src/game/simulation/__tests__/TurnSimulator.test.ts
+++ b/src/game/simulation/__tests__/TurnSimulator.test.ts
@@ -252,6 +252,18 @@ describe("TurnSimulator", () => {
       expect(turnResult.revenue).toBe(expectedRevenue);
     });
 
+    it("skips paused routes — no revenue and no fuel charged", () => {
+      const state = makeGameState();
+      // Mark the only route as paused
+      state.activeRoutes[0].paused = true;
+      const rng = new SeededRNG(42);
+
+      const result = simulateTurn(state, rng);
+      const turnResult = result.history[result.history.length - 1];
+      expect(turnResult.revenue).toBe(0);
+      expect(turnResult.fuelCosts).toBe(0);
+    });
+
     it("deducts fuel costs correctly", () => {
       const state = makeGameState();
       const rng = new SeededRNG(42);

--- a/src/scenes/RoutesScene.ts
+++ b/src/scenes/RoutesScene.ts
@@ -35,6 +35,7 @@ import {
   scanAllRouteOpportunities,
   addCargoLock,
   removeCargoLocks,
+  setRoutePaused,
   getAvailableRouteSlots,
   getUsedRouteSlots,
   getAvailableLocalRouteSlots,
@@ -86,6 +87,7 @@ export class RoutesScene extends Phaser.Scene {
   private deleteRouteButton!: Button;
   private assignShipButton!: Button;
   private setCargoButton!: Button;
+  private pauseRouteButton!: Button;
 
   // ── Route Finder tab state ──
   private finderTable!: DataTable;
@@ -547,8 +549,18 @@ export class RoutesScene extends Phaser.Scene {
     });
     activeContent.add(this.setCargoButton);
 
-    const addRouteBtn = new Button(this, {
+    this.pauseRouteButton = new Button(this, {
       x: contentInnerX + 420,
+      y: activeButtonY,
+      width: 120,
+      label: "Pause",
+      disabled: true,
+      onClick: () => this.toggleRoutePause(),
+    });
+    activeContent.add(this.pauseRouteButton);
+
+    const addRouteBtn = new Button(this, {
+      x: contentInnerX + 560,
       y: activeButtonY,
       width: 140,
       label: "Create Route",
@@ -935,7 +947,11 @@ export class RoutesScene extends Phaser.Scene {
       let fuelCost: number | string = "\u2014";
       let profit: number | string = "\u2014";
 
-      if (firstShip && route.cargoType) {
+      if (route.paused) {
+        revenue = "\u23f8 paused";
+        fuelCost = 0;
+        profit = 0;
+      } else if (firstShip && route.cargoType) {
         const rev = estimateRouteRevenue(route, firstShip, state.market, state);
         const fuel = estimateRouteFuelCost(
           route,
@@ -947,11 +963,15 @@ export class RoutesScene extends Phaser.Scene {
         profit = rev - fuel;
       }
 
+      const originName =
+        planetMap.get(route.originPlanetId) ?? route.originPlanetId;
+      const destinationName =
+        planetMap.get(route.destinationPlanetId) ?? route.destinationPlanetId;
+
       return {
         id: route.id,
-        origin: planetMap.get(route.originPlanetId) ?? route.originPlanetId,
-        destination:
-          planetMap.get(route.destinationPlanetId) ?? route.destinationPlanetId,
+        origin: route.paused ? `\u23f8 ${originName}` : originName,
+        destination: destinationName,
         distance: route.distance,
         ships: route.assignedShipIds.length,
         shipClass: firstShip?.class ?? null,
@@ -959,6 +979,7 @@ export class RoutesScene extends Phaser.Scene {
         revenue,
         fuelCost,
         profit,
+        paused: route.paused ?? false,
       };
     });
 
@@ -977,6 +998,8 @@ export class RoutesScene extends Phaser.Scene {
     this.deleteRouteButton?.setDisabled(!hasSelection);
     this.assignShipButton?.setDisabled(!hasSelection);
     this.setCargoButton?.setDisabled(!hasSelection);
+    this.pauseRouteButton?.setDisabled(!hasSelection);
+    this.pauseRouteButton?.setLabel(route?.paused ? "Resume" : "Pause");
 
     if (!route) {
       this.selectedRouteSummary?.setText("Pick a route to manage it");
@@ -1162,6 +1185,23 @@ export class RoutesScene extends Phaser.Scene {
         this.refreshActiveTable();
       },
     });
+  }
+
+  private toggleRoutePause(): void {
+    if (!this.selectedRouteId) return;
+    const state = gameStore.getState();
+    const route = state.activeRoutes.find(
+      (r) => r.id === this.selectedRouteId,
+    );
+    if (!route) return;
+    const updated = setRoutePaused(
+      this.selectedRouteId,
+      !route.paused,
+      state.activeRoutes,
+    );
+    gameStore.update({ activeRoutes: updated });
+    this.refreshActiveTable();
+    this.refreshFinderTable();
   }
 
   private confirmDeleteRoute(): void {


### PR DESCRIPTION
## Summary

When a route hits a temporary downturn (war embargo, fuel spike, saturated destination), the only lever players had was **Delete Route** — which forfeited the license fee, broke the inter-empire cargo lock, and forced a full re-create cycle. This PR adds the natural lever: **Pause**.

## Changes

- `ActiveRoute` gains an optional `paused?: boolean` field. Default falsy for backwards compatibility with existing saves.
- `TurnSimulator` (`src/game/simulation/TurnSimulator.ts`) skips paused routes entirely — no revenue, no fuel burn, no mothball fee. The slot stays paid and the route stays in the list, ready to resume next turn.
- `RouteManager` exports two new pure helpers — `setRoutePaused(routeId, paused, routes)` and `setRouteCargo(routeId, newCargo, routes)` — both immutable.
- `RoutesScene` gains a **Pause/Resume** button on the Active Routes tab. The button label toggles based on the selected route's state. The active routes table prefixes the origin with ⏸ and shows \"⏸ paused\" in the revenue column for paused entries.

## Verification

- `npm run test` — 738/738 pass (730 existing + 7 new RoutePause + 1 new TurnSimulator paused-gate integration test).
- Visual smoke via `__sft.list()`: button renders as **Pause** when disabled (no route selected), enabled state and label switch correctly when a route is selected.

## Test plan

- [ ] Pull the branch, `npm install`, `npm run dev`.
- [ ] New game → create a route → select it → click **Pause** → confirm origin shows ⏸ and revenue column reads ⏸ paused.
- [ ] End turn → confirm zero revenue + zero fuel cost charged for the paused route in the turn report.
- [ ] Click **Resume** → confirm next turn produces normal revenue.
- [ ] Save / reload — pause state should persist (it's plain JSON on the route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)