### PR TITLE
feat(routes): distance-band filter chips on Route Finder

### DIFF
--- a/src/scenes/RoutesScene.ts
+++ b/src/scenes/RoutesScene.ts
@@ -1,5 +1,7 @@
 import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
+import { isInDistanceBand } from "./routesFinderFilters.ts";
+import type { DistanceBand } from "./routesFinderFilters.ts";
 import { CargoType } from "../data/types.ts";
 import type { CargoType as CargoTypeValue } from "../data/types.ts";
 import {
@@ -94,7 +96,9 @@ export class RoutesScene extends Phaser.Scene {
   private finderSummary!: Phaser.GameObjects.Text;
   private opportunities: RouteOpportunity[] = [];
   private finderCargoFilter: CargoTypeValue | null = null;
+  private finderDistanceBand: DistanceBand = null;
   private filterButtons: Button[] = [];
+  private distanceBandButtons: Button[] = [];
 
   // ── Sidebar mini-map ──
   private miniMap!: MiniMap;
@@ -173,7 +177,7 @@ export class RoutesScene extends Phaser.Scene {
     const contentInnerW = panelW - 24;
     const tabBarHeight = 40; // theme.button.height
     const summaryHeight = 50;
-    const filterRowHeight = 32; // cargo filter buttons
+    const filterRowHeight = 64; // cargo filter row + distance-band row
     const buttonAreaHeight = 52; // 8px gap + 40px button + 4px pad
     const tableTop = tabContentY + summaryHeight + filterRowHeight;
     const tableHeight =
@@ -238,6 +242,38 @@ export class RoutesScene extends Phaser.Scene {
       filterX += btn.width + 4;
     }
     this.updateFilterButtonStyles();
+
+    // ── Distance-band filter buttons (second row) ──
+    const distanceBandY = filterY + 30;
+    const distanceBands: Array<{ label: string; value: DistanceBand }> = [
+      { label: "Any dist.", value: null },
+      { label: "Short (<50)", value: "short" },
+      { label: "Med (50-150)", value: "medium" },
+      { label: "Long (>150)", value: "long" },
+    ];
+    this.distanceBandButtons = [];
+    let distanceX = contentInnerX;
+    for (let i = 0; i < distanceBands.length; i++) {
+      const band = distanceBands[i];
+      const btn = new Button(this, {
+        x: distanceX,
+        y: distanceBandY,
+        autoWidth: true,
+        paddingX: filterBtnPadX,
+        height: 26,
+        label: band.label,
+        fontSize: 11,
+        onClick: () => {
+          this.finderDistanceBand = band.value;
+          this.updateDistanceBandButtonStyles();
+          this.refreshFinderTable();
+        },
+      });
+      this.distanceBandButtons.push(btn);
+      finderContent.add(btn);
+      distanceX += btn.width + 4;
+    }
+    this.updateDistanceBandButtonStyles();
 
     this.finderTable = new DataTable(this, {
       x: contentInnerX,
@@ -590,12 +626,13 @@ export class RoutesScene extends Phaser.Scene {
       state,
     );
 
-    // Apply cargo type filter
-    const filtered = this.finderCargoFilter
-      ? this.opportunities.filter(
-          (o) => o.bestCargoType === this.finderCargoFilter,
-        )
-      : this.opportunities;
+    // Apply cargo type + distance band filters
+    const filtered = this.opportunities.filter((o) => {
+      if (this.finderCargoFilter && o.bestCargoType !== this.finderCargoFilter)
+        return false;
+      if (!isInDistanceBand(o.distance, this.finderDistanceBand)) return false;
+      return true;
+    });
 
     const availableShips = state.fleet.filter((s) => !s.assignedRouteId).length;
     const profitableCount = filtered.filter(
@@ -706,6 +743,20 @@ export class RoutesScene extends Phaser.Scene {
     for (let i = 0; i < this.filterButtons.length; i++) {
       const btn = this.filterButtons[i];
       const isActive = allCargoFilters[i] === this.finderCargoFilter;
+      btn.setAlpha(isActive ? 1.0 : 0.5);
+    }
+  }
+
+  private updateDistanceBandButtonStyles(): void {
+    const bands: Array<DistanceBand> = [
+      null,
+      "short",
+      "medium",
+      "long",
+    ];
+    for (let i = 0; i < this.distanceBandButtons.length; i++) {
+      const btn = this.distanceBandButtons[i];
+      const isActive = bands[i] === this.finderDistanceBand;
       btn.setAlpha(isActive ? 1.0 : 0.5);
     }
   }

--- a/src/scenes/__tests__/routesFinderFilters.test.ts
+++ b/src/scenes/__tests__/routesFinderFilters.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { isInDistanceBand } from "../routesFinderFilters.ts";
+
+describe("isInDistanceBand", () => {
+  it("returns true for any distance when band is null", () => {
+    expect(isInDistanceBand(0, null)).toBe(true);
+    expect(isInDistanceBand(49.9, null)).toBe(true);
+    expect(isInDistanceBand(50, null)).toBe(true);
+    expect(isInDistanceBand(1000, null)).toBe(true);
+  });
+
+  it("classifies short routes (< 50)", () => {
+    expect(isInDistanceBand(0, "short")).toBe(true);
+    expect(isInDistanceBand(49.9, "short")).toBe(true);
+    expect(isInDistanceBand(50, "short")).toBe(false);
+    expect(isInDistanceBand(150, "short")).toBe(false);
+  });
+
+  it("classifies medium routes (50–150 inclusive)", () => {
+    expect(isInDistanceBand(50, "medium")).toBe(true);
+    expect(isInDistanceBand(100, "medium")).toBe(true);
+    expect(isInDistanceBand(150, "medium")).toBe(true);
+    expect(isInDistanceBand(49.9, "medium")).toBe(false);
+    expect(isInDistanceBand(150.1, "medium")).toBe(false);
+  });
+
+  it("classifies long routes (> 150)", () => {
+    expect(isInDistanceBand(150, "long")).toBe(false);
+    expect(isInDistanceBand(150.1, "long")).toBe(true);
+    expect(isInDistanceBand(1000, "long")).toBe(true);
+  });
+
+  it("partitions every distance into exactly one of short/medium/long", () => {
+    for (const d of [0, 25, 49.9, 50, 75, 150, 150.01, 200, 1000]) {
+      const bands = (
+        ["short", "medium", "long"] as const
+      ).filter((b) => isInDistanceBand(d, b));
+      expect(bands.length).toBe(1);
+    }
+  });
+});

--- a/src/scenes/routesFinderFilters.ts
+++ b/src/scenes/routesFinderFilters.ts
@@ -1,0 +1,24 @@
+export type DistanceBand = "short" | "medium" | "long" | null;
+
+/**
+ * Distance-band predicate for the Route Finder filter row.
+ *
+ * Bucket boundaries are intentionally inclusive on the upper edge of "medium"
+ * (50–150) so a route with distance exactly 150 stays in the medium band, not
+ * promoted to long. Routes at distance 50 belong to medium, not short.
+ */
+export function isInDistanceBand(
+  distance: number,
+  band: DistanceBand,
+): boolean {
+  switch (band) {
+    case "short":
+      return distance < 50;
+    case "medium":
+      return distance >= 50 && distance <= 150;
+    case "long":
+      return distance > 150;
+    default:
+      return true;
+  }
+}


### PR DESCRIPTION
## Summary

Players scanning the Route Finder for profitable runs could only narrow by **cargo type**. With long lists of opportunities, finding routes of a specific scale (quick local hops vs cross-galaxy long-hauls) meant sorting by distance and eyeballing.

This PR adds a second filter row below the cargo chips with four distance bands: **Any** / **Short (<50)** / **Medium (50–150)** / **Long (>150)**. Filters compose (intersection — both cargo and distance must match), so e.g. \"Tech + Long\" narrows immediately to long-haul tech runs.

## Changes

- New pure helper `isInDistanceBand(distance, band)` in `src/scenes/routesFinderFilters.ts`. Bucket boundaries are explicit about the upper edge — a 150-unit route stays in **medium**, not **long**.
- `RoutesScene` gains a `finderDistanceBand` field, a four-button row rendered below the cargo chips, and a styling toggle that mirrors the cargo filter (active=alpha 1.0, inactive=alpha 0.5).
- 5 new unit tests cover boundary cases (49.9 vs 50 vs 150 vs 150.1) and the partition property: every distance maps to exactly one of short/medium/long.

## Verification

- `npm run test` — 743/743 pass (738 existing + 5 new boundary tests).
- Visual smoke via `__sft.list()`: all four distance-band buttons render, are enabled, and click handlers fire (no errors logged).

## Test plan

- [ ] Pull the branch, `npm install`, `npm run dev`.
- [ ] New game → Routes → click **Long (>150)** chip; finder rows narrow to long-distance opportunities.
- [ ] Click **Tech** chip too; intersection narrows further.
- [ ] Click **Any dist.** — restores the cargo-filtered view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)