### PR TITLE
fix(scale): break resize feedback loop on the homepage

### DIFF
--- a/src/game/__tests__/config.test.ts
+++ b/src/game/__tests__/config.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  calculateGameSize,
+  BASE_HEIGHT,
+  MIN_WIDTH,
+  MAX_WIDTH,
+} from "../calculateGameSize.ts";
+
+describe("calculateGameSize", () => {
+  describe("landscape (ratio >= 1)", () => {
+    it("locks height to BASE_HEIGHT and scales width with the ratio", () => {
+      const size = calculateGameSize(1920, 1080);
+      expect(size.height).toBe(BASE_HEIGHT);
+      // width ≈ 720 * (1920/1080) = 1280
+      expect(size.width).toBe(Math.round(BASE_HEIGHT * (1920 / 1080)));
+    });
+
+    it("clamps width to MIN_WIDTH on near-square viewports", () => {
+      // 720x720 ratio is 1.0 → width = 720, but clamped to MIN_WIDTH (960)
+      const size = calculateGameSize(720, 720);
+      expect(size.width).toBe(MIN_WIDTH);
+      expect(size.height).toBe(BASE_HEIGHT);
+    });
+
+    it("clamps width to MAX_WIDTH on ultra-wide viewports", () => {
+      const size = calculateGameSize(5120, 720); // ultra-wide ratio
+      expect(size.width).toBe(MAX_WIDTH);
+      expect(size.height).toBe(BASE_HEIGHT);
+    });
+
+    it("is stable when called twice with the same inputs", () => {
+      const a = calculateGameSize(1440, 900);
+      const b = calculateGameSize(1440, 900);
+      expect(a).toEqual(b);
+    });
+
+    // Regression for the resize feedback loop: when the source width is
+    // already at MAX_WIDTH, sub-pixel changes in either axis must collapse
+    // to the same clamped output. Otherwise the main.ts dedupe can't break
+    // the loop on ultra-wide displays.
+    it("collapses to the same size when the result is clamped to MAX_WIDTH", () => {
+      const a = calculateGameSize(5120, 720);
+      const b = calculateGameSize(5121, 720);
+      expect(a).toEqual(b);
+      expect(a.width).toBe(MAX_WIDTH);
+    });
+  });
+
+  describe("portrait (ratio < 1)", () => {
+    it("locks width to MIN_WIDTH and scales height inversely", () => {
+      const size = calculateGameSize(600, 1200); // ratio 0.5
+      expect(size.width).toBe(MIN_WIDTH);
+      // height = MIN_WIDTH / ratio = 960 / 0.5 = 1920, capped at 1600
+      expect(size.height).toBe(1600);
+    });
+
+    it("respects the 1600px portrait cap", () => {
+      const size = calculateGameSize(360, 800);
+      expect(size.height).toBeLessThanOrEqual(1600);
+    });
+  });
+
+  describe("defensive defaults", () => {
+    it("falls back to safe values for zero or negative inputs", () => {
+      const size = calculateGameSize(0, 0);
+      expect(size.width).toBeGreaterThan(0);
+      expect(size.height).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/game/calculateGameSize.ts
+++ b/src/game/calculateGameSize.ts
@@ -1,0 +1,43 @@
+// Import directly from Layout.ts (not the @spacebiz/ui barrel) so this module
+// stays free of Phaser — keeps it cheap to import in unit tests.
+import {
+  BASE_HEIGHT,
+  MIN_WIDTH,
+  MAX_WIDTH,
+} from "../../packages/spacebiz-ui/src/Layout.ts";
+
+export { BASE_HEIGHT, MIN_WIDTH, MAX_WIDTH };
+
+/** Calculate a virtual game size for a given screen aspect ratio.
+ *
+ * Pure: takes explicit dimensions instead of reading `window` so the result is
+ * deterministic and testable. Falls back to window.innerWidth/Height when the
+ * caller doesn't pass dimensions.
+ */
+export function calculateGameSize(
+  screenW: number = typeof window !== "undefined"
+    ? window.innerWidth || 1280
+    : 1280,
+  screenH: number = typeof window !== "undefined"
+    ? window.innerHeight || 720
+    : 720,
+): { width: number; height: number } {
+  const safeW = screenW > 0 ? screenW : 1280;
+  const safeH = screenH > 0 ? screenH : 720;
+  const ratio = safeW / safeH;
+
+  if (ratio >= 1) {
+    // Landscape: fixed height, variable width
+    const w = Math.round(BASE_HEIGHT * ratio);
+    return {
+      width: Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, w)),
+      height: BASE_HEIGHT,
+    };
+  }
+  // Portrait: fixed width at MIN_WIDTH, variable height
+  const h = Math.round(MIN_WIDTH / ratio);
+  return {
+    width: MIN_WIDTH,
+    height: Math.min(h, 1600),
+  };
+}

--- a/src/game/config.ts
+++ b/src/game/config.ts
@@ -1,29 +1,8 @@
 import * as Phaser from "phaser";
-import { BASE_HEIGHT, MIN_WIDTH, MAX_WIDTH, updateLayout } from "@spacebiz/ui";
+import { updateLayout } from "@spacebiz/ui";
+import { calculateGameSize, BASE_HEIGHT, MIN_WIDTH, MAX_WIDTH } from "./calculateGameSize.ts";
 
-export { BASE_HEIGHT, MIN_WIDTH, MAX_WIDTH };
-
-/** Calculate a virtual game size that fills the screen at the current aspect ratio. */
-export function calculateGameSize(): { width: number; height: number } {
-  const screenW = window.innerWidth || 1280;
-  const screenH = window.innerHeight || 720;
-  const ratio = screenW / screenH;
-
-  if (ratio >= 1) {
-    // Landscape: fixed height, variable width
-    const w = Math.round(BASE_HEIGHT * ratio);
-    return {
-      width: Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, w)),
-      height: BASE_HEIGHT,
-    };
-  }
-  // Portrait: fixed width at MIN_WIDTH, variable height
-  const h = Math.round(MIN_WIDTH / ratio);
-  return {
-    width: MIN_WIDTH,
-    height: Math.min(h, 1600),
-  };
-}
+export { calculateGameSize, BASE_HEIGHT, MIN_WIDTH, MAX_WIDTH };
 
 export function createGameConfig(
   scenes: Phaser.Types.Scenes.SceneType[],

--- a/src/main.ts
+++ b/src/main.ts
@@ -656,15 +656,46 @@ function updateFooterYear(): void {
   }
 }
 
+// Cache the last applied dimensions so we can no-op when the resize event
+// fires for the same size (common during scroll-bar toggling reflows).
+let lastAppliedWidth = 0;
+let lastAppliedHeight = 0;
+
 function resizeGameToViewport(): void {
   if (!activeGame) {
     return;
   }
 
-  const size = calculateGameSize();
+  // Prefer the canvas parent's bounding box. Reading window.innerWidth/Height
+  // includes scrollbar width on some browsers, which flips when the canvas
+  // resize itself toggles a page scrollbar — that's the feedback loop we
+  // want to break. Fall back to the window when the parent isn't laid out yet.
+  const parent = document.getElementById("game-container");
+  const parentRect = parent?.getBoundingClientRect();
+  const parentW = parentRect && parentRect.width > 0 ? parentRect.width : 0;
+  const parentH = parentRect && parentRect.height > 0 ? parentRect.height : 0;
+  const sourceW = parentW > 0 ? parentW : window.innerWidth || 1280;
+  const sourceH = parentH > 0 ? parentH : window.innerHeight || 720;
+
+  const size = calculateGameSize(sourceW, sourceH);
+
+  // Skip the round-trip if the resulting virtual size hasn't changed by at
+  // least 1px in either axis. Phaser's scale.resize triggers a layout pass
+  // and emits its own internal events; calling it for a no-op size starts the
+  // exact thrash we're trying to avoid.
+  if (
+    size.width === lastAppliedWidth &&
+    size.height === lastAppliedHeight
+  ) {
+    return;
+  }
+  lastAppliedWidth = size.width;
+  lastAppliedHeight = size.height;
+
   updateLayout(size.width, size.height);
+  // scale.resize internally refreshes the layout — calling scale.refresh()
+  // afterwards is redundant and triggers an extra layout pass.
   activeGame.scale.resize(size.width, size.height);
-  activeGame.scale.refresh();
 }
 
 function setupFullscreenControl(): void {
@@ -760,14 +791,28 @@ function mountGame(): void {
     );
   }
 
-  // Recalculate virtual resolution on significant viewport changes (orientation flip)
-  let resizeTimer: ReturnType<typeof setTimeout> | null = null;
-  window.addEventListener("resize", () => {
-    if (resizeTimer) clearTimeout(resizeTimer);
-    resizeTimer = setTimeout(() => {
+  // Track resizes via a ResizeObserver on the canvas parent. This is more
+  // accurate than window.resize because the game cares about its own
+  // container's box, not the window — and it avoids the scrollbar-flicker
+  // feedback loop where a window.resize fires every time the canvas resize
+  // itself toggles a page scrollbar.
+  let pendingFrame = 0;
+  const scheduleResize = (): void => {
+    if (pendingFrame) return;
+    pendingFrame = window.requestAnimationFrame(() => {
+      pendingFrame = 0;
       resizeGameToViewport();
-    }, 250);
-  });
+    });
+  };
+
+  const parent = document.getElementById("game-container");
+  if (parent && typeof ResizeObserver !== "undefined") {
+    const observer = new ResizeObserver(scheduleResize);
+    observer.observe(parent);
+  }
+  // Keep a window.resize fallback for orientation flips and browsers that
+  // don't fire the ResizeObserver on viewport-driven CSS changes.
+  window.addEventListener("resize", scheduleResize);
 }
 
 renderSite();
@@ -782,5 +827,7 @@ if (import.meta.hot) {
   import.meta.hot.dispose(() => {
     activeGame?.destroy(true);
     activeGame = null;
+    lastAppliedWidth = 0;
+    lastAppliedHeight = 0;
   });
 }


### PR DESCRIPTION
## Summary

Dragging a window edge or resizing the browser caused the embedded game canvas to thrash in a refresh loop. Three causes, all in the resize plumbing in `main.ts`:

1. `resizeGameToViewport` read `window.innerWidth`/`Height` — which on some browsers includes scrollbar width, and flips when the canvas resize itself toggles a page scrollbar. That's the loop: resize → canvas resize → scrollbar toggles → window dimensions change → resize.
2. After `scale.resize(w,h)` we also called `scale.refresh()`. Phaser's `scale.resize` already triggers a layout pass; calling `refresh` after is redundant and runs a second layout per resize event.
3. No same-size guard. Every resize event invoked `game.scale.resize()` even when the resulting virtual size hadn't changed by 1px.

## Changes

- Read the canvas parent's bounding rect (`game-container`) instead of `window.innerWidth/Height`. Falls back to the window when the parent isn't laid out yet.
- Cache `lastAppliedWidth/Height` and bail when the new size matches. Reset the cache on HMR dispose so a fresh game still applies its first real resize.
- Replace the 250ms `setTimeout` debounce with a `ResizeObserver` on the game-container, plus a `requestAnimationFrame` coalescer so a burst of events collapses to a single layout pass per frame. Keep `window.resize` as a fallback for orientation flips.
- Drop the redundant `scale.refresh()` after `scale.resize()`.
- Extract `calculateGameSize` into its own pure module (`src/game/calculateGameSize.ts`) so it's unit-testable without pulling Phaser. Now accepts explicit `(screenW, screenH)` for deterministic tests.
- 8 new tests cover the landscape/portrait branches, MIN/MAX_WIDTH clamping, defensive zero-input handling, and the dedupe-relevant case where ultra-wide widths collapse to MAX_WIDTH.

## Verification

- `npm run test` — 751/751 pass (743 existing + 8 new `calculateGameSize` tests).
- Live in browser: dispatched 10 synchronous `resize` events; canvas remained stable at 1152×720 internal with display correctly scaled by Phaser's FIT mode. Resized viewport from 1280×800 → 1920×1080 → 2560×1440; canvas dimensions stayed deterministic with no flicker or repeated layout passes.

## Test plan

- [ ] Pull the branch, `npm install`, `npm run dev`.
- [ ] Drag the browser window edge — canvas should not flicker.
- [ ] Toggle browser zoom (Cmd+/Cmd-) — canvas adjusts cleanly.
- [ ] Resize across 1280×720, 1440×900, 1920×1080, 2560×1440 — no oscillation.

## Out of scope (next)

Making the canvas pretty on high-DPI MacBook displays (currently caps internal width at MAX_WIDTH=1920, displayed canvas stays small at 1230×769 on a 2560+ panel). Tracked as a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)