### PR TITLE
fix(scale): kill residual letterbox on Mac fullscreen

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -656,10 +656,15 @@ function updateFooterYear(): void {
   }
 }
 
-// Cache the last applied dimensions so we can no-op when the resize event
-// fires for the same size (common during scroll-bar toggling reflows).
-let lastAppliedWidth = 0;
-let lastAppliedHeight = 0;
+// Cache the last source dimensions (the canvas parent's box) so we can
+// no-op when nothing actually changed. Tracking the source — not the
+// rounded virtual game size — matters for fullscreen on 16:10-ish MacBook
+// panels: the virtual size can round to the same value across small parent
+// changes, but Phaser's FIT-mode layout still needs a refresh to recompute
+// the canvas display rect against the new container aspect. Skipping that
+// refresh leaves residual top/bottom letterboxing.
+let lastSourceWidth = 0;
+let lastSourceHeight = 0;
 
 function resizeGameToViewport(): void {
   if (!activeGame) {
@@ -668,8 +673,8 @@ function resizeGameToViewport(): void {
 
   // Prefer the canvas parent's bounding box. Reading window.innerWidth/Height
   // includes scrollbar width on some browsers, which flips when the canvas
-  // resize itself toggles a page scrollbar — that's the feedback loop we
-  // want to break. Fall back to the window when the parent isn't laid out yet.
+  // resize itself toggles a page scrollbar — that's the feedback loop the
+  // source-dim dedupe below also breaks.
   const parent = document.getElementById("game-container");
   const parentRect = parent?.getBoundingClientRect();
   const parentW = parentRect && parentRect.width > 0 ? parentRect.width : 0;
@@ -677,25 +682,26 @@ function resizeGameToViewport(): void {
   const sourceW = parentW > 0 ? parentW : window.innerWidth || 1280;
   const sourceH = parentH > 0 ? parentH : window.innerHeight || 720;
 
-  const size = calculateGameSize(sourceW, sourceH);
+  // Round to integers so sub-pixel reflows don't fire a resize per frame
+  // (browsers can report fractional getBoundingClientRect values).
+  const sourceWInt = Math.round(sourceW);
+  const sourceHInt = Math.round(sourceH);
 
-  // Skip the round-trip if the resulting virtual size hasn't changed by at
-  // least 1px in either axis. Phaser's scale.resize triggers a layout pass
-  // and emits its own internal events; calling it for a no-op size starts the
-  // exact thrash we're trying to avoid.
-  if (
-    size.width === lastAppliedWidth &&
-    size.height === lastAppliedHeight
-  ) {
+  if (sourceWInt === lastSourceWidth && sourceHInt === lastSourceHeight) {
     return;
   }
-  lastAppliedWidth = size.width;
-  lastAppliedHeight = size.height;
+  lastSourceWidth = sourceWInt;
+  lastSourceHeight = sourceHInt;
 
+  const size = calculateGameSize(sourceW, sourceH);
   updateLayout(size.width, size.height);
-  // scale.resize internally refreshes the layout — calling scale.refresh()
-  // afterwards is redundant and triggers an extra layout pass.
   activeGame.scale.resize(size.width, size.height);
+  // Force Phaser to recompute the FIT-scaled display rect against the new
+  // parent box. scale.resize alone doesn't always refresh the layout when
+  // the virtual size happens to round to the previous value but the
+  // container's aspect changed (e.g., entering Mac fullscreen on a 16:10.4
+  // panel after sizing on a 16:9 window).
+  activeGame.scale.refresh();
 }
 
 function setupFullscreenControl(): void {
@@ -767,8 +773,15 @@ function mountGame(): void {
   ]);
 
   activeGame = new Phaser.Game(config);
+  // The initial calculateGameSize() in createGameConfig() uses window
+  // dimensions, but the game-container's actual box is usually narrower
+  // (constrained by a column on the marketing page). Fire one extra resize
+  // pass after the first paint so the canvas snaps to the real container
+  // aspect — without this the canvas can stay locked to the wider window
+  // ratio and letterbox inside its column.
   window.requestAnimationFrame(() => {
     activeGame?.scale.refresh();
+    resizeGameToViewport();
   });
 
   // QA testing façade (`window.__sft`).
@@ -827,7 +840,7 @@ if (import.meta.hot) {
   import.meta.hot.dispose(() => {
     activeGame?.destroy(true);
     activeGame = null;
-    lastAppliedWidth = 0;
-    lastAppliedHeight = 0;
+    lastSourceWidth = 0;
+    lastSourceHeight = 0;
   });
 }

--- a/src/site.css
+++ b/src/site.css
@@ -695,7 +695,8 @@ canvas {
   color: var(--text);
 }
 
-.game-frame:fullscreen {
+.game-frame:fullscreen,
+.game-frame.is-browser-fullscreen {
   width: 100vw;
   height: 100vh;
   height: 100dvh;
@@ -707,6 +708,13 @@ canvas {
 .game-frame:fullscreen .game-frame__screen,
 .game-frame.is-browser-fullscreen .game-frame__screen {
   padding: 0.2rem;
+}
+
+/* Clear the .viewport base class's aspect-ratio: 16/9 in fullscreen so the
+   canvas can fill 16:10-ish MacBook panels without top/bottom letterboxing. */
+.game-frame:fullscreen .viewport,
+.game-frame.is-browser-fullscreen .viewport {
+  aspect-ratio: auto;
 }
 
 .game-frame:fullscreen .viewport,


### PR DESCRIPTION
## Summary

User reported black bands top + bottom of the canvas in macOS browser fullscreen on a 16-inch MBP (effective viewport ≈ 1728×1117, ratio 1.547 — not 16:9). Three overlapping causes:

1. **Cache deduped by rounded virtual size, not source box.** The resize-loop dedupe from #42 keyed off `calculateGameSize`'s rounded result. When the parent box changed but the virtual size rounded the same, the handler skipped `scale.resize` — and Phaser's FIT-mode layout never recomputed against the new container aspect.
2. **.viewport's `aspect-ratio: 16/9` bled into fullscreen.** The `.viewport--hero` variant overrides with `aspect-ratio: auto` for the hero region, but no fullscreen rule explicitly cleared it, so the cascade could leave the 16/9 constraint active.
3. **Initial size used window dims, not the canvas parent's box.** `createGameConfig`'s boot-time `calculateGameSize()` reads full `window.innerWidth/Height`, but the canvas parent (`game-container` inside `.viewport-hero`) is narrower due to the marketing column. Without a follow-up resize after first paint, the canvas stayed locked to the wider window ratio.

## Changes

- **`src/main.ts`** — switch the dedupe to integer-rounded **source** dimensions (parent W × H). Any actual parent change now triggers a fresh `scale.resize` regardless of virtual rounding. Always call `activeGame.scale.refresh()` after the resize so Phaser recomputes the FIT display rect.
- **`src/main.ts`** — fire one extra `resizeGameToViewport()` in the post-mount rAF so the canvas snaps to the real container box, not the boot-time window.
- **`src/site.css`** — add explicit `aspect-ratio: auto` for `.viewport` in fullscreen so the 16/9 base class can't bleed through. Apply the `100vw × 100vh` sizing to both `:fullscreen` and `.is-browser-fullscreen` variants.

## Verification

- `npm run typecheck` — clean (only pre-existing 9 Phaser-4 typings errors).
- `npm run test` — 759/759 pass.
- The embedded preview at 1728×1117 already showed source-vs-virtual mismatch behavior I was targeting; the underlying cause + each fix is documented in the commit body. The cleanest verification is on the user's actual Mac fullscreen — should now fill edge-to-edge.

## Test plan

- [ ] Pull, `npm run dev`, click **Full Screen** in the hero header.
- [ ] On a 16:10-ish display (any MacBook), the canvas should fill edge-to-edge with no top/bottom black band.
- [ ] Exit fullscreen — canvas snaps back to its column.
- [ ] Resize the browser window — no flicker, no oscillating layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)