### PR TITLE
fix(routes): trim Route Finder column widths + context-aware empty state

### DIFF
--- a/packages/spacebiz-ui/src/DataTable.ts
+++ b/packages/spacebiz-ui/src/DataTable.ts
@@ -687,6 +687,17 @@ export class DataTable extends Phaser.GameObjects.Container {
     return this.rows[this.selectedRowIndex] ?? null;
   }
 
+  /**
+   * Override the empty-state copy at runtime. Lets callers swap a generic
+   * "no data yet" hint for a context-aware one (e.g. "Try a different filter"
+   * vs "Generate a galaxy first") without rebuilding the table.
+   */
+  setEmptyState(text?: string, hint?: string): void {
+    if (text !== undefined) this.tableConfig.emptyStateText = text;
+    if (hint !== undefined) this.tableConfig.emptyStateHint = hint;
+    this.setRows(this.rows);
+  }
+
   /** Scroll by one visible page height in the given direction (-1 up, +1 down). */
   private scrollPage(direction: number): void {
     const pageSize = this.tableConfig.height - this.headerHeight;

--- a/src/scenes/RoutesScene.ts
+++ b/src/scenes/RoutesScene.ts
@@ -281,18 +281,21 @@ export class RoutesScene extends Phaser.Scene {
       width: contentInnerW,
       height: tableHeight,
       columns: [
-        { key: "origin", label: "From", width: 100, sortable: true },
-        { key: "destination", label: "To", width: 100, sortable: true },
+        // Column widths sum to 695 — fits inside contentInnerW (~696) at the
+        // smallest supported game width (1152). Trimmed from a 776-px set
+        // that overflowed the panel right edge.
+        { key: "origin", label: "From", width: 92, sortable: true },
+        { key: "destination", label: "To", width: 92, sortable: true },
         {
           key: "empire",
           label: "Empire",
-          width: 80,
+          width: 70,
           sortable: true,
         },
         {
           key: "cargo",
           label: "Cargo",
-          width: 90,
+          width: 80,
           sortable: true,
           format: (v) => getCargoShortLabel(v as string),
           iconFn: (v) => getCargoIconKey(v as string),
@@ -322,7 +325,7 @@ export class RoutesScene extends Phaser.Scene {
         {
           key: "price",
           label: "Price",
-          width: 70,
+          width: 65,
           align: "right",
           sortable: true,
           format: (v) => `§${(v as number).toFixed(0)}`,
@@ -342,14 +345,14 @@ export class RoutesScene extends Phaser.Scene {
         {
           key: "dist",
           label: "Dist",
-          width: 45,
+          width: 40,
           align: "right",
           sortable: true,
         },
         {
           key: "profit",
           label: "Profit/turn",
-          width: 80,
+          width: 75,
           align: "right",
           sortable: true,
           format: (v) => formatCompact(v as number),
@@ -361,7 +364,7 @@ export class RoutesScene extends Phaser.Scene {
         {
           key: "ship",
           label: "Ship",
-          width: 110,
+          width: 80,
           sortable: true,
           iconFn: (_v, row) => {
             const sc = row?.["shipClass"] as string | undefined;
@@ -731,6 +734,28 @@ export class RoutesScene extends Phaser.Scene {
             : opp.shipName,
       };
     });
+
+    // Context-aware empty-state hint. The default ("Generate a galaxy first")
+    // is misleading once a galaxy exists — the real reason for an empty
+    // table is almost always a too-narrow filter or no compatible ship.
+    if (rows.length === 0) {
+      const noGalaxy = state.galaxy.planets.length === 0;
+      const hasFilter =
+        this.finderCargoFilter !== null || this.finderDistanceBand !== null;
+      let emptyText = "No route opportunities found";
+      let emptyHint: string;
+      if (noGalaxy) {
+        emptyHint = "Generate a galaxy first.";
+      } else if (hasFilter) {
+        emptyText = `No ${filterLabel} routes match your filter`;
+        emptyHint = "Widen the cargo or distance filter — or try All.";
+      } else if (availableShips === 0 && state.fleet.length === 0) {
+        emptyHint = "Buy a ship from the Fleet screen to unlock routes.";
+      } else {
+        emptyHint = "Tech and luxury cargo unlocks more options later.";
+      }
+      this.finderTable.setEmptyState(emptyText, emptyHint);
+    }
 
     this.finderTable.setRows(rows);
   }


### PR DESCRIPTION
## Summary

Two issues spotted in QA on the homepage hero canvas (screenshots showed the empty grid + a column overflow on the Route Finder):

### 1. Column overflow

DataTable column widths summed to **776px**, but at the smallest supported game width (1152) the panel's `contentInnerW` is only **~696**. The table extended ~80px past the panel's right edge — most visible on Profit/turn + Ship columns.

Trimmed to total 695px (origin 100→92, destination 100→92, empire 80→70, cargo 90→80, price 70→65, dist 45→40, profit 80→75, ship 110→80; restricted/tariff/trend unchanged).

### 2. Misleading empty-state hint

The hint always read \"Generate a galaxy first.\" — even after the galaxy was generated and the player just had a too-narrow filter. Now context-aware:

| Condition | Hint |
|---|---|
| No galaxy planets | \"Generate a galaxy first.\" |
| Cargo or distance filter narrowed to zero | \"Widen the cargo or distance filter — or try All.\" |
| Player has zero ships | \"Buy a ship from the Fleet screen to unlock routes.\" |
| Otherwise | \"Tech and luxury cargo unlocks more options later.\" |

To support runtime mutation, `DataTable` gains a `setEmptyState(text, hint)` method that re-renders the table.

## Verification

- `npm run test` — 751/751 pass.
- `npm run typecheck` — clean (only the pre-existing 9 Phaser-4 typings errors remain).
- Manual: filter the Route Finder by HAZ on a fresh galaxy → hint now reads \"Widen the cargo or distance filter — or try All.\" instead of \"Generate a galaxy first.\"
- Manual: column right edge no longer extends past the panel border at game-width 1152.

## Test plan

- [ ] Pull, `npm run dev`.
- [ ] Open Routes → click HAZ filter on a fresh game with limited fleet — hint should read \"Widen the cargo or distance filter — or try All.\"
- [ ] Resize window so canvas is at the smallest supported size — Route Finder columns stay inside the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)