### PR TITLE
refactor(adviser): name onboard delay constant, clarify dedup contract

### DIFF
--- a/src/scenes/GameHUDScene.ts
+++ b/src/scenes/GameHUDScene.ts
@@ -50,6 +50,10 @@ function formatCash(amount: number): string {
   return "\u00A7" + Math.round(amount).toLocaleString("en-US");
 }
 
+/** Delay before surfacing the new-game adviser welcome, so the HUD has
+ * fully rendered before the drawer slides in. */
+const ADVISER_ONBOARD_DELAY_MS = 700;
+
 function fitImageCover(
   image: Phaser.GameObjects.Image,
   width: number,
@@ -639,7 +643,7 @@ export class GameHUDScene extends Phaser.Scene {
 
     // Fire initial tutorial trigger — surfaces the welcome step via the
     // adviser drawer (route-building onboarding).
-    this.time.delayedCall(700, () => {
+    this.time.delayedCall(ADVISER_ONBOARD_DELAY_MS, () => {
       this.fireTutorialTrigger("newGame");
     });
 
@@ -1341,6 +1345,8 @@ export class GameHUDScene extends Phaser.Scene {
     const step = TUTORIAL_STEPS[stepIndex];
     if (!step) return;
 
+    // Dedup is by message id (via shownMessageIds in AdviserEngine), and
+    // each tutorial step has a unique id, so firing across turns is safe.
     const msg: AdviserMessage = {
       id: step.id,
       text: step.text,


### PR DESCRIPTION
## Summary

Follow-up to #60 addressing review feedback that arrived after merge.

- Extract the 700ms HUD-render-then-show-drawer delay into `ADVISER_ONBOARD_DELAY_MS` so its intent is documented at the source.
- Add a comment to `showTutorialStep` noting that `AdviserMessage` dedup is keyed on the unique step id (via `AdviserEngine.shownMessageIds`), so `turnGenerated` being the current turn is safe — it represents when the message was surfaced, not a dedup key.

No behavior change.

## Test plan

- [x] `npm run test` — 774/774 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)