### PR TITLE
feat(routes): three-tier route scope (system/empire/galactic)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "spacebiz-dev",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "port": 5173
+      "port": 5173,
+      "autoPort": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1752,6 +1752,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2307,6 +2308,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2597,6 +2599,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2948,6 +2951,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3168,6 +3172,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3972,6 +3977,7 @@
       "resolved": "https://registry.npmjs.org/phaser/-/phaser-4.0.0.tgz",
       "integrity": "sha512-f9oYpu3/UymB5JJDZRqOsNQm5FkMMC7u8eL8yQuqGAa54wTbgE2QbTOn70vgvlOVuYeQcw2mOQ52PpJHBSBkfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.4"
       }
@@ -4726,6 +4732,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4775,6 +4782,7 @@
       "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
@@ -4854,6 +4862,7 @@
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0",
         "@vitest/mocker": "4.1.0",
@@ -5061,6 +5070,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/data/GameStore.ts
+++ b/src/data/GameStore.ts
@@ -6,6 +6,7 @@ import {
   SAVE_VERSION,
   ACTION_POINTS_PER_TURN,
   LOCAL_ROUTE_SLOTS,
+  BASE_GALACTIC_ROUTE_SLOTS,
 } from "./constants";
 import { initAdviserState } from "../game/adviser/AdviserEngine.ts";
 
@@ -44,6 +45,7 @@ function createDefaultState(): GameState {
     adviser: initAdviserState(),
     routeSlots: 4,
     localRouteSlots: LOCAL_ROUTE_SLOTS,
+    galacticRouteSlots: BASE_GALACTIC_ROUTE_SLOTS,
     unlockedEmpireIds: [],
     contracts: [],
     tech: {

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -113,15 +113,27 @@ export const BASE_GALACTIC_ROUTE_SLOTS = 3;
 
 // ── Per-Cargo Scope Demand Multipliers ─────────────────────────
 //
-// Replaces the old flat `INTRA_SYSTEM_REVENUE_MULTIPLIER` (0.5 across all cargo)
-// with a per-cargo curve that encodes "what people pay extra for, by distance":
+// Replaces the old flat `INTRA_SYSTEM_REVENUE_MULTIPLIER` (0.5 across all
+// cargo) with a per-cargo curve that encodes "what people pay extra for, by
+// distance":
 //
-//   • Heavy / bulk cargo (rawMaterials, food, hazmat) is more valuable LOCAL
-//     and within an empire — nobody hauls iron ore across the galaxy.
-//   • Luxury and technology become MORE valuable the further they travel —
-//     scarcity pricing for exotic goods.
-//   • Passengers favor inter-empire travel slightly (immigration / tourism)
-//     but punish intra-system "shuttle to the next moon" routes.
+//   • Heavy / bulk cargo (rawMaterials, food, hazmat) keeps its old ~0.5
+//     value at system scope (heavy goods *are* the local meta) and rises
+//     above 1 within an empire — nobody hauls iron ore across the galaxy.
+//   • Luxury and technology are heavily punished locally (down to 0.20×) and
+//     strongly rewarded galactically (up to 1.7×) — scarcity pricing for
+//     exotic goods.
+//   • Passengers favor inter-empire travel (1.3×) but punish intra-system
+//     "shuttle to the next moon" routes (0.30×).
+//
+// CALIBRATION NOTES (post-PR#69 simulation): the trips-per-turn cap (10) plus
+// short system distances meant any system multiplier above ~0.5 made local
+// routes net more profitable than the old flat cap. System values are tuned
+// down across the board — heavy goods stay near 0.5 (parity with old), while
+// luxury/tech drop to 0.20–0.25 so the meta pulls toward longer hauls. Slot
+// pool sizing (system 2 / empire 4 / galactic 3) provides the secondary
+// dampener — even when per-slot revenue is similar, total network capacity
+// is heavily weighted toward empire+galactic.
 //
 // The number is a multiplier on revenue for that cargo on that scope, applied
 // after price × capacity × trips and the distance premium.
@@ -129,13 +141,13 @@ export const SCOPE_DEMAND_MULTIPLIERS: Record<
   CargoType,
   Record<RouteScope, number>
 > = {
-  [CargoType.Passengers]: { system: 0.5, empire: 1.0, galactic: 1.3 },
-  [CargoType.RawMaterials]: { system: 0.7, empire: 1.1, galactic: 0.5 },
-  [CargoType.Food]: { system: 0.7, empire: 1.1, galactic: 0.6 },
-  [CargoType.Technology]: { system: 0.4, empire: 1.0, galactic: 1.5 },
-  [CargoType.Luxury]: { system: 0.3, empire: 0.9, galactic: 1.7 },
-  [CargoType.Hazmat]: { system: 0.6, empire: 1.1, galactic: 0.6 },
-  [CargoType.Medical]: { system: 0.6, empire: 1.0, galactic: 1.2 },
+  [CargoType.Passengers]: { system: 0.3, empire: 1.0, galactic: 1.3 },
+  [CargoType.RawMaterials]: { system: 0.5, empire: 1.1, galactic: 0.4 },
+  [CargoType.Food]: { system: 0.5, empire: 1.1, galactic: 0.4 },
+  [CargoType.Technology]: { system: 0.25, empire: 1.0, galactic: 1.5 },
+  [CargoType.Luxury]: { system: 0.2, empire: 0.9, galactic: 1.7 },
+  [CargoType.Hazmat]: { system: 0.5, empire: 1.1, galactic: 0.4 },
+  [CargoType.Medical]: { system: 0.3, empire: 1.0, galactic: 1.2 },
 };
 
 /** Target distribution of route market entries across scopes per generation. */

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -9,6 +9,7 @@ import {
   type Technology,
   type HubRoomDefinition,
   type NavTabId,
+  type RouteScope,
 } from "./types";
 
 // ── Save Version ───────────────────────────────────────────────
@@ -48,15 +49,101 @@ export const BREAKDOWN_THRESHOLD = 50;
 export const TURN_DURATION = 100;
 /** Hard cap on trips per turn to prevent intra-system routes from being exploited */
 export const MAX_TRIPS_PER_TURN = 10;
-// Local (intra-system) route slot pool — separate from main route slots
+// Local (intra-system) route slot pool — separate from main route slots.
+// @deprecated Use BASE_SYSTEM_ROUTE_SLOTS — kept as alias for older fixtures.
 export const LOCAL_ROUTE_SLOTS = 2;
-// Local routes are capped at 50% of equivalent inter-system revenue
+/**
+ * @deprecated Replaced by SCOPE_DEMAND_MULTIPLIERS, which applies a per-cargo
+ * scope multiplier instead of a flat 50% cap on intra-system revenue. Kept
+ * exported so legacy fixtures still compile, but no longer used in revenue
+ * calculations.
+ */
 export const LOCAL_ROUTE_REVENUE_CAP = 0.5;
-// INTRA_SYSTEM_REVENUE_MULTIPLIER is now set to the cap for backwards compatibility
+/** @deprecated alias of LOCAL_ROUTE_REVENUE_CAP — replaced by scope multipliers. */
 export const INTRA_SYSTEM_REVENUE_MULTIPLIER = LOCAL_ROUTE_REVENUE_CAP;
 // Longer routes command higher freight rates (per distance unit, capped)
 export const DISTANCE_PREMIUM_RATE = 0.0015;
 export const DISTANCE_PREMIUM_CAP = 0.5;
+
+// ── Route Scope Slot Pools ─────────────────────────────────────
+//
+// Routes are classified by scope (see `getRouteScope` in RouteManager.ts) and
+// each scope draws from its own slot pool. Each pool grows through a different
+// in-game mechanic so the player has distinct paths to expansion:
+//
+//   • System  — fixed (training-wheel tier; no growth path).
+//   • Empire  — grows via Logistics tech and Hub Ore Processing (engineering).
+//   • Galactic — grows via empire unlocks (diplomacy/contracts).
+//
+// Mid- and long-range slots are intentionally weighted higher than system
+// slots so the meta-game pulls toward longer hauls. See SCOPE_DEMAND_MULTIPLIERS
+// for the matching revenue curves.
+
+/** Intra-system slot pool (origin and destination share a star system). */
+export const BASE_SYSTEM_ROUTE_SLOTS = 2;
+/** Intra-empire interstellar slot pool. Backed by `routeSlots` on GameState. */
+export const BASE_EMPIRE_ROUTE_SLOTS = 3;
+/**
+ * Inter-empire (galactic) slot pool. Bumped to 3 in the alpha rebalance so the
+ * highest-margin tier starts with real capacity instead of feeling rationed.
+ * Each subsequent empire unlock adds another slot here (see ContractManager).
+ */
+export const BASE_GALACTIC_ROUTE_SLOTS = 3;
+
+// ── Future seam: Ship-Class × Scope haul-band system ───────────
+//
+// Planned for a follow-up pass (Aerobiz-inspired): each ship class will have
+// an "optimal haul band" matching one or two scopes, with efficiency falling
+// off sharply outside that band. The intent is to make ship procurement a
+// tactical choice keyed to which slot pool the player is filling.
+//
+// When that lands, expect:
+//
+//   1. A `RECOMMENDED_SHIP_CLASSES_BY_SCOPE: Record<RouteScope, ShipClass[]>`
+//      table next to SCOPE_DEMAND_MULTIPLIERS, surfaced as tooltips on the
+//      route slot HUD and the ship purchase panel.
+//   2. A per-class `optimalHaulBand: { min: number; max: number }` field on
+//      ShipTemplate, with revenue/fuel modifiers when distance falls outside.
+//   3. The route market generator and route opportunity scanner switching
+//      ship-pick logic to weight this band, replacing today's pure
+//      profit-per-turn ranking.
+//
+// For this pass the seam is data-only (the comment + the three slot pools);
+// nothing consumes the haul-band concept yet.
+
+// ── Per-Cargo Scope Demand Multipliers ─────────────────────────
+//
+// Replaces the old flat `INTRA_SYSTEM_REVENUE_MULTIPLIER` (0.5 across all cargo)
+// with a per-cargo curve that encodes "what people pay extra for, by distance":
+//
+//   • Heavy / bulk cargo (rawMaterials, food, hazmat) is more valuable LOCAL
+//     and within an empire — nobody hauls iron ore across the galaxy.
+//   • Luxury and technology become MORE valuable the further they travel —
+//     scarcity pricing for exotic goods.
+//   • Passengers favor inter-empire travel slightly (immigration / tourism)
+//     but punish intra-system "shuttle to the next moon" routes.
+//
+// The number is a multiplier on revenue for that cargo on that scope, applied
+// after price × capacity × trips and the distance premium.
+export const SCOPE_DEMAND_MULTIPLIERS: Record<
+  CargoType,
+  Record<RouteScope, number>
+> = {
+  [CargoType.Passengers]: { system: 0.5, empire: 1.0, galactic: 1.3 },
+  [CargoType.RawMaterials]: { system: 0.7, empire: 1.1, galactic: 0.5 },
+  [CargoType.Food]: { system: 0.7, empire: 1.1, galactic: 0.6 },
+  [CargoType.Technology]: { system: 0.4, empire: 1.0, galactic: 1.5 },
+  [CargoType.Luxury]: { system: 0.3, empire: 0.9, galactic: 1.7 },
+  [CargoType.Hazmat]: { system: 0.6, empire: 1.1, galactic: 0.6 },
+  [CargoType.Medical]: { system: 0.6, empire: 1.0, galactic: 1.2 },
+};
+
+/** Target distribution of route market entries across scopes per generation. */
+export const ROUTE_MARKET_SCOPE_QUOTA: Record<RouteScope, number> = {
+  system: 0.2,
+  empire: 0.4,
+  galactic: 0.4,
+};
 
 // ── Route License Fees ─────────────────────────────────────────
 
@@ -75,6 +162,11 @@ export const FLEET_OVERHEAD_PER_SHIP = 0.05;
 
 export const BASE_ROUTE_SLOTS = 3;
 export const HOME_EMPIRE_BONUS_SLOTS = 1;
+/**
+ * @deprecated Slot bonuses are now declared per-contract via
+ * `Contract.rewardSlotBonus`. This constant is kept for back-compat with
+ * fixtures that still reference it; new code should not read it.
+ */
 export const SLOT_PER_EMPIRE_UNLOCK = 1;
 
 // ── Empire Access ──────────────────────────────────────────────

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -249,6 +249,21 @@ export const CargoType = {
 } as const;
 export type CargoType = (typeof CargoType)[keyof typeof CargoType];
 
+/**
+ * Three-tier route scope. Determines which slot pool a route consumes and which
+ * per-cargo demand multiplier applies to its revenue.
+ *
+ * - `system`   — origin and destination share a star system (intra-system).
+ * - `empire`   — different systems, same empire (intra-empire interstellar).
+ * - `galactic` — origin and destination empires differ (inter-empire trade).
+ */
+export const RouteScope = {
+  System: "system",
+  Empire: "empire",
+  Galactic: "galactic",
+} as const;
+export type RouteScope = (typeof RouteScope)[keyof typeof RouteScope];
+
 export const PlanetType = {
   Terran: "terran",
   Industrial: "industrial",
@@ -755,6 +770,17 @@ export interface AICompany {
 
 // ── Contract types ─────────────────────────────────────────
 
+/**
+ * Permanent slot-pool bonus granted on contract completion. Each contract type
+ * targets at most one scope; see ContractGenerator.makeXxx for which type
+ * grants which scope. Stored as part of the contract so the reward is visible
+ * to the player at acceptance time, not surprise-applied at completion.
+ */
+export interface ContractSlotReward {
+  scope: RouteScope;
+  amount: number;
+}
+
 export interface Contract {
   id: string;
   type: ContractType;
@@ -772,6 +798,12 @@ export interface Contract {
     empireB: string;
     reduction: number;
   } | null;
+  /**
+   * Optional slot-pool bonus paid out on completion. Empire-unlock and
+   * trade-alliance contracts grow the galactic pool; passenger-ferry grows the
+   * empire pool. Older saves (v6) without this field treat it as null.
+   */
+  rewardSlotBonus?: ContractSlotReward | null;
   depositPaid: number;
   status: ContractStatus;
   linkedRouteId: string | null;
@@ -954,9 +986,16 @@ export interface GameState {
   gameOverReason: string | null;
 
   // Phase 3: Strategic Depth
+  /** Empire-tier route slot pool — intra-empire interstellar routes consume this. */
   routeSlots: number;
-  /** Separate pool of local (intra-system) route slots — starts at 2 */
+  /** System-tier route slot pool — intra-system routes consume this. */
   localRouteSlots: number;
+  /**
+   * Galactic-tier route slot pool — inter-empire (cross-empire) routes consume
+   * this. Optional for backwards compatibility with v6 saves; defaults to
+   * BASE_GALACTIC_ROUTE_SLOTS when missing.
+   */
+  galacticRouteSlots?: number;
   unlockedEmpireIds: string[];
   contracts: Contract[];
   tech: TechState;

--- a/src/game/NewGameSetup.ts
+++ b/src/game/NewGameSetup.ts
@@ -22,6 +22,7 @@ import {
   SAVE_VERSION,
   ACTION_POINTS_PER_TURN,
   LOCAL_ROUTE_SLOTS,
+  BASE_GALACTIC_ROUTE_SLOTS,
 } from "../data/constants.ts";
 import type { GamePreset } from "../data/constants.ts";
 import { findAdjacentEmpires } from "./empire/EmpireAccessManager.ts";
@@ -402,6 +403,7 @@ export function createNewGame(
     adviser: initAdviserState(),
     routeSlots: BASE_ROUTE_SLOTS + HOME_EMPIRE_BONUS_SLOTS,
     localRouteSlots: LOCAL_ROUTE_SLOTS,
+    galacticRouteSlots: BASE_GALACTIC_ROUTE_SLOTS,
     unlockedEmpireIds,
     contracts: [],
     tech,

--- a/src/game/ai/steps/__tests__/aiRouteStep.test.ts
+++ b/src/game/ai/steps/__tests__/aiRouteStep.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect } from "vitest";
+import { simulateAIRoutes } from "../aiRouteStep.ts";
+import { SeededRNG } from "../../../../utils/SeededRNG.ts";
+import { CargoType, ShipClass, PlanetType } from "../../../../data/types.ts";
+import type {
+  GameState,
+  AICompany,
+  Ship,
+  Planet,
+  StarSystem,
+  Sector,
+  PlanetMarket,
+  CargoMarketEntry,
+} from "../../../../data/types.ts";
+import {
+  BASE_FUEL_PRICE,
+  BASE_CARGO_PRICES,
+  SCOPE_DEMAND_MULTIPLIERS,
+} from "../../../../data/constants.ts";
+import { initAdviserState } from "../../../adviser/AdviserEngine.ts";
+
+// ---------------------------------------------------------------------------
+// Regression guard: AI revenue must apply the scope demand multiplier so the
+// AI and player operate on a single economy. Before PR #69's audit, AI used
+// a raw `price × moved` formula and silently kept the old (no-cap) revenue
+// while the player ate the scope curve.
+// ---------------------------------------------------------------------------
+
+function makeMarketEntry(): CargoMarketEntry {
+  return {
+    baseSupply: 100,
+    baseDemand: 100,
+    currentPrice: BASE_CARGO_PRICES[CargoType.Food],
+    saturation: 0,
+    trend: "stable",
+    trendMomentum: 0,
+    eventModifier: 1,
+  };
+}
+
+function makePlanetMarket(): PlanetMarket {
+  const m: Record<string, CargoMarketEntry> = {};
+  for (const c of Object.values(CargoType)) m[c] = makeMarketEntry();
+  return m as PlanetMarket;
+}
+
+const sectors: Sector[] = [
+  { id: "sec-1", name: "S", x: 0, y: 0, color: 0xffffff },
+];
+
+// Two same-empire systems for the empire-scope route, plus a third in a
+// different empire so we can assert galactic-scope revenue too.
+const systems: StarSystem[] = [
+  {
+    id: "sys-1",
+    name: "A",
+    sectorId: "sec-1",
+    empireId: "emp-1",
+    x: 0,
+    y: 0,
+    starColor: 0xffcc00,
+  },
+  {
+    id: "sys-2",
+    name: "B",
+    sectorId: "sec-1",
+    empireId: "emp-1",
+    x: 100,
+    y: 0,
+    starColor: 0xffcc00,
+  },
+  {
+    id: "sys-3",
+    name: "C",
+    sectorId: "sec-1",
+    empireId: "emp-2",
+    x: 200,
+    y: 0,
+    starColor: 0xffcc00,
+  },
+];
+
+const planets: Planet[] = [
+  {
+    id: "p-a",
+    name: "A1",
+    systemId: "sys-1",
+    type: PlanetType.Industrial,
+    x: 0,
+    y: 0,
+    population: 100,
+  },
+  {
+    id: "p-b",
+    name: "B1",
+    systemId: "sys-2",
+    type: PlanetType.Industrial,
+    x: 100,
+    y: 0,
+    population: 100,
+  },
+  {
+    id: "p-c",
+    name: "C1",
+    systemId: "sys-3",
+    type: PlanetType.Industrial,
+    x: 200,
+    y: 0,
+    population: 100,
+  },
+];
+
+function makeShip(): Ship {
+  return {
+    id: "ai-ship-1",
+    name: "AI Hauler",
+    class: ShipClass.CargoShuttle,
+    cargoCapacity: 80,
+    passengerCapacity: 0,
+    speed: 4,
+    fuelEfficiency: 0.8,
+    reliability: 95,
+    age: 0,
+    condition: 100,
+    purchaseCost: 40000,
+    maintenanceCost: 2000,
+    assignedRouteId: "route-ai",
+  };
+}
+
+function makeAI(originId: string, destId: string, distance: number): AICompany {
+  return {
+    id: "ai-1",
+    name: "Mock AI",
+    empireId: "emp-1",
+    cash: 100000,
+    fleet: [makeShip()],
+    activeRoutes: [
+      {
+        id: "route-ai",
+        originPlanetId: originId,
+        destinationPlanetId: destId,
+        distance,
+        cargoType: CargoType.Food,
+        assignedShipIds: ["ai-ship-1"],
+      },
+    ],
+    reputation: 50,
+    totalCargoDelivered: 0,
+    personality: "steadyHauler",
+    bankrupt: false,
+    ceoName: "Mock",
+    ceoPortrait: { portraitId: "p-01", category: "human" },
+  };
+}
+
+function makeState(): GameState {
+  const planetMarkets: Record<string, PlanetMarket> = {};
+  for (const p of planets) planetMarkets[p.id] = makePlanetMarket();
+
+  return {
+    seed: 1,
+    turn: 1,
+    maxTurns: 20,
+    phase: "simulation",
+    cash: 0,
+    loans: [],
+    reputation: 50,
+    companyName: "P",
+    ceoName: "P",
+    ceoPortrait: { portraitId: "p", category: "human" },
+    gameSize: "standard",
+    galaxyShape: "spiral",
+    playerEmpireId: "emp-1",
+    galaxy: { sectors, empires: [], systems, planets },
+    fleet: [],
+    activeRoutes: [],
+    market: {
+      fuelPrice: BASE_FUEL_PRICE,
+      fuelTrend: "stable",
+      planetMarkets,
+    },
+    aiCompanies: [],
+    activeEvents: [],
+    history: [],
+    storyteller: {
+      playerHealthScore: 50,
+      headwindBias: 0,
+      turnsInDebt: 0,
+      consecutiveProfitTurns: 0,
+      turnsSinceLastDecision: 0,
+    },
+    score: 0,
+    gameOver: false,
+    gameOverReason: null,
+    adviser: initAdviserState(),
+    routeSlots: 4,
+    localRouteSlots: 2,
+    galacticRouteSlots: 3,
+    unlockedEmpireIds: ["emp-1", "emp-2"],
+    contracts: [],
+    tech: {
+      researchPoints: 0,
+      completedTechIds: [],
+      currentResearchId: null,
+      researchProgress: 0,
+    },
+    empireTradePolicies: {},
+    interEmpireCargoLocks: [],
+    stationHub: null,
+    saveVersion: 6,
+    actionPoints: { current: 2, max: 2 },
+    turnBrief: [],
+    pendingChoiceEvents: [],
+    activeEventChains: [],
+    captains: [],
+    routeMarket: [],
+    researchEvents: [],
+    unlockedNavTabs: ["map", "routes", "fleet", "finance"],
+    reputationTier: "unknown",
+  };
+}
+
+describe("simulateAIRoutes — scope multiplier parity", () => {
+  it("applies the empire scope multiplier (1.1× for food)", () => {
+    const state = makeState();
+    const company = makeAI("p-a", "p-b", 100); // sys-1 → sys-2, both emp-1
+    const result = simulateAIRoutes(
+      company,
+      state,
+      state.market,
+      new SeededRNG(1),
+    );
+
+    // Expected: price × capacity × trips × scopeMult × (1 + distancePremium)
+    // ship speed 4, distance 100 → trips = floor(100 / 50) = 2
+    // food@empire = 1.1, distancePremium = min(0.5, 100*0.0015) = 0.15
+    const price = BASE_CARGO_PRICES[CargoType.Food];
+    const trips = 2;
+    const scopeMult = SCOPE_DEMAND_MULTIPLIERS[CargoType.Food].empire;
+    const distancePremium = 0.15;
+    const expected = price * 80 * trips * scopeMult * (1 + distancePremium);
+
+    expect(result.revenue).toBeCloseTo(expected, 0);
+  });
+
+  it("applies the galactic scope multiplier and rewards distance for luxury", () => {
+    const state = makeState();
+    // luxury cargo, p-a (emp-1) → p-c (emp-2), distance 200
+    const company: AICompany = {
+      ...makeAI("p-a", "p-c", 200),
+      activeRoutes: [
+        {
+          id: "route-ai",
+          originPlanetId: "p-a",
+          destinationPlanetId: "p-c",
+          distance: 200,
+          cargoType: CargoType.Luxury,
+          assignedShipIds: ["ai-ship-1"],
+        },
+      ],
+    };
+    const result = simulateAIRoutes(
+      company,
+      state,
+      state.market,
+      new SeededRNG(1),
+    );
+
+    const price = BASE_CARGO_PRICES[CargoType.Luxury];
+    // ship speed 4, distance 200 → trips = floor(100 / 100) = 1
+    const trips = 1;
+    const scopeMult = SCOPE_DEMAND_MULTIPLIERS[CargoType.Luxury].galactic;
+    const distancePremium = Math.min(0.5, 200 * 0.0015);
+    // tariff is applied separately in the AI step (separate from revenue)
+    const expectedRevenue =
+      price * 80 * trips * scopeMult * (1 + distancePremium);
+
+    // revenue is the *gross* before tariff — match the gross
+    expect(result.revenue).toBeCloseTo(expectedRevenue, 0);
+  });
+
+  it("does not apply distance premium at system scope", () => {
+    const state = makeState();
+    // Both planets in sys-1 — make a second p-a2 in sys-1 to construct a
+    // system-scope route.
+    const localPlanets: Planet[] = [
+      ...planets,
+      {
+        id: "p-a2",
+        name: "A2",
+        systemId: "sys-1",
+        type: PlanetType.Mining,
+        x: 5,
+        y: 5,
+        population: 100,
+      },
+    ];
+    const localMarkets: Record<string, PlanetMarket> = {};
+    for (const p of localPlanets) localMarkets[p.id] = makePlanetMarket();
+    const localState: GameState = {
+      ...state,
+      galaxy: { ...state.galaxy, planets: localPlanets },
+      market: { ...state.market, planetMarkets: localMarkets },
+    };
+
+    const company = makeAI("p-a", "p-a2", 25);
+    const result = simulateAIRoutes(
+      company,
+      localState,
+      localState.market,
+      new SeededRNG(1),
+    );
+
+    const price = BASE_CARGO_PRICES[CargoType.Food];
+    // dist 25, speed 4 → trips = floor(100 / 12.5) = 8
+    const trips = 8;
+    const scopeMult = SCOPE_DEMAND_MULTIPLIERS[CargoType.Food].system;
+    // System scope: NO distance premium
+    const expected = price * 80 * trips * scopeMult * 1.0;
+
+    expect(result.revenue).toBeCloseTo(expected, 0);
+  });
+});

--- a/src/game/ai/steps/aiRouteStep.ts
+++ b/src/game/ai/steps/aiRouteStep.ts
@@ -1,12 +1,20 @@
-import { CargoType } from "../../../data/types.ts";
+import { CargoType, RouteScope } from "../../../data/types.ts";
 import type {
   AICompany,
   GameState,
   MarketState,
   CargoType as CargoTypeT,
 } from "../../../data/types.ts";
-import { BREAKDOWN_THRESHOLD } from "../../../data/constants.ts";
-import { calculateTripsPerTurn } from "../../routes/RouteManager.ts";
+import {
+  BREAKDOWN_THRESHOLD,
+  DISTANCE_PREMIUM_RATE,
+  DISTANCE_PREMIUM_CAP,
+} from "../../../data/constants.ts";
+import {
+  calculateTripsPerTurn,
+  getRouteScope,
+  getScopeDemandMultiplier,
+} from "../../routes/RouteManager.ts";
 import { calculatePrice } from "../../economy/PriceCalculator.ts";
 import { calculateTariff } from "../../routes/TariffCalculator.ts";
 import type { SeededRNG } from "../../../utils/SeededRNG.ts";
@@ -77,7 +85,24 @@ export function simulateAIRoutes(
         : ship.cargoCapacity;
 
       const moved = capacity * trips;
-      let revenue = price * moved;
+
+      // Apply the same scope-based revenue curve the player uses, so AI and
+      // player operate on a single economy. Without this, AI silently kept
+      // earning `price × moved` while the player ate the scope multiplier —
+      // making AI ~2× stronger on system food and ~40% weaker on galactic
+      // luxury vs the player.
+      const scope = getRouteScope(route, state);
+      const scopeMult = getScopeDemandMultiplier(route.cargoType, scope);
+      const distancePremium =
+        scope === RouteScope.System
+          ? 0
+          : Math.min(
+              DISTANCE_PREMIUM_CAP,
+              route.distance * DISTANCE_PREMIUM_RATE,
+            );
+      const revenueMultiplier = scopeMult * (1 + distancePremium);
+
+      let revenue = price * moved * revenueMultiplier;
       let fuelCost =
         route.distance * 2 * ship.fuelEfficiency * market.fuelPrice * trips;
 

--- a/src/game/contracts/ContractGenerator.ts
+++ b/src/game/contracts/ContractGenerator.ts
@@ -180,6 +180,9 @@ function tryGenerateEmpireUnlock(
     rewardReputation: 5,
     rewardResearchPoints: 3,
     rewardTariffReduction: null,
+    // Empire-unlock contracts open a brand-new cross-empire trade lane —
+    // the slot bonus lands in the galactic pool, not the empire pool.
+    rewardSlotBonus: { scope: "galactic", amount: 1 },
     depositPaid: 0,
     status: ContractStatus.Available,
     linkedRouteId: null,
@@ -279,6 +282,8 @@ function makePassengerFerry(
     rewardReputation: 0,
     rewardResearchPoints: 2,
     rewardTariffReduction: null,
+    // Standing passenger lanes expand the empire-tier network capacity.
+    rewardSlotBonus: { scope: "empire", amount: 1 },
     depositPaid: Math.round(rewardCash * 0.15),
     status: ContractStatus.Available,
     linkedRouteId: null,
@@ -348,6 +353,9 @@ function makeTradeAlliance(
       empireB: destEmpireId,
       reduction: 0.5,
     },
+    // Trade-alliance contracts formalize a cross-empire lane; reward a
+    // permanent galactic slot on top of the tariff reduction.
+    rewardSlotBonus: { scope: "galactic", amount: 1 },
     depositPaid: 5000,
     status: ContractStatus.Available,
     linkedRouteId: null,

--- a/src/game/contracts/ContractManager.ts
+++ b/src/game/contracts/ContractManager.ts
@@ -1,9 +1,10 @@
 import type { GameState, Contract } from "../../data/types.ts";
-import { ContractType, ContractStatus } from "../../data/types.ts";
+import { ContractType, ContractStatus, RouteScope } from "../../data/types.ts";
 import {
   CONTRACT_FAILURE_REP_PENALTY,
   CONTRACT_UNASSIGNED_SHIP_LIMIT,
-  SLOT_PER_EMPIRE_UNLOCK,
+  BASE_GALACTIC_ROUTE_SLOTS,
+  BASE_SYSTEM_ROUTE_SLOTS,
 } from "../../data/constants.ts";
 import { createRoute } from "../routes/RouteManager.ts";
 import { calculateDistance } from "../routes/RouteManager.ts";
@@ -85,7 +86,13 @@ export function processContracts(state: GameState): Partial<GameState> {
   let cash = state.cash;
   let reputation = state.reputation;
   let researchPoints = state.tech.researchPoints;
+  // Each scope has its own pool — contract rewards land in whichever scope
+  // the rewardSlotBonus declares. Backfill defaults so older saves still
+  // accumulate correctly on completion.
+  let systemRouteSlots = state.localRouteSlots ?? BASE_SYSTEM_ROUTE_SLOTS;
   let routeSlots = state.routeSlots;
+  let galacticRouteSlots =
+    state.galacticRouteSlots ?? BASE_GALACTIC_ROUTE_SLOTS;
   let unlockedEmpireIds = [...state.unlockedEmpireIds];
   let activeRoutes = [...state.activeRoutes];
 
@@ -137,7 +144,20 @@ export function processContracts(state: GameState): Partial<GameState> {
         !unlockedEmpireIds.includes(c.targetEmpireId)
       ) {
         unlockedEmpireIds = [...unlockedEmpireIds, c.targetEmpireId];
-        routeSlots += SLOT_PER_EMPIRE_UNLOCK;
+      }
+
+      if (c.rewardSlotBonus) {
+        switch (c.rewardSlotBonus.scope) {
+          case RouteScope.System:
+            systemRouteSlots += c.rewardSlotBonus.amount;
+            break;
+          case RouteScope.Empire:
+            routeSlots += c.rewardSlotBonus.amount;
+            break;
+          case RouteScope.Galactic:
+            galacticRouteSlots += c.rewardSlotBonus.amount;
+            break;
+        }
       }
 
       updatedContracts[i] = {
@@ -156,6 +176,8 @@ export function processContracts(state: GameState): Partial<GameState> {
     cash,
     reputation,
     routeSlots,
+    localRouteSlots: systemRouteSlots,
+    galacticRouteSlots,
     unlockedEmpireIds,
     activeRoutes,
     tech: { ...state.tech, researchPoints },

--- a/src/game/contracts/__tests__/ContractManager.test.ts
+++ b/src/game/contracts/__tests__/ContractManager.test.ts
@@ -310,13 +310,15 @@ describe("Contract Lifecycle", () => {
       expect(result.contracts![0].status).toBe(ContractStatus.Failed);
     });
 
-    it("empire unlock contract adds empire and route slot on completion", () => {
+    it("empire unlock contract adds empire and a galactic slot on completion", () => {
       const contract = makeContract({
         type: ContractType.EmpireUnlock,
         targetEmpireId: "empire-2",
         status: ContractStatus.Active,
         linkedRouteId: "route-1",
         turnsRemaining: 1,
+        // Mirror what the generator now attaches to empire-unlock contracts.
+        rewardSlotBonus: { scope: "galactic", amount: 1 },
       });
       const route: ActiveRoute = {
         id: "route-1",
@@ -335,7 +337,95 @@ describe("Contract Lifecycle", () => {
 
       const result = processContracts(state);
       expect(result.unlockedEmpireIds).toContain("empire-2");
-      expect(result.routeSlots).toBe(5); // +1 for empire unlock
+      // Empire-unlock contracts now grow the galactic pool (was empire pool).
+      // Empire (routeSlots) should be unchanged; galactic should bump by 1.
+      expect(result.routeSlots).toBe(4);
+      expect(result.galacticRouteSlots).toBe(
+        (state.galacticRouteSlots ?? 3) + 1,
+      );
+    });
+
+    it("trade-alliance contract grants a galactic slot on completion", () => {
+      const contract = makeContract({
+        type: ContractType.TradeAlliance,
+        status: ContractStatus.Active,
+        linkedRouteId: "route-1",
+        turnsRemaining: 1,
+        rewardSlotBonus: { scope: "galactic", amount: 1 },
+      });
+      const route: ActiveRoute = {
+        id: "route-1",
+        originPlanetId: "planet-1",
+        destinationPlanetId: "planet-2",
+        distance: 10,
+        cargoType: CargoType.Food,
+        assignedShipIds: ["ship-1"],
+      };
+      const state = createTestState({
+        contracts: [contract],
+        activeRoutes: [route],
+        routeSlots: 4,
+      });
+
+      const result = processContracts(state);
+      expect(result.routeSlots).toBe(4);
+      expect(result.galacticRouteSlots).toBe(
+        (state.galacticRouteSlots ?? 3) + 1,
+      );
+    });
+
+    it("passenger-ferry contract grants an empire slot on completion", () => {
+      const contract = makeContract({
+        type: ContractType.PassengerFerry,
+        status: ContractStatus.Active,
+        linkedRouteId: "route-1",
+        turnsRemaining: 1,
+        rewardSlotBonus: { scope: "empire", amount: 1 },
+      });
+      const route: ActiveRoute = {
+        id: "route-1",
+        originPlanetId: "planet-1",
+        destinationPlanetId: "planet-2",
+        distance: 10,
+        cargoType: CargoType.Passengers,
+        assignedShipIds: ["ship-1"],
+      };
+      const state = createTestState({
+        contracts: [contract],
+        activeRoutes: [route],
+        routeSlots: 4,
+      });
+
+      const result = processContracts(state);
+      expect(result.routeSlots).toBe(5);
+    });
+
+    it("contracts without rewardSlotBonus leave all pools unchanged", () => {
+      const contract = makeContract({
+        type: ContractType.EmergencySupply,
+        status: ContractStatus.Active,
+        linkedRouteId: "route-1",
+        turnsRemaining: 1,
+        // No rewardSlotBonus set — emergency supply is one-shot.
+      });
+      const route: ActiveRoute = {
+        id: "route-1",
+        originPlanetId: "planet-1",
+        destinationPlanetId: "planet-2",
+        distance: 10,
+        cargoType: CargoType.Food,
+        assignedShipIds: ["ship-1"],
+      };
+      const state = createTestState({
+        contracts: [contract],
+        activeRoutes: [route],
+        routeSlots: 4,
+      });
+
+      const result = processContracts(state);
+      expect(result.routeSlots).toBe(4);
+      expect(result.galacticRouteSlots).toBe(state.galacticRouteSlots ?? 3);
+      expect(result.localRouteSlots).toBe(state.localRouteSlots ?? 2);
     });
   });
 });

--- a/src/game/empire/EmpireAccessManager.ts
+++ b/src/game/empire/EmpireAccessManager.ts
@@ -180,30 +180,45 @@ export function validateRouteCreation(
     return "Destination empire is not yet accessible";
   }
 
-  // Check route slot availability (local and main routes use separate pools)
-  const isLocal = originPlanet.systemId === destinationPlanet.systemId;
-  if (isLocal) {
-    const availableLocalSlots = state.localRouteSlots ?? 2;
-    const usedLocalSlots = state.activeRoutes.filter((r) => {
-      const rOrigin = planets.find((p) => p.id === r.originPlanetId);
-      const rDest = planets.find((p) => p.id === r.destinationPlanetId);
-      return rOrigin && rDest && rOrigin.systemId === rDest.systemId;
-    }).length;
-    if (availableLocalSlots - usedLocalSlots <= 0) {
-      return "No available local route slots";
+  // Each route consumes a slot from the pool that matches its scope.
+  // System (intra-system), empire (intra-empire interstellar), and galactic
+  // (inter-empire) each draw from a separate pool.
+  const isSystem = originPlanet.systemId === destinationPlanet.systemId;
+  const isGalactic = !isSystem && originEmpireId !== destEmpireId;
+
+  const systemRoutes = state.activeRoutes.filter((r) => {
+    const o = planets.find((p) => p.id === r.originPlanetId);
+    const d = planets.find((p) => p.id === r.destinationPlanetId);
+    return o && d && o.systemId === d.systemId;
+  });
+  const galacticRoutes = state.activeRoutes.filter((r) => {
+    const o = planets.find((p) => p.id === r.originPlanetId);
+    const d = planets.find((p) => p.id === r.destinationPlanetId);
+    if (!o || !d || o.systemId === d.systemId) return false;
+    const oSys = systems.find((s) => s.id === o.systemId);
+    const dSys = systems.find((s) => s.id === d.systemId);
+    return !!oSys && !!dSys && oSys.empireId !== dSys.empireId;
+  });
+  const empireRoutes =
+    state.activeRoutes.length - systemRoutes.length - galacticRoutes.length;
+
+  if (isSystem) {
+    const available = state.localRouteSlots ?? 2;
+    if (available - systemRoutes.length <= 0) {
+      return "No available system route slots";
+    }
+  } else if (isGalactic) {
+    const available = state.galacticRouteSlots ?? 2;
+    if (available - galacticRoutes.length <= 0) {
+      return "No available galactic route slots";
     }
   } else {
-    const availableSlots =
+    const available =
       state.routeSlots +
       getTechRouteSlotBonus(state) +
       getRouteSlotBonus(state.stationHub);
-    const usedSlots = state.activeRoutes.filter((r) => {
-      const rOrigin = planets.find((p) => p.id === r.originPlanetId);
-      const rDest = planets.find((p) => p.id === r.destinationPlanetId);
-      return !(rOrigin && rDest && rOrigin.systemId === rDest.systemId);
-    }).length;
-    if (availableSlots - usedSlots <= 0) {
-      return "No available route slots";
+    if (available - empireRoutes <= 0) {
+      return "No available empire route slots";
     }
   }
 

--- a/src/game/empire/__tests__/EmpireAccess.test.ts
+++ b/src/game/empire/__tests__/EmpireAccess.test.ts
@@ -362,8 +362,11 @@ describe("Empire Access", () => {
     });
 
     it("blocks route when no slots available", () => {
+      // planet-1 → planet-2 is cross-empire (empire-1 → empire-2), so the
+      // galactic-tier slot pool is the one that needs to be exhausted.
       const state = createTestState({
         routeSlots: 0,
+        galacticRouteSlots: 0,
         unlockedEmpireIds: ["empire-1", "empire-2"],
       });
       const result = validateRouteCreation(
@@ -372,7 +375,7 @@ describe("Empire Access", () => {
         "food",
         state,
       );
-      expect(result).toContain("No available route slots");
+      expect(result).toMatch(/No available .*route slots/);
     });
 
     it("requires different planets even for same-system routes", () => {

--- a/src/game/routes/RouteManager.ts
+++ b/src/game/routes/RouteManager.ts
@@ -1033,12 +1033,35 @@ export function scanAllRouteOpportunities(
     }
   }
 
-  // Sort by profit descending and limit to top 200 for performance
+  // Sort by profit descending. The Route Finder caps the displayed list at
+  // 200, but a flat profit-DESC truncation lets a single high-margin cargo
+  // (typically galactic luxury, often 100+ entries on a fresh standard
+  // galaxy) crowd every other cargo out of the top 200 — the player then
+  // sees zero raw-materials or hazmat options even though the underlying
+  // opportunities exist. We reserve a per-cargo quota first (top-K by
+  // profit per cargo type), then fill the remaining slots from the global
+  // profit-sorted tail.
   opportunities.sort((a, b) => b.estProfit - a.estProfit);
-  if (opportunities.length > 200) {
-    opportunities.length = 200;
+  const HARD_CAP = 200;
+  if (opportunities.length <= HARD_CAP) return opportunities;
+
+  const PER_CARGO_QUOTA = 12;
+  const reserved: RouteOpportunity[] = [];
+  const overflow: RouteOpportunity[] = [];
+  const quotaUsed = new Map<CargoType, number>();
+  for (const opp of opportunities) {
+    const used = quotaUsed.get(opp.bestCargoType) ?? 0;
+    if (used < PER_CARGO_QUOTA) {
+      reserved.push(opp);
+      quotaUsed.set(opp.bestCargoType, used + 1);
+    } else {
+      overflow.push(opp);
+    }
   }
-  return opportunities;
+  const remaining = HARD_CAP - reserved.length;
+  return remaining > 0
+    ? [...reserved, ...overflow.slice(0, remaining)]
+    : reserved.slice(0, HARD_CAP);
 }
 
 interface ShipCandidate {

--- a/src/game/routes/RouteManager.ts
+++ b/src/game/routes/RouteManager.ts
@@ -10,8 +10,12 @@ import type {
   InterEmpireCargoLock,
   Hyperlane,
   BorderPort,
+  RouteScope,
 } from "../../data/types.ts";
-import { CargoType as CargoTypeEnum } from "../../data/types.ts";
+import {
+  CargoType as CargoTypeEnum,
+  RouteScope as RouteScopeEnum,
+} from "../../data/types.ts";
 import {
   TURN_DURATION,
   MAX_TRIPS_PER_TURN,
@@ -19,9 +23,11 @@ import {
   BASE_LICENSE_FEE,
   LICENSE_FEE_DISTANCE_DIVISOR,
   LICENSE_FEE_ROUTE_ESCALATION,
-  INTRA_SYSTEM_REVENUE_MULTIPLIER,
   DISTANCE_PREMIUM_RATE,
   DISTANCE_PREMIUM_CAP,
+  SCOPE_DEMAND_MULTIPLIERS,
+  BASE_GALACTIC_ROUTE_SLOTS,
+  BASE_SYSTEM_ROUTE_SLOTS,
 } from "../../data/constants.ts";
 import { calculatePrice } from "../economy/PriceCalculator.ts";
 import { getLicenseFeeMultiplier } from "../reputation/ReputationEffects.ts";
@@ -122,27 +128,81 @@ export function calculateLicenseFee(
   return Math.round(BASE_LICENSE_FEE * distMult * routeMult * repMult);
 }
 
+// ── Route Scope Classification ─────────────────────────────────────────
+//
+// Each route falls into exactly one scope, which determines:
+//   1. Which slot pool it consumes (system / empire / galactic)
+//   2. Which per-cargo demand multiplier applies to its revenue
+//
+// Scope is derived from the planet → system → empire chain. Falling back to
+// "empire" when an empire id is missing keeps generated/test routes from
+// crashing the slot accounting; it is the safest "neutral" bucket.
+
+type RouteEndpoints = Pick<
+  ActiveRoute,
+  "originPlanetId" | "destinationPlanetId"
+>;
+
+export function getRouteScope(
+  route: RouteEndpoints,
+  state: Pick<GameState, "galaxy">,
+): RouteScope {
+  const { planets, systems } = state.galaxy;
+  const origin = planets.find((p) => p.id === route.originPlanetId);
+  const dest = planets.find((p) => p.id === route.destinationPlanetId);
+  if (!origin || !dest) return RouteScopeEnum.Empire;
+  if (origin.systemId === dest.systemId) return RouteScopeEnum.System;
+
+  const originSystem = systems.find((s) => s.id === origin.systemId);
+  const destSystem = systems.find((s) => s.id === dest.systemId);
+  if (!originSystem || !destSystem) return RouteScopeEnum.Empire;
+  if (originSystem.empireId !== destSystem.empireId) {
+    return RouteScopeEnum.Galactic;
+  }
+  return RouteScopeEnum.Empire;
+}
+
+/**
+ * Resolve the scope-based revenue multiplier for a (cargoType, scope) pair.
+ * Centralised so the simulator, route estimator, and opportunity scanner all
+ * stay in lock-step.
+ */
+export function getScopeDemandMultiplier(
+  cargoType: CargoType,
+  scope: RouteScope,
+): number {
+  return SCOPE_DEMAND_MULTIPLIERS[cargoType][scope];
+}
+
 // ── Local Route Helpers ────────────────────────────────────────────────
 
 /**
  * Returns true when origin and destination are in the same star system.
- * These routes use the separate localRouteSlots pool.
+ * These routes use the separate localRouteSlots (system) pool.
  */
 export function isLocalRoute(
-  route: { originPlanetId: string; destinationPlanetId: string },
+  route: RouteEndpoints,
   state: Pick<GameState, "galaxy">,
 ): boolean {
-  const planets = state.galaxy.planets;
-  const originPlanet = planets.find((p) => p.id === route.originPlanetId);
-  const destPlanet = planets.find((p) => p.id === route.destinationPlanetId);
-  if (!originPlanet || !destPlanet) return false;
-  return originPlanet.systemId === destPlanet.systemId;
+  return getRouteScope(route, state) === RouteScopeEnum.System;
+}
+
+/**
+ * Returns true when origin and destination empires differ. These routes use
+ * the galacticRouteSlots pool.
+ */
+export function isGalacticRoute(
+  route: RouteEndpoints,
+  state: Pick<GameState, "galaxy">,
+): boolean {
+  return getRouteScope(route, state) === RouteScopeEnum.Galactic;
 }
 
 // ── Route Slot Helpers ─────────────────────────────────────────────────
 
 /**
- * Total main route slots available (base + tech bonus).
+ * Empire-tier slots available (intra-empire interstellar).
+ * Backed by `state.routeSlots` plus tech and hub bonuses.
  */
 export function getAvailableRouteSlots(state: GameState): number {
   return (
@@ -152,42 +212,92 @@ export function getAvailableRouteSlots(state: GameState): number {
   );
 }
 
-/**
- * Total local route slots available.
- */
+/** Alias used by 3-tier UI — same value as `getAvailableRouteSlots`. */
+export function getAvailableEmpireRouteSlots(state: GameState): number {
+  return getAvailableRouteSlots(state);
+}
+
+/** System-tier slot pool. Falls back to default when missing on legacy saves. */
 export function getAvailableLocalRouteSlots(state: GameState): number {
-  return state.localRouteSlots ?? 2;
+  return state.localRouteSlots ?? BASE_SYSTEM_ROUTE_SLOTS;
 }
 
-/**
- * Number of main route slots currently in use (excludes local routes).
- */
+/** Alias used by 3-tier UI — same value as `getAvailableLocalRouteSlots`. */
+export function getAvailableSystemRouteSlots(state: GameState): number {
+  return getAvailableLocalRouteSlots(state);
+}
+
+/** Galactic-tier slot pool. Falls back to default when missing on legacy saves. */
+export function getAvailableGalacticRouteSlots(state: GameState): number {
+  return state.galacticRouteSlots ?? BASE_GALACTIC_ROUTE_SLOTS;
+}
+
+/** Empire-tier slots in use (intra-empire interstellar only). */
 export function getUsedRouteSlots(state: GameState): number {
-  return state.activeRoutes.filter((r) => !isLocalRoute(r, state)).length;
+  return state.activeRoutes.filter(
+    (r) => getRouteScope(r, state) === RouteScopeEnum.Empire,
+  ).length;
 }
 
-/**
- * Number of local route slots currently in use.
- */
+/** Alias used by 3-tier UI — same value as `getUsedRouteSlots`. */
+export function getUsedEmpireRouteSlots(state: GameState): number {
+  return getUsedRouteSlots(state);
+}
+
+/** System-tier slots in use. */
 export function getUsedLocalRouteSlots(state: GameState): number {
-  return state.activeRoutes.filter((r) => isLocalRoute(r, state)).length;
+  return state.activeRoutes.filter(
+    (r) => getRouteScope(r, state) === RouteScopeEnum.System,
+  ).length;
 }
 
-/**
- * Number of free main route slots remaining.
- */
+/** Alias used by 3-tier UI — same value as `getUsedLocalRouteSlots`. */
+export function getUsedSystemRouteSlots(state: GameState): number {
+  return getUsedLocalRouteSlots(state);
+}
+
+/** Galactic-tier slots in use. */
+export function getUsedGalacticRouteSlots(state: GameState): number {
+  return state.activeRoutes.filter(
+    (r) => getRouteScope(r, state) === RouteScopeEnum.Galactic,
+  ).length;
+}
+
+/** Free empire-tier slots remaining. */
 export function getFreeRouteSlots(state: GameState): number {
   return Math.max(0, getAvailableRouteSlots(state) - getUsedRouteSlots(state));
 }
 
-/**
- * Number of free local route slots remaining.
- */
+/** Free system-tier slots remaining. */
 export function getFreeLocalRouteSlots(state: GameState): number {
   return Math.max(
     0,
     getAvailableLocalRouteSlots(state) - getUsedLocalRouteSlots(state),
   );
+}
+
+/** Free galactic-tier slots remaining. */
+export function getFreeGalacticRouteSlots(state: GameState): number {
+  return Math.max(
+    0,
+    getAvailableGalacticRouteSlots(state) - getUsedGalacticRouteSlots(state),
+  );
+}
+
+/** Free slots for a given scope — convenience for validators and UI. */
+export function getFreeSlotsForScope(
+  state: GameState,
+  scope: RouteScope,
+): number {
+  switch (scope) {
+    case RouteScopeEnum.System:
+      return getFreeLocalRouteSlots(state);
+    case RouteScopeEnum.Galactic:
+      return getFreeGalacticRouteSlots(state);
+    case RouteScopeEnum.Empire:
+    default:
+      return getFreeRouteSlots(state);
+  }
 }
 
 export interface RouteTrafficVisual {
@@ -635,9 +745,15 @@ export function setRouteCargo(
 }
 
 /**
- * Estimate revenue for a route+ship for one turn.
- * Matches the TurnSimulator formula: applies calculatePrice, distancePremium,
- * and INTRA_SYSTEM_REVENUE_MULTIPLIER so the displayed estimate is accurate.
+ * Estimate revenue for a route+ship for one turn. Mirrors the TurnSimulator
+ * formula so the displayed estimate matches actual simulation:
+ *
+ *   revenue = price × capacity × trips × scopeDemand × distancePremium
+ *
+ * For system-scope routes, only the per-cargo scope multiplier applies (no
+ * distance premium — there isn't enough distance to matter). For empire and
+ * galactic routes, the scope multiplier stacks with the standard distance
+ * premium.
  */
 export function estimateRouteRevenue(
   route: ActiveRoute,
@@ -663,28 +779,37 @@ export function estimateRouteRevenue(
 
   const totalCargoMoved = capacity * trips;
 
-  // Determine intra-system status: extract system from planet ID "planet-{si}-{syi}-{pi}"
-  const originParts = route.originPlanetId.split("-");
-  const destParts = route.destinationPlanetId.split("-");
-  const isIntraSystem =
-    state != null
-      ? isLocalRoute(route, state)
-      : originParts.length >= 4 &&
-        destParts.length >= 4 &&
-        originParts[0] === "planet" &&
-        destParts[0] === "planet" &&
-        `${originParts[1]}-${originParts[2]}` ===
-          `${destParts[1]}-${destParts[2]}`;
+  const scope =
+    state != null ? getRouteScope(route, state) : inferScopeFromIds(route);
+  const scopeMult = getScopeDemandMultiplier(route.cargoType, scope);
 
-  const distancePremium = Math.min(
-    DISTANCE_PREMIUM_CAP,
-    route.distance * DISTANCE_PREMIUM_RATE,
-  );
-  const revenueMultiplier = isIntraSystem
-    ? INTRA_SYSTEM_REVENUE_MULTIPLIER
-    : 1 + distancePremium;
+  const distancePremium =
+    scope === RouteScopeEnum.System
+      ? 0
+      : Math.min(DISTANCE_PREMIUM_CAP, route.distance * DISTANCE_PREMIUM_RATE);
+  const revenueMultiplier = scopeMult * (1 + distancePremium);
 
   return Math.round(totalCargoMoved * price * revenueMultiplier * 100) / 100;
+}
+
+/**
+ * Best-effort scope inference from planet ID structure when no state is
+ * available (legacy callers). Recognizes "planet-{si}-{syi}-{pi}" → system id.
+ * Cannot tell empire from system, so returns Empire for cross-system routes
+ * (the default neutral bucket).
+ */
+function inferScopeFromIds(
+  route: Pick<ActiveRoute, "originPlanetId" | "destinationPlanetId">,
+): RouteScope {
+  const originParts = route.originPlanetId.split("-");
+  const destParts = route.destinationPlanetId.split("-");
+  const sameSystem =
+    originParts.length >= 4 &&
+    destParts.length >= 4 &&
+    originParts[0] === "planet" &&
+    destParts[0] === "planet" &&
+    `${originParts[1]}-${originParts[2]}` === `${destParts[1]}-${destParts[2]}`;
+  return sameSystem ? RouteScopeEnum.System : RouteScopeEnum.Empire;
 }
 
 /**
@@ -723,6 +848,28 @@ export interface RouteOpportunity {
   shipCost: number;
   licenseFee: number;
   alreadyActive: boolean;
+  /** Route scope (system / empire / galactic) — drives slot pool + demand multiplier. */
+  scope: RouteScope;
+  /** Per-cargo scope demand multiplier applied to revenue. Surfaced for UI tooltips. */
+  scopeDemandMultiplier: number;
+}
+
+/**
+ * Classify a (origin, dest) pair given galaxy data. Used by the opportunity
+ * scanner where we have raw planet/system arrays in scope.
+ */
+function classifyScope(
+  origin: Planet,
+  dest: Planet,
+  systems: StarSystem[],
+): RouteScope {
+  if (origin.systemId === dest.systemId) return RouteScopeEnum.System;
+  const oSys = systems.find((s) => s.id === origin.systemId);
+  const dSys = systems.find((s) => s.id === dest.systemId);
+  if (!oSys || !dSys) return RouteScopeEnum.Empire;
+  return oSys.empireId !== dSys.empireId
+    ? RouteScopeEnum.Galactic
+    : RouteScopeEnum.Empire;
 }
 
 /**
@@ -833,14 +980,13 @@ export function scanAllRouteOpportunities(
 
         const destEntry = destMarket[cargoType];
         const price = calculatePrice(destEntry, cargoType);
-        const isIntraSystem = origin.systemId === dest.systemId;
-        const distancePremium = Math.min(
-          DISTANCE_PREMIUM_CAP,
-          distance * DISTANCE_PREMIUM_RATE,
-        );
-        const revenueMultiplier = isIntraSystem
-          ? INTRA_SYSTEM_REVENUE_MULTIPLIER
-          : 1 + distancePremium;
+        const scope = classifyScope(origin, dest, systems);
+        const scopeMult = getScopeDemandMultiplier(cargoType, scope);
+        const distancePremium =
+          scope === RouteScopeEnum.System
+            ? 0
+            : Math.min(DISTANCE_PREMIUM_CAP, distance * DISTANCE_PREMIUM_RATE);
+        const revenueMultiplier = scopeMult * (1 + distancePremium);
 
         // Pick the *most profitable* ship the player can field on this
         // specific route (owned, or affordable to buy). Trying only the
@@ -880,6 +1026,8 @@ export function scanAllRouteOpportunities(
             best.candidate.source === "owned" ? 0 : best.candidate.purchaseCost,
           licenseFee,
           alreadyActive,
+          scope,
+          scopeDemandMultiplier: scopeMult,
         });
       }
     }

--- a/src/game/routes/RouteMarket.ts
+++ b/src/game/routes/RouteMarket.ts
@@ -28,6 +28,7 @@ import {
   calculateTripsPerTurn,
   getScopeDemandMultiplier,
 } from "./RouteManager.ts";
+import { calculateTariff } from "./TariffCalculator.ts";
 import {
   getEmpireForPlanet,
   isEmpireAccessible,
@@ -122,7 +123,31 @@ function estimateExactProfit(
   const revenue = trips * representativeCapacity * price * revenueMultiplier;
   const fuelCost = trips * fuelPerTrip;
 
-  return Math.max(0, Math.round((revenue - fuelCost) * 100) / 100);
+  // Galactic-scope routes pay tariff to the destination empire — apply it
+  // here so the scouted "exact profit" actually matches what the player
+  // earns. Without this, scouted galactic profits over-state by 10–20%.
+  let tariff = 0;
+  if (scope === RouteScopeEnum.Galactic) {
+    const synthRoute = {
+      id: "estimator",
+      originPlanetId: origin.id,
+      destinationPlanetId: dest.id,
+      distance,
+      assignedShipIds: [],
+      cargoType,
+    };
+    tariff = calculateTariff(
+      synthRoute,
+      revenue,
+      "", // no owner empire — estimator treats the player as a generic carrier
+      state.galaxy.systems,
+      state.galaxy.empires,
+      state.reputation,
+      state.diplomaticRelations,
+    );
+  }
+
+  return Math.max(0, Math.round((revenue - fuelCost - tariff) * 100) / 100);
 }
 
 /**

--- a/src/game/routes/RouteMarket.ts
+++ b/src/game/routes/RouteMarket.ts
@@ -5,20 +5,29 @@ import type {
   CargoType,
   Planet,
   StarSystem,
+  RouteScope,
 } from "../../data/types.ts";
 import {
   CargoType as CargoTypeEnum,
   DiplomaticStatus,
+  RouteScope as RouteScopeEnum,
 } from "../../data/types.ts";
 import {
   ROUTE_MARKET_SIZE,
   ROUTE_MARKET_ENTRY_DURATION,
   SCOUT_COST_AP,
   SCOUT_COST_CASH,
+  ROUTE_MARKET_SCOPE_QUOTA,
+  DISTANCE_PREMIUM_RATE,
+  DISTANCE_PREMIUM_CAP,
 } from "../../data/constants.ts";
 import type { SeededRNG } from "../../utils/SeededRNG.ts";
 import { calculatePrice } from "../economy/PriceCalculator.ts";
-import { calculateDistance, calculateTripsPerTurn } from "./RouteManager.ts";
+import {
+  calculateDistance,
+  calculateTripsPerTurn,
+  getScopeDemandMultiplier,
+} from "./RouteManager.ts";
 import {
   getEmpireForPlanet,
   isEmpireAccessible,
@@ -56,10 +65,26 @@ function routeDistance(origin: Planet, dest: Planet, state: GameState): number {
 }
 
 /**
- * Estimate profit-per-turn for a route.
- * Uses: trips × capacity (avg cargo shuttle 80) × (destPrice - originPrice)
- * This mirrors the logic used in the route opportunity scanner but simplified
- * to a representative ship (avg cargoCapacity 80, speed 4).
+ * Classify a candidate (origin → dest) pair into a RouteScope.
+ */
+function classifyPairScope(
+  origin: Planet,
+  dest: Planet,
+  systems: StarSystem[],
+): RouteScope {
+  if (origin.systemId === dest.systemId) return RouteScopeEnum.System;
+  const oSys = systems.find((s) => s.id === origin.systemId);
+  const dSys = systems.find((s) => s.id === dest.systemId);
+  if (!oSys || !dSys) return RouteScopeEnum.Empire;
+  return oSys.empireId !== dSys.empireId
+    ? RouteScopeEnum.Galactic
+    : RouteScopeEnum.Empire;
+}
+
+/**
+ * Estimate profit-per-turn for a route. Mirrors the simulator's revenue
+ * formula (price × capacity × trips × scopeMult × distance premium) so
+ * scouted profits match what the player will actually earn.
  */
 function estimateExactProfit(
   origin: Planet,
@@ -85,8 +110,16 @@ function estimateExactProfit(
   const representativeSpeed = 4;
   const trips = calculateTripsPerTurn(distance, representativeSpeed);
 
+  const scope = classifyPairScope(origin, dest, state.galaxy.systems);
+  const scopeMult = getScopeDemandMultiplier(cargoType, scope);
+  const distancePremium =
+    scope === RouteScopeEnum.System
+      ? 0
+      : Math.min(DISTANCE_PREMIUM_CAP, distance * DISTANCE_PREMIUM_RATE);
+  const revenueMultiplier = scopeMult * (1 + distancePremium);
+
   const fuelPerTrip = distance * 2 * 0.8 * state.market.fuelPrice;
-  const revenue = trips * representativeCapacity * price;
+  const revenue = trips * representativeCapacity * price * revenueMultiplier;
   const fuelCost = trips * fuelPerTrip;
 
   return Math.max(0, Math.round((revenue - fuelCost) * 100) / 100);
@@ -191,10 +224,66 @@ function computeRiskTags(
 // Public API
 // ---------------------------------------------------------------------------
 
+interface CandidatePair {
+  origin: Planet;
+  dest: Planet;
+  scope: RouteScope;
+}
+
+/**
+ * Pick a cargo type for a candidate pair, weighting by the per-cargo demand
+ * multiplier for the pair's scope. Heavy goods cluster on system/empire
+ * routes; luxury and tech cluster on galactic. Embargoed cargo is excluded.
+ */
+function pickCargoForPair(
+  origin: Planet,
+  dest: Planet,
+  scope: RouteScope,
+  systems: StarSystem[],
+  planets: Planet[],
+  state: GameState,
+  rng: SeededRNG,
+): CargoType | null {
+  const originEmpireId = getEmpireForPlanet(origin.id, systems, planets);
+  const destEmpireId = getEmpireForPlanet(dest.id, systems, planets);
+
+  const allowed: Array<{ cargo: CargoType; weight: number }> = [];
+  for (const cargo of ALL_CARGO_TYPES) {
+    if (originEmpireId && destEmpireId && originEmpireId !== destEmpireId) {
+      const violation = checkTradePolicyViolation(
+        originEmpireId,
+        destEmpireId,
+        cargo,
+        state.empireTradePolicies,
+      );
+      if (violation) continue;
+    }
+    // Square the multiplier so the bias toward "scope-appropriate" cargo is
+    // visible without becoming deterministic — luxury still occasionally
+    // shows up on a system route, but rarely.
+    const mult = getScopeDemandMultiplier(cargo, scope);
+    const weight = Math.max(0.01, mult * mult);
+    allowed.push({ cargo, weight });
+  }
+  if (allowed.length === 0) return null;
+
+  const totalWeight = allowed.reduce((sum, e) => sum + e.weight, 0);
+  let target = rng.nextFloat(0, totalWeight);
+  for (const entry of allowed) {
+    target -= entry.weight;
+    if (target <= 0) return entry.cargo;
+  }
+  return allowed[allowed.length - 1].cargo;
+}
+
 /**
  * Generate a fresh batch of route market entries for the current turn.
- * Only considers O→D pairs where both empires are unlocked by the player.
- * Sets exactProfitPerTurn = null and scouted = false (hidden until scouted).
+ *
+ * The market is partitioned into three scope buckets (system / empire /
+ * galactic) using ROUTE_MARKET_SCOPE_QUOTA. Each bucket tries to hit its
+ * quota first; any leftover slack is filled from the remaining candidate
+ * pool so the player never sees an empty market because one tier had no
+ * candidates.
  */
 export function generateRouteMarketEntries(
   state: GameState,
@@ -204,8 +293,16 @@ export function generateRouteMarketEntries(
   const hyperlanes = state.hyperlanes ?? [];
   const marketSize = getMarketSize(state);
 
-  // Build candidate planet pairs filtered by empire access and hyperlane reachability
-  const candidatePairs: Array<{ origin: Planet; dest: Planet }> = [];
+  // Build candidate pairs grouped by scope. Same-system pairs ARE eligible
+  // now (system tier) — previously they were skipped entirely, which is part
+  // of why players saw "only a couple non-system routes": there were too few
+  // candidate pairs to fill the empire/galactic buckets in early-game maps
+  // with restricted empire access.
+  const bucketedCandidates: Record<RouteScope, CandidatePair[]> = {
+    [RouteScopeEnum.System]: [],
+    [RouteScopeEnum.Empire]: [],
+    [RouteScopeEnum.Galactic]: [],
+  };
 
   for (const origin of planets) {
     const originEmpireId = getEmpireForPlanet(origin.id, systems, planets);
@@ -217,96 +314,163 @@ export function generateRouteMarketEntries(
       const destEmpireId = getEmpireForPlanet(dest.id, systems, planets);
       if (!destEmpireId || !isEmpireAccessible(destEmpireId, state)) continue;
 
-      // Skip same-system intra-system pairs (too short for the market)
-      if (origin.systemId === dest.systemId) continue;
-
-      // If hyperlanes exist, require a valid path
-      if (hyperlanes.length > 0) {
+      // If hyperlanes exist, require a valid path between different systems
+      if (hyperlanes.length > 0 && origin.systemId !== dest.systemId) {
         const dist = routeDistance(origin, dest, state);
         if (dist <= 0 || dist === -1) continue;
       }
 
-      candidatePairs.push({ origin, dest });
+      const scope = classifyPairScope(origin, dest, systems);
+      bucketedCandidates[scope].push({ origin, dest, scope });
     }
   }
 
-  if (candidatePairs.length === 0) {
-    return [];
-  }
+  const totalCandidates =
+    bucketedCandidates.system.length +
+    bucketedCandidates.empire.length +
+    bucketedCandidates.galactic.length;
+  if (totalCandidates === 0) return [];
+
+  // Compute per-scope target counts. If a scope has no candidates, its quota
+  // is reassigned proportionally to the remaining scopes.
+  const targets = computeScopeTargets(marketSize, bucketedCandidates);
 
   const entries: RouteMarketEntry[] = [];
   const usedIds = new Set<string>();
 
-  // Try up to marketSize * 5 attempts to fill the market
-  const maxAttempts = marketSize * 5;
-  let attempts = 0;
+  const fillFromBucket = (
+    bucket: CandidatePair[],
+    target: number,
+    maxAttemptsPerEntry: number,
+  ): number => {
+    let added = 0;
+    let attempts = 0;
+    const maxAttempts = target * maxAttemptsPerEntry;
+    while (added < target && attempts < maxAttempts && bucket.length > 0) {
+      attempts++;
+      const pair = rng.pick(bucket);
+      const cargo = pickCargoForPair(
+        pair.origin,
+        pair.dest,
+        pair.scope,
+        systems,
+        planets,
+        state,
+        rng,
+      );
+      if (!cargo) continue;
 
-  while (entries.length < marketSize && attempts < maxAttempts) {
-    attempts++;
+      const pairKey = `${pair.origin.id}→${pair.dest.id}→${cargo}`;
+      if (usedIds.has(pairKey)) continue;
 
-    // Pick a random O→D pair
-    const pair = rng.pick(candidatePairs);
-    const { origin, dest } = pair;
+      const exactProfit = estimateExactProfit(
+        pair.origin,
+        pair.dest,
+        cargo,
+        state,
+      );
+      if (exactProfit <= 0) continue;
 
-    // Pick a random cargo type that is not embargoed
-    const shuffledCargo = [...ALL_CARGO_TYPES];
-    rng.shuffle(shuffledCargo);
+      usedIds.add(pairKey);
 
-    let selectedCargo: CargoType | null = null;
-    for (const cargoType of shuffledCargo) {
-      const originEmpireId = getEmpireForPlanet(origin.id, systems, planets);
-      const destEmpireId = getEmpireForPlanet(dest.id, systems, planets);
+      const estimatedProfitMin = Math.round(exactProfit * 0.7);
+      const estimatedProfitMax = Math.round(exactProfit * 1.3);
+      const riskTags = computeRiskTags(pair.origin, pair.dest, cargo, state);
 
-      if (originEmpireId && destEmpireId && originEmpireId !== destEmpireId) {
-        const violation = checkTradePolicyViolation(
-          originEmpireId,
-          destEmpireId,
-          cargoType,
-          state.empireTradePolicies,
-        );
-        if (violation) continue;
-      }
-
-      selectedCargo = cargoType;
-      break;
+      entries.push({
+        id: `rm-${state.turn}-${entries.length}-${rng.nextInt(0, 999999)}`,
+        originPlanetId: pair.origin.id,
+        destinationPlanetId: pair.dest.id,
+        cargoType: cargo,
+        estimatedProfitMin,
+        estimatedProfitMax,
+        exactProfitPerTurn: null,
+        riskTags,
+        scouted: false,
+        expiresOnTurn: state.turn + ROUTE_MARKET_ENTRY_DURATION,
+        claimedByAiId: null,
+      });
+      added++;
     }
+    return added;
+  };
 
-    if (!selectedCargo) continue;
+  const scopeOrder: RouteScope[] = [
+    RouteScopeEnum.System,
+    RouteScopeEnum.Empire,
+    RouteScopeEnum.Galactic,
+  ];
 
-    // Avoid exact duplicates within a single generation batch
-    const pairKey = `${origin.id}→${dest.id}→${selectedCargo}`;
-    if (usedIds.has(pairKey)) continue;
-    usedIds.add(pairKey);
+  // First pass — fill each bucket toward its quota.
+  for (const scope of scopeOrder) {
+    fillFromBucket(bucketedCandidates[scope], targets[scope], 6);
+  }
 
-    // Compute the hidden exact profit
-    const exactProfit = estimateExactProfit(origin, dest, selectedCargo, state);
-    if (exactProfit <= 0) continue;
-
-    // Estimated range is ±30% of the real value (hidden noise)
-    const estimatedProfitMin = Math.round(exactProfit * 0.7);
-    const estimatedProfitMax = Math.round(exactProfit * 1.3);
-
-    // Risk tags
-    const riskTags = computeRiskTags(origin, dest, selectedCargo, state);
-
-    const id = `rm-${state.turn}-${entries.length}-${rng.nextInt(0, 999999)}`;
-
-    entries.push({
-      id,
-      originPlanetId: origin.id,
-      destinationPlanetId: dest.id,
-      cargoType: selectedCargo,
-      estimatedProfitMin,
-      estimatedProfitMax,
-      exactProfitPerTurn: null, // hidden until scouted
-      riskTags,
-      scouted: false,
-      expiresOnTurn: state.turn + ROUTE_MARKET_ENTRY_DURATION,
-      claimedByAiId: null,
-    });
+  // Second pass — top up any unmet quota from any bucket that still has room.
+  // Order by largest remaining first so quotas converge.
+  let deficit = marketSize - entries.length;
+  if (deficit > 0) {
+    const allCandidates = [
+      ...bucketedCandidates.system,
+      ...bucketedCandidates.empire,
+      ...bucketedCandidates.galactic,
+    ];
+    fillFromBucket(allCandidates, deficit, 6);
   }
 
   return entries;
+}
+
+/**
+ * Allocate `marketSize` entries across the three scopes using
+ * ROUTE_MARKET_SCOPE_QUOTA. Scopes with zero candidates have their quota
+ * redistributed proportionally to scopes that DO have candidates so the
+ * market does not under-fill when one tier is unavailable.
+ */
+function computeScopeTargets(
+  marketSize: number,
+  bucketed: Record<RouteScope, CandidatePair[]>,
+): Record<RouteScope, number> {
+  const scopes: RouteScope[] = [
+    RouteScopeEnum.System,
+    RouteScopeEnum.Empire,
+    RouteScopeEnum.Galactic,
+  ];
+
+  let activeWeight = 0;
+  for (const scope of scopes) {
+    if (bucketed[scope].length > 0) {
+      activeWeight += ROUTE_MARKET_SCOPE_QUOTA[scope];
+    }
+  }
+
+  const targets: Record<RouteScope, number> = {
+    [RouteScopeEnum.System]: 0,
+    [RouteScopeEnum.Empire]: 0,
+    [RouteScopeEnum.Galactic]: 0,
+  };
+  if (activeWeight === 0) return targets;
+
+  let assigned = 0;
+  for (const scope of scopes) {
+    if (bucketed[scope].length === 0) continue;
+    const share = ROUTE_MARKET_SCOPE_QUOTA[scope] / activeWeight;
+    const target = Math.floor(marketSize * share);
+    targets[scope] = target;
+    assigned += target;
+  }
+
+  // Distribute rounding remainder to scopes with the largest weight first.
+  let remainder = marketSize - assigned;
+  const ordered = [...scopes]
+    .filter((s) => bucketed[s].length > 0)
+    .sort((a, b) => ROUTE_MARKET_SCOPE_QUOTA[b] - ROUTE_MARKET_SCOPE_QUOTA[a]);
+  for (const scope of ordered) {
+    if (remainder <= 0) break;
+    targets[scope]++;
+    remainder--;
+  }
+  return targets;
 }
 
 /**

--- a/src/game/routes/__tests__/LocalLanes.test.ts
+++ b/src/game/routes/__tests__/LocalLanes.test.ts
@@ -250,19 +250,19 @@ describe("Local route slot management", () => {
   });
 });
 
-// ── LOCAL_ROUTE_REVENUE_CAP constant ─────────────────────────────────────────
+// ── Legacy revenue-cap constants (deprecated, kept for back-compat) ──────────
+//
+// The flat 50% intra-system cap has been replaced by per-cargo
+// SCOPE_DEMAND_MULTIPLIERS — see data/constants.ts. The constants below are
+// only re-exported so older fixtures still compile; they're no longer read by
+// revenue calculations.
 
-describe("LOCAL_ROUTE_REVENUE_CAP", () => {
-  it("is set to 0.5 (50% cap)", () => {
+describe("legacy LOCAL_ROUTE_REVENUE_CAP shim", () => {
+  it("still exports 0.5 for back-compat", () => {
     expect(LOCAL_ROUTE_REVENUE_CAP).toBe(0.5);
   });
 
-  it("matches INTRA_SYSTEM_REVENUE_MULTIPLIER", () => {
-    // After the fix, INTRA_SYSTEM_REVENUE_MULTIPLIER should equal the cap (0.5, not 0.25)
+  it("INTRA_SYSTEM_REVENUE_MULTIPLIER matches the legacy cap", () => {
     expect(INTRA_SYSTEM_REVENUE_MULTIPLIER).toBe(LOCAL_ROUTE_REVENUE_CAP);
-  });
-
-  it("INTRA_SYSTEM_REVENUE_MULTIPLIER is 0.5 (not the old 0.25)", () => {
-    expect(INTRA_SYSTEM_REVENUE_MULTIPLIER).toBe(0.5);
   });
 });

--- a/src/game/routes/__tests__/RouteMarket.test.ts
+++ b/src/game/routes/__tests__/RouteMarket.test.ts
@@ -454,6 +454,167 @@ describe("scoutRoute (RouteScout)", () => {
   });
 });
 
+describe("scope-aware market generation", () => {
+  // A galaxy with two systems in emp-1 and one system in emp-2 lets the
+  // generator pull from all three scope buckets.
+  const richSystems: StarSystem[] = [
+    {
+      id: "sys-1",
+      name: "Alpha",
+      sectorId: "sec-1",
+      empireId: "emp-1",
+      x: 0,
+      y: 0,
+      starColor: 0xffcc00,
+    },
+    {
+      id: "sys-2",
+      name: "Beta",
+      sectorId: "sec-1",
+      empireId: "emp-1",
+      x: 100,
+      y: 0,
+      starColor: 0xffcc00,
+    },
+    {
+      id: "sys-3",
+      name: "Gamma",
+      sectorId: "sec-1",
+      empireId: "emp-2",
+      x: 200,
+      y: 0,
+      starColor: 0xffcc00,
+    },
+  ];
+
+  function richPlanets(): Planet[] {
+    return [
+      {
+        id: "planet-a1",
+        name: "A1",
+        systemId: "sys-1",
+        type: PlanetType.Terran,
+        x: 0,
+        y: 0,
+        population: 100,
+      },
+      {
+        id: "planet-a2",
+        name: "A2",
+        systemId: "sys-1",
+        type: PlanetType.Industrial,
+        x: 5,
+        y: 5,
+        population: 100,
+      },
+      {
+        id: "planet-b",
+        name: "B",
+        systemId: "sys-2",
+        type: PlanetType.Mining,
+        x: 100,
+        y: 0,
+        population: 100,
+      },
+      {
+        id: "planet-c",
+        name: "C",
+        systemId: "sys-3",
+        type: PlanetType.Agricultural,
+        x: 200,
+        y: 0,
+        population: 100,
+      },
+    ];
+  }
+
+  function richState(): GameState {
+    const planets = richPlanets();
+    const planetMarkets: Record<string, PlanetMarket> = {};
+    for (const p of planets) planetMarkets[p.id] = makePlanetMarket();
+    return makeGameState({
+      galaxy: {
+        sectors: [makeSector()],
+        empires: [
+          {
+            id: "emp-1",
+            name: "One",
+            color: 0x0000ff,
+            tariffRate: 0.1,
+            disposition: "neutral",
+            homeSystemId: "sys-1",
+            leaderName: "L1",
+            leaderPortrait: { portraitId: "p-01", category: "human" },
+          },
+          {
+            id: "emp-2",
+            name: "Two",
+            color: 0xff0000,
+            tariffRate: 0.1,
+            disposition: "neutral",
+            homeSystemId: "sys-3",
+            leaderName: "L2",
+            leaderPortrait: { portraitId: "p-02", category: "human" },
+          },
+        ],
+        systems: richSystems,
+        planets,
+      },
+      market: {
+        fuelPrice: BASE_FUEL_PRICE,
+        fuelTrend: "stable",
+        planetMarkets,
+      },
+      unlockedEmpireIds: ["emp-1", "emp-2"],
+    });
+  }
+
+  function classify(
+    entry: RouteMarketEntry,
+    state: GameState,
+  ): "system" | "empire" | "galactic" {
+    const o = state.galaxy.planets.find((p) => p.id === entry.originPlanetId)!;
+    const d = state.galaxy.planets.find(
+      (p) => p.id === entry.destinationPlanetId,
+    )!;
+    if (o.systemId === d.systemId) return "system";
+    const oSys = state.galaxy.systems.find((s) => s.id === o.systemId)!;
+    const dSys = state.galaxy.systems.find((s) => s.id === d.systemId)!;
+    return oSys.empireId !== dSys.empireId ? "galactic" : "empire";
+  }
+
+  it("produces entries spanning all three scopes when candidates exist", () => {
+    const state = richState();
+    // Try several seeds — quotas are stochastic per seed, but at least one
+    // run should hit all three scopes within a small batch.
+    const scopesSeen = new Set<string>();
+    for (let seed = 1; seed <= 10; seed++) {
+      const rng = new SeededRNG(seed);
+      const entries = generateRouteMarketEntries(state, rng);
+      for (const e of entries) scopesSeen.add(classify(e, state));
+      if (scopesSeen.size === 3) break;
+    }
+    expect(scopesSeen.has("system")).toBe(true);
+    expect(scopesSeen.has("empire")).toBe(true);
+    expect(scopesSeen.has("galactic")).toBe(true);
+  });
+
+  it("still fills the market when only one scope has candidates", () => {
+    // Restrict to a single empire so galactic candidates vanish; the generator
+    // should redistribute the galactic quota to the remaining scopes.
+    const state = makeGameState({
+      unlockedEmpireIds: ["emp-1"],
+    });
+    const rng = new SeededRNG(7);
+    const entries = generateRouteMarketEntries(state, rng);
+    // Two-planet emp-1 fixture has only an empire-tier candidate, so the
+    // result is non-empty but never galactic.
+    for (const e of entries) {
+      expect(e.cargoType).toBeDefined();
+    }
+  });
+});
+
 describe("aiClaimRouteEntry", () => {
   it("removes the entry from the market after AI claims it", () => {
     const entry = makeRouteMarketEntry({

--- a/src/game/routes/__tests__/RouteScope.test.ts
+++ b/src/game/routes/__tests__/RouteScope.test.ts
@@ -328,4 +328,45 @@ describe("Scope demand multipliers", () => {
       }
     }
   });
+
+  // ── Balance regression guards ──────────────────────────────────────
+  //
+  // These thresholds were derived from the post-rebalance simulation that
+  // accompanied PR #69's balance audit. They protect against accidentally
+  // re-buffing local routes (the original "local routes too profitable"
+  // complaint) when tuning future cargo curves.
+
+  it("average system multiplier stays well below the old 0.5 flat cap", () => {
+    const all = Object.values(CargoType);
+    const sum = all.reduce(
+      (acc, c) => acc + SCOPE_DEMAND_MULTIPLIERS[c][RouteScope.System],
+      0,
+    );
+    const avg = sum / all.length;
+    // Old model used a flat 0.5 across all cargo at intra-system.
+    // The new curve must be a meaningful nerf, not a buff or wash.
+    expect(avg).toBeLessThan(0.45);
+  });
+
+  it("luxury and technology favor galactic over system by a wide margin", () => {
+    for (const c of [CargoType.Luxury, CargoType.Technology] as const) {
+      const sys = SCOPE_DEMAND_MULTIPLIERS[c][RouteScope.System];
+      const gal = SCOPE_DEMAND_MULTIPLIERS[c][RouteScope.Galactic];
+      // Galactic should be at least 5× system for "scarcity-priced" cargo —
+      // the headline mechanic that distinguishes the new model.
+      expect(gal / sys).toBeGreaterThanOrEqual(5);
+    }
+  });
+
+  it("heavy goods (raw, food, hazmat) all peak at empire scope", () => {
+    for (const c of [
+      CargoType.RawMaterials,
+      CargoType.Food,
+      CargoType.Hazmat,
+    ] as const) {
+      const m = SCOPE_DEMAND_MULTIPLIERS[c];
+      expect(m[RouteScope.Empire]).toBeGreaterThan(m[RouteScope.System]);
+      expect(m[RouteScope.Empire]).toBeGreaterThan(m[RouteScope.Galactic]);
+    }
+  });
 });

--- a/src/game/routes/__tests__/RouteScope.test.ts
+++ b/src/game/routes/__tests__/RouteScope.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect } from "vitest";
+import {
+  getRouteScope,
+  getScopeDemandMultiplier,
+  getAvailableSystemRouteSlots,
+  getAvailableEmpireRouteSlots,
+  getAvailableGalacticRouteSlots,
+  getUsedSystemRouteSlots,
+  getUsedEmpireRouteSlots,
+  getUsedGalacticRouteSlots,
+  getFreeSlotsForScope,
+  isLocalRoute,
+  isGalacticRoute,
+} from "../RouteManager.ts";
+import type {
+  GameState,
+  ActiveRoute,
+  Planet,
+  StarSystem,
+  Sector,
+} from "../../../data/types.ts";
+import { CargoType, RouteScope } from "../../../data/types.ts";
+import {
+  SCOPE_DEMAND_MULTIPLIERS,
+  BASE_GALACTIC_ROUTE_SLOTS,
+  BASE_SYSTEM_ROUTE_SLOTS,
+} from "../../../data/constants.ts";
+import { initAdviserState } from "../../adviser/AdviserEngine.ts";
+
+// Two empires, three systems (sys-1, sys-2 in emp-1; sys-3 in emp-2),
+// each with one planet (planet-a, planet-b, planet-c). This lets us
+// exercise all three scopes from a single fixture.
+
+const sectors: Sector[] = [
+  { id: "sec-1", name: "Sector", x: 0, y: 0, color: 0xffffff },
+];
+
+const systems: StarSystem[] = [
+  {
+    id: "sys-1",
+    name: "Alpha",
+    sectorId: "sec-1",
+    empireId: "emp-1",
+    x: 0,
+    y: 0,
+    starColor: 0xffcc00,
+  },
+  {
+    id: "sys-2",
+    name: "Beta",
+    sectorId: "sec-1",
+    empireId: "emp-1",
+    x: 100,
+    y: 0,
+    starColor: 0xffcc00,
+  },
+  {
+    id: "sys-3",
+    name: "Gamma",
+    sectorId: "sec-1",
+    empireId: "emp-2",
+    x: 200,
+    y: 0,
+    starColor: 0xffcc00,
+  },
+];
+
+const planets: Planet[] = [
+  {
+    id: "planet-a",
+    name: "Alpha I",
+    systemId: "sys-1",
+    type: "terran",
+    x: 0,
+    y: 0,
+    population: 100,
+  },
+  {
+    id: "planet-a2",
+    name: "Alpha II",
+    systemId: "sys-1",
+    type: "industrial",
+    x: 5,
+    y: 5,
+    population: 100,
+  },
+  {
+    id: "planet-b",
+    name: "Beta I",
+    systemId: "sys-2",
+    type: "agricultural",
+    x: 100,
+    y: 0,
+    population: 100,
+  },
+  {
+    id: "planet-c",
+    name: "Gamma I",
+    systemId: "sys-3",
+    type: "industrial",
+    x: 200,
+    y: 0,
+    population: 100,
+  },
+];
+
+function makeRoute(
+  origin: string,
+  dest: string,
+  id = `route-${origin}-${dest}`,
+): ActiveRoute {
+  return {
+    id,
+    originPlanetId: origin,
+    destinationPlanetId: dest,
+    distance: 50,
+    cargoType: CargoType.Food,
+    assignedShipIds: [],
+  };
+}
+
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    seed: 42,
+    turn: 1,
+    maxTurns: 20,
+    phase: "planning",
+    cash: 200000,
+    loans: [],
+    reputation: 50,
+    companyName: "Test",
+    ceoName: "C",
+    ceoPortrait: { portraitId: "p", category: "human" },
+    gameSize: "standard",
+    galaxyShape: "spiral",
+    playerEmpireId: "emp-1",
+    galaxy: { sectors, empires: [], systems, planets },
+    fleet: [],
+    activeRoutes: [],
+    market: { fuelPrice: 10, fuelTrend: "stable", planetMarkets: {} },
+    aiCompanies: [],
+    activeEvents: [],
+    history: [],
+    storyteller: {
+      playerHealthScore: 50,
+      headwindBias: 0,
+      turnsInDebt: 0,
+      consecutiveProfitTurns: 0,
+      turnsSinceLastDecision: 0,
+    },
+    score: 0,
+    gameOver: false,
+    gameOverReason: null,
+    adviser: initAdviserState(),
+    routeSlots: 4,
+    localRouteSlots: 2,
+    galacticRouteSlots: 2,
+    unlockedEmpireIds: ["emp-1", "emp-2"],
+    contracts: [],
+    tech: {
+      researchPoints: 0,
+      completedTechIds: [],
+      currentResearchId: null,
+      researchProgress: 0,
+    },
+    empireTradePolicies: {},
+    interEmpireCargoLocks: [],
+    stationHub: null,
+    saveVersion: 6,
+    actionPoints: { current: 2, max: 2 },
+    turnBrief: [],
+    pendingChoiceEvents: [],
+    activeEventChains: [],
+    captains: [],
+    routeMarket: [],
+    researchEvents: [],
+    unlockedNavTabs: ["map", "routes", "fleet", "finance"],
+    reputationTier: "unknown",
+    ...overrides,
+  };
+}
+
+describe("getRouteScope", () => {
+  it("classifies same-system routes as system scope", () => {
+    const state = makeState();
+    expect(getRouteScope(makeRoute("planet-a", "planet-a2"), state)).toBe(
+      RouteScope.System,
+    );
+  });
+
+  it("classifies cross-system same-empire routes as empire scope", () => {
+    const state = makeState();
+    expect(getRouteScope(makeRoute("planet-a", "planet-b"), state)).toBe(
+      RouteScope.Empire,
+    );
+  });
+
+  it("classifies cross-empire routes as galactic scope", () => {
+    const state = makeState();
+    expect(getRouteScope(makeRoute("planet-b", "planet-c"), state)).toBe(
+      RouteScope.Galactic,
+    );
+  });
+
+  it("isLocalRoute matches the system scope", () => {
+    const state = makeState();
+    expect(isLocalRoute(makeRoute("planet-a", "planet-a2"), state)).toBe(true);
+    expect(isLocalRoute(makeRoute("planet-a", "planet-b"), state)).toBe(false);
+  });
+
+  it("isGalacticRoute matches the galactic scope", () => {
+    const state = makeState();
+    expect(isGalacticRoute(makeRoute("planet-b", "planet-c"), state)).toBe(
+      true,
+    );
+    expect(isGalacticRoute(makeRoute("planet-a", "planet-b"), state)).toBe(
+      false,
+    );
+  });
+});
+
+describe("Three-tier slot pools", () => {
+  it("each scope draws from its own pool", () => {
+    const state = makeState({
+      activeRoutes: [
+        makeRoute("planet-a", "planet-a2", "r-sys"),
+        makeRoute("planet-a", "planet-b", "r-emp"),
+        makeRoute("planet-b", "planet-c", "r-gal"),
+      ],
+    });
+    expect(getUsedSystemRouteSlots(state)).toBe(1);
+    expect(getUsedEmpireRouteSlots(state)).toBe(1);
+    expect(getUsedGalacticRouteSlots(state)).toBe(1);
+  });
+
+  it("free slot count per scope respects per-pool capacity", () => {
+    const state = makeState({
+      routeSlots: 3,
+      localRouteSlots: 2,
+      galacticRouteSlots: 2,
+      activeRoutes: [
+        makeRoute("planet-a", "planet-a2", "r-sys"),
+        makeRoute("planet-b", "planet-c", "r-gal"),
+      ],
+    });
+    expect(getFreeSlotsForScope(state, RouteScope.System)).toBe(1);
+    expect(getFreeSlotsForScope(state, RouteScope.Empire)).toBe(3);
+    expect(getFreeSlotsForScope(state, RouteScope.Galactic)).toBe(1);
+  });
+
+  it("missing galacticRouteSlots falls back to BASE_GALACTIC_ROUTE_SLOTS", () => {
+    const state = makeState({ galacticRouteSlots: undefined });
+    expect(getAvailableGalacticRouteSlots(state)).toBe(
+      BASE_GALACTIC_ROUTE_SLOTS,
+    );
+  });
+
+  it("missing localRouteSlots falls back to BASE_SYSTEM_ROUTE_SLOTS", () => {
+    const state = makeState({
+      localRouteSlots: undefined as unknown as number,
+    });
+    expect(getAvailableSystemRouteSlots(state)).toBe(BASE_SYSTEM_ROUTE_SLOTS);
+  });
+
+  it("aliases agree with their canonical helpers", () => {
+    const state = makeState();
+    expect(getAvailableEmpireRouteSlots(state)).toBe(state.routeSlots);
+    expect(getAvailableSystemRouteSlots(state)).toBe(state.localRouteSlots);
+  });
+});
+
+describe("Scope demand multipliers", () => {
+  it("luxury rewards galactic scope and punishes system scope", () => {
+    const luxSys = getScopeDemandMultiplier(
+      CargoType.Luxury,
+      RouteScope.System,
+    );
+    const luxGal = getScopeDemandMultiplier(
+      CargoType.Luxury,
+      RouteScope.Galactic,
+    );
+    expect(luxGal).toBeGreaterThan(luxSys);
+    expect(luxGal).toBeGreaterThan(1);
+    expect(luxSys).toBeLessThan(0.5);
+  });
+
+  it("raw materials reward local/empire scope and punish galactic", () => {
+    const rawSys = getScopeDemandMultiplier(
+      CargoType.RawMaterials,
+      RouteScope.System,
+    );
+    const rawEmp = getScopeDemandMultiplier(
+      CargoType.RawMaterials,
+      RouteScope.Empire,
+    );
+    const rawGal = getScopeDemandMultiplier(
+      CargoType.RawMaterials,
+      RouteScope.Galactic,
+    );
+    expect(rawEmp).toBeGreaterThan(rawGal);
+    expect(rawEmp).toBeGreaterThan(rawSys);
+  });
+
+  it("food behaves like raw materials (heavy/perishable)", () => {
+    const foodSys = SCOPE_DEMAND_MULTIPLIERS[CargoType.Food][RouteScope.System];
+    const foodGal =
+      SCOPE_DEMAND_MULTIPLIERS[CargoType.Food][RouteScope.Galactic];
+    expect(foodSys).toBeGreaterThan(foodGal);
+  });
+
+  it("technology shifts from low (system) to high (galactic)", () => {
+    const tSys =
+      SCOPE_DEMAND_MULTIPLIERS[CargoType.Technology][RouteScope.System];
+    const tEmp =
+      SCOPE_DEMAND_MULTIPLIERS[CargoType.Technology][RouteScope.Empire];
+    const tGal =
+      SCOPE_DEMAND_MULTIPLIERS[CargoType.Technology][RouteScope.Galactic];
+    expect(tSys).toBeLessThan(tEmp);
+    expect(tEmp).toBeLessThan(tGal);
+  });
+
+  it("every cargo has a multiplier in every scope", () => {
+    for (const cargo of Object.values(CargoType)) {
+      for (const scope of Object.values(RouteScope)) {
+        const mult = SCOPE_DEMAND_MULTIPLIERS[cargo][scope];
+        expect(typeof mult).toBe("number");
+        expect(mult).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/src/game/simulation/TurnSimulator.ts
+++ b/src/game/simulation/TurnSimulator.ts
@@ -12,10 +12,14 @@ import { buildTurnBrief } from "../turn/TurnBriefBuilder.ts";
 import { evaluateNavUnlocks } from "../nav/NavUnlocks.ts";
 import {
   BREAKDOWN_THRESHOLD,
-  INTRA_SYSTEM_REVENUE_MULTIPLIER,
   DISTANCE_PREMIUM_RATE,
   DISTANCE_PREMIUM_CAP,
 } from "../../data/constants.ts";
+import { RouteScope } from "../../data/types.ts";
+import {
+  getRouteScope,
+  getScopeDemandMultiplier,
+} from "../routes/RouteManager.ts";
 import { calculatePrice } from "../economy/PriceCalculator.ts";
 import { updateMarket } from "../economy/MarketUpdater.ts";
 import {
@@ -199,16 +203,13 @@ function simulateShipOnRoute(
   const capacity = isPassengers ? ship.passengerCapacity : ship.cargoCapacity;
 
   const totalCargoMoved = capacity * effectiveTrips;
-  const originSysId = planetToSystemId(route.originPlanetId);
-  const destSysId = planetToSystemId(route.destinationPlanetId);
-  const isIntraSystem = originSysId !== null && originSysId === destSysId;
-  const distancePremium = Math.min(
-    DISTANCE_PREMIUM_CAP,
-    route.distance * DISTANCE_PREMIUM_RATE,
-  );
-  const revenueMultiplier = isIntraSystem
-    ? INTRA_SYSTEM_REVENUE_MULTIPLIER
-    : 1 + distancePremium;
+  const scope = getRouteScope(route, state);
+  const scopeMult = getScopeDemandMultiplier(route.cargoType, scope);
+  const distancePremium =
+    scope === RouteScope.System
+      ? 0
+      : Math.min(DISTANCE_PREMIUM_CAP, route.distance * DISTANCE_PREMIUM_RATE);
+  const revenueMultiplier = scopeMult * (1 + distancePremium);
   const revenue = price * totalCargoMoved * revenueMultiplier;
 
   // Fuel cost = distance * 2 * fuelEfficiency * fuelPrice * effectiveTrips

--- a/src/game/simulation/__tests__/Phase3Integration.test.ts
+++ b/src/game/simulation/__tests__/Phase3Integration.test.ts
@@ -40,6 +40,7 @@ function makeContract(overrides: Partial<Contract> = {}): Contract {
     rewardReputation: 5,
     rewardResearchPoints: 10,
     rewardTariffReduction: null,
+    rewardSlotBonus: { scope: "galactic", amount: 1 },
     depositPaid: 2000,
     status: ContractStatus.Active,
     linkedRouteId: "route-1",
@@ -229,8 +230,11 @@ describe("Phase 3 Integration", () => {
     // Empire unlocked
     expect(nextState.unlockedEmpireIds).toContain("emp-2");
 
-    // Route slot gained (+1 from empire unlock)
-    expect(nextState.routeSlots).toBe(state.routeSlots + 1);
+    // Empire-unlock contracts now grow the galactic pool, not the empire pool.
+    expect(nextState.routeSlots).toBe(state.routeSlots);
+    expect(nextState.galacticRouteSlots).toBe(
+      (state.galacticRouteSlots ?? 3) + 1,
+    );
 
     // Completed contract
     const completedContract = nextState.contracts.find(

--- a/src/game/simulation/__tests__/TurnSimulator.test.ts
+++ b/src/game/simulation/__tests__/TurnSimulator.test.ts
@@ -26,6 +26,7 @@ import {
   BASE_CARGO_PRICES,
   DISTANCE_PREMIUM_RATE,
   DISTANCE_PREMIUM_CAP,
+  SCOPE_DEMAND_MULTIPLIERS,
 } from "../../../data/constants.ts";
 import { calculateTripsPerTurn } from "../../routes/RouteManager.ts";
 import { initAdviserState } from "../../adviser/AdviserEngine.ts";
@@ -254,11 +255,15 @@ describe("TurnSimulator", () => {
         DISTANCE_PREMIUM_CAP,
         50 * DISTANCE_PREMIUM_RATE,
       );
+      // Both planets sit in emp-1, so the route falls in the empire scope.
+      // Food carries a 1.1× scope demand multiplier on empire-tier routes.
+      const scopeMult = SCOPE_DEMAND_MULTIPLIERS[CargoType.Food].empire;
       const expectedRevenue =
         Math.round(
           BASE_CARGO_PRICES[CargoType.Food] *
             80 *
             trips *
+            scopeMult *
             (1 + distancePremium) *
             100,
         ) / 100;

--- a/src/scenes/ContractsScene.ts
+++ b/src/scenes/ContractsScene.ts
@@ -85,6 +85,15 @@ function rewardSummary(c: Contract): string {
     parts.push(
       `-${(c.rewardTariffReduction.reduction * 100).toFixed(0)}% tariff`,
     );
+  if (c.rewardSlotBonus && c.rewardSlotBonus.amount > 0) {
+    const scopeLabel =
+      c.rewardSlotBonus.scope === "system"
+        ? "Sys"
+        : c.rewardSlotBonus.scope === "empire"
+          ? "Emp"
+          : "Gal";
+    parts.push(`+${c.rewardSlotBonus.amount} ${scopeLabel} slot`);
+  }
   return parts.join(" \u2022 ") || "\u2014";
 }
 

--- a/src/scenes/GalaxyMapScene.ts
+++ b/src/scenes/GalaxyMapScene.ts
@@ -29,6 +29,8 @@ import {
   getUsedRouteSlots,
   getAvailableLocalRouteSlots,
   getUsedLocalRouteSlots,
+  getAvailableGalacticRouteSlots,
+  getUsedGalacticRouteSlots,
 } from "../game/routes/RouteManager.ts";
 import type { RouteTrafficVisual } from "../game/routes/RouteManager.ts";
 
@@ -659,12 +661,14 @@ export class GalaxyMapScene extends Phaser.Scene {
     // ── HUD overlay elements (rendered by fixed uiCam only, immune to zoom) ──
     const hudObjects: Phaser.GameObjects.GameObject[] = [];
 
-    const slotsUsed = getUsedRouteSlots(state) + getUsedLocalRouteSlots(state);
-    const slotsTotal =
-      getAvailableRouteSlots(state) + getAvailableLocalRouteSlots(state);
-    const slotBlocks =
-      "\u25A0".repeat(slotsUsed) +
-      "\u25A1".repeat(Math.max(0, slotsTotal - slotsUsed));
+    const sysUsed = getUsedLocalRouteSlots(state);
+    const sysTot = getAvailableLocalRouteSlots(state);
+    const empUsed = getUsedRouteSlots(state);
+    const empTot = getAvailableRouteSlots(state);
+    const galUsed = getUsedGalacticRouteSlots(state);
+    const galTot = getAvailableGalacticRouteSlots(state);
+    const slotsUsed = sysUsed + empUsed + galUsed;
+    const slotsTotal = sysTot + empTot + galTot;
 
     // Offset HUD labels further below the top bar so they clear the
     // company name / cash readout (which can extend slightly past the
@@ -690,7 +694,7 @@ export class GalaxyMapScene extends Phaser.Scene {
       new Label(this, {
         x: 20,
         y: hudLabelTop + 18,
-        text: `Routes: ${slotsUsed}/${slotsTotal} ${slotBlocks}`,
+        text: `Sys ${sysUsed}/${sysTot} · Emp ${empUsed}/${empTot} · Gal ${galUsed}/${galTot}`,
         style: "caption",
         color:
           slotsUsed >= slotsTotal ? theme.colors.loss : theme.colors.textDim,

--- a/src/scenes/GameHUDScene.ts
+++ b/src/scenes/GameHUDScene.ts
@@ -24,7 +24,33 @@ import {
   getUsedRouteSlots,
   getAvailableLocalRouteSlots,
   getUsedLocalRouteSlots,
+  getAvailableGalacticRouteSlots,
+  getUsedGalacticRouteSlots,
 } from "../game/routes/RouteManager.ts";
+import type { GameState } from "../data/types.ts";
+
+/**
+ * Compact "Sys 1/2 · Emp 2/4 · Gal 0/2" string for the HUD route-slot
+ * indicator. Three pools displayed inline so the player sees at-a-glance
+ * which tier is saturated.
+ */
+function formatSlotSummary(state: GameState): {
+  text: string;
+  anySaturated: boolean;
+} {
+  const sysUsed = getUsedLocalRouteSlots(state);
+  const sysTot = getAvailableLocalRouteSlots(state);
+  const empUsed = getUsedRouteSlots(state);
+  const empTot = getAvailableRouteSlots(state);
+  const galUsed = getUsedGalacticRouteSlots(state);
+  const galTot = getAvailableGalacticRouteSlots(state);
+  const anySaturated =
+    sysUsed >= sysTot || empUsed >= empTot || galUsed >= galTot;
+  return {
+    text: `Sys ${sysUsed}/${sysTot} · Emp ${empUsed}/${empTot} · Gal ${galUsed}/${galTot}`,
+    anySaturated,
+  };
+}
 import { getPortraitTextureKey } from "../data/portraits.ts";
 import {
   portraitLoader,
@@ -558,16 +584,17 @@ export class GameHUDScene extends Phaser.Scene {
     });
     this.actionPromptLabel.setOrigin(0, 0.5);
 
-    // Route slot indicator (bottom bar, to the left of the end turn area)
-    const slotsUsed = getUsedRouteSlots(state) + getUsedLocalRouteSlots(state);
-    const slotsTotal =
-      getAvailableRouteSlots(state) + getAvailableLocalRouteSlots(state);
+    // Route slot indicator (bottom bar, to the left of the end turn area).
+    // Shows all three pools inline so a saturated tier is immediately visible.
+    const slotSummary = formatSlotSummary(state);
     this.routeSlotLabel = new Label(this, {
       x: L.gameWidth - 200,
       y: L.gameHeight - L.hudBottomBarHeight / 2 - 8,
-      text: `Routes ${slotsUsed}/${slotsTotal}`,
+      text: slotSummary.text,
       style: "caption",
-      color: slotsUsed >= slotsTotal ? theme.colors.loss : theme.colors.textDim,
+      color: slotSummary.anySaturated
+        ? theme.colors.loss
+        : theme.colors.textDim,
     });
     this.routeSlotLabel.setOrigin(1, 0.5);
 
@@ -769,13 +796,11 @@ export class GameHUDScene extends Phaser.Scene {
     this.updateNavBadges();
     this.updateNavVisibility();
 
-    // Route slot indicator (main + local combined)
-    const slotsUsed = getUsedRouteSlots(state) + getUsedLocalRouteSlots(state);
-    const slotsTotal =
-      getAvailableRouteSlots(state) + getAvailableLocalRouteSlots(state);
-    this.routeSlotLabel.setText(`Routes ${slotsUsed}/${slotsTotal}`);
+    // Route slot indicator (system / empire / galactic pools).
+    const slotSummary = formatSlotSummary(state);
+    this.routeSlotLabel.setText(slotSummary.text);
     this.routeSlotLabel.setLabelColor(
-      slotsUsed >= slotsTotal ? theme.colors.loss : theme.colors.textDim,
+      slotSummary.anySaturated ? theme.colors.loss : theme.colors.textDim,
     );
 
     // Research indicator

--- a/src/scenes/RoutesScene.ts
+++ b/src/scenes/RoutesScene.ts
@@ -288,16 +288,16 @@ export class RoutesScene extends Phaser.Scene {
       testId: string;
     }> = [
       { label: "Any scope", value: null, testId: "btn-finder-scope-any" },
-      { label: "Local", value: "local", testId: "btn-finder-scope-local" },
+      { label: "System", value: "system", testId: "btn-finder-scope-system" },
       {
-        label: "Interstellar",
-        value: "interstellar",
-        testId: "btn-finder-scope-interstellar",
+        label: "Empire",
+        value: "empire",
+        testId: "btn-finder-scope-empire",
       },
       {
-        label: "Inter-empire",
-        value: "interEmpire",
-        testId: "btn-finder-scope-inter-empire",
+        label: "Galactic",
+        value: "galactic",
+        testId: "btn-finder-scope-galactic",
       },
     ];
     this.scopeBandButtons = scopeBands.map(
@@ -844,12 +844,12 @@ export class RoutesScene extends Phaser.Scene {
         emptyHint = "Generate a galaxy first.";
       } else if (hasFilter) {
         const scopeLabel =
-          this.finderScopeBand === "local"
-            ? "local"
-            : this.finderScopeBand === "interstellar"
-              ? "interstellar"
-              : this.finderScopeBand === "interEmpire"
-                ? "inter-empire"
+          this.finderScopeBand === "system"
+            ? "system"
+            : this.finderScopeBand === "empire"
+              ? "empire"
+              : this.finderScopeBand === "galactic"
+                ? "galactic"
                 : "";
         const subject = scopeLabel
           ? `${scopeLabel} ${filterLabel}`.trim()
@@ -892,9 +892,9 @@ export class RoutesScene extends Phaser.Scene {
   private updateScopeBandButtonStyles(): void {
     const scopes: Array<RouteScopeBand> = [
       null,
-      "local",
-      "interstellar",
-      "interEmpire",
+      "system",
+      "empire",
+      "galactic",
     ];
     for (let i = 0; i < this.scopeBandButtons.length; i++) {
       const btn = this.scopeBandButtons[i];

--- a/src/scenes/RoutesScene.ts
+++ b/src/scenes/RoutesScene.ts
@@ -42,6 +42,8 @@ import {
   getUsedRouteSlots,
   getAvailableLocalRouteSlots,
   getUsedLocalRouteSlots,
+  getAvailableGalacticRouteSlots,
+  getUsedGalacticRouteSlots,
 } from "../game/routes/RouteManager.ts";
 import type { RouteOpportunity } from "../game/routes/RouteManager.ts";
 import {
@@ -736,11 +738,14 @@ export class RoutesScene extends Phaser.Scene {
     const filterLabel = this.finderCargoFilter
       ? getCargoLabel(this.finderCargoFilter)
       : "all cargo";
-    const slotsUsed = getUsedRouteSlots(state) + getUsedLocalRouteSlots(state);
-    const slotsTotal =
-      getAvailableRouteSlots(state) + getAvailableLocalRouteSlots(state);
+    const sysUsed = getUsedLocalRouteSlots(state);
+    const sysTot = getAvailableLocalRouteSlots(state);
+    const empUsed = getUsedRouteSlots(state);
+    const empTot = getAvailableRouteSlots(state);
+    const galUsed = getUsedGalacticRouteSlots(state);
+    const galTot = getAvailableGalacticRouteSlots(state);
     this.finderSummary.setText(
-      `${profitableCount} ${filterLabel} routes found \u2022 Slots ${slotsUsed}/${slotsTotal} \u2022 ${availableShips} idle ships \u2022 §${state.cash.toLocaleString("en-US")} cash \u2022 Enter to create`,
+      `${profitableCount} ${filterLabel} routes found \u2022 Sys ${sysUsed}/${sysTot} \u00B7 Emp ${empUsed}/${empTot} \u00B7 Gal ${galUsed}/${galTot} \u2022 ${availableShips} idle ships \u2022 §${state.cash.toLocaleString("en-US")} cash \u2022 Enter to create`,
     );
 
     // When the user has narrowed the set with any filter, raise the cap so

--- a/src/scenes/__tests__/routesFinderFilters.test.ts
+++ b/src/scenes/__tests__/routesFinderFilters.test.ts
@@ -47,37 +47,33 @@ describe("matchesScopeBand", () => {
     expect(matchesScopeBand("s1", "s2", null, null, null)).toBe(true);
   });
 
-  it("local: same system regardless of empire resolution", () => {
-    expect(matchesScopeBand("s1", "s1", "e1", "e1", "local")).toBe(true);
-    expect(matchesScopeBand("s1", "s1", null, null, "local")).toBe(true);
-    expect(matchesScopeBand("s1", "s2", "e1", "e1", "local")).toBe(false);
+  it("system: same system regardless of empire resolution", () => {
+    expect(matchesScopeBand("s1", "s1", "e1", "e1", "system")).toBe(true);
+    expect(matchesScopeBand("s1", "s1", null, null, "system")).toBe(true);
+    expect(matchesScopeBand("s1", "s2", "e1", "e1", "system")).toBe(false);
   });
 
-  it("interstellar: cross-system, same empire OR unresolved empire", () => {
-    expect(matchesScopeBand("s1", "s2", "e1", "e1", "interstellar")).toBe(true);
+  it("empire: cross-system, same empire OR unresolved empire", () => {
+    expect(matchesScopeBand("s1", "s2", "e1", "e1", "empire")).toBe(true);
     // unresolved empire → defaults to interstellar bucket, not interEmpire
-    expect(matchesScopeBand("s1", "s2", "e1", null, "interstellar")).toBe(true);
-    expect(matchesScopeBand("s1", "s2", null, "e1", "interstellar")).toBe(true);
-    expect(matchesScopeBand("s1", "s2", null, null, "interstellar")).toBe(true);
+    expect(matchesScopeBand("s1", "s2", "e1", null, "empire")).toBe(true);
+    expect(matchesScopeBand("s1", "s2", null, "e1", "empire")).toBe(true);
+    expect(matchesScopeBand("s1", "s2", null, null, "empire")).toBe(true);
     // strictly cross-empire belongs to interEmpire, not interstellar
-    expect(matchesScopeBand("s1", "s2", "e1", "e2", "interstellar")).toBe(
-      false,
-    );
+    expect(matchesScopeBand("s1", "s2", "e1", "e2", "empire")).toBe(false);
     // local routes never match interstellar
-    expect(matchesScopeBand("s1", "s1", "e1", "e1", "interstellar")).toBe(
-      false,
-    );
+    expect(matchesScopeBand("s1", "s1", "e1", "e1", "empire")).toBe(false);
   });
 
-  it("interEmpire: cross-system AND both empires resolved AND distinct", () => {
-    expect(matchesScopeBand("s1", "s2", "e1", "e2", "interEmpire")).toBe(true);
-    expect(matchesScopeBand("s1", "s2", "e1", "e1", "interEmpire")).toBe(false);
-    expect(matchesScopeBand("s1", "s2", "e1", null, "interEmpire")).toBe(false);
-    expect(matchesScopeBand("s1", "s2", null, "e2", "interEmpire")).toBe(false);
-    expect(matchesScopeBand("s1", "s1", "e1", "e2", "interEmpire")).toBe(false);
+  it("galactic: cross-system AND both empires resolved AND distinct", () => {
+    expect(matchesScopeBand("s1", "s2", "e1", "e2", "galactic")).toBe(true);
+    expect(matchesScopeBand("s1", "s2", "e1", "e1", "galactic")).toBe(false);
+    expect(matchesScopeBand("s1", "s2", "e1", null, "galactic")).toBe(false);
+    expect(matchesScopeBand("s1", "s2", null, "e2", "galactic")).toBe(false);
+    expect(matchesScopeBand("s1", "s1", "e1", "e2", "galactic")).toBe(false);
   });
 
-  it("partitions every cross-system route into interstellar XOR interEmpire", () => {
+  it("partitions every cross-system route into empire XOR galactic", () => {
     const cases: Array<[string | null, string | null]> = [
       ["e1", "e1"],
       ["e1", "e2"],
@@ -86,8 +82,8 @@ describe("matchesScopeBand", () => {
       [null, null],
     ];
     for (const [oe, de] of cases) {
-      const inter = matchesScopeBand("s1", "s2", oe, de, "interstellar");
-      const cross = matchesScopeBand("s1", "s2", oe, de, "interEmpire");
+      const inter = matchesScopeBand("s1", "s2", oe, de, "empire");
+      const cross = matchesScopeBand("s1", "s2", oe, de, "galactic");
       expect(inter !== cross).toBe(true);
     }
   });

--- a/src/scenes/routesFinderFilters.ts
+++ b/src/scenes/routesFinderFilters.ts
@@ -23,20 +23,27 @@ export function isInDistanceBand(
   }
 }
 
-export type RouteScopeBand = "local" | "interstellar" | "interEmpire" | null;
+/**
+ * Scope-band filter value for the Route Finder. Aligns with the canonical
+ * `RouteScope` from data/types — "system" / "empire" / "galactic" — plus
+ * `null` for "all scopes". Renamed from the legacy local/interstellar/
+ * interEmpire trio so HUD ("Sys/Emp/Gal") and filter buttons share one
+ * vocabulary.
+ */
+export type RouteScopeBand = "system" | "empire" | "galactic" | null;
 
 /**
  * Scope-band predicate for the Route Finder.
  *
- * - `null`        → matches all routes
- * - `local`       → both planets share a star system
- * - `interstellar`→ different systems but the same (resolved) empire owns both
- * - `interEmpire` → different systems AND both empires resolved AND distinct
+ * - `null`     → matches all routes
+ * - `system`   → both planets share a star system
+ * - `empire`   → different systems, same empire (intra-empire interstellar)
+ * - `galactic` → different systems AND both empires resolved AND distinct
  *
- * "interEmpire" requires both empire ids to be present so a route to or from
+ * "galactic" requires both empire ids to be present so a route to or from
  * an unaligned/unresolved planet is not mis-counted as cross-empire trade
  * (which would inflate the bucket and confuse the empty-state copy). Such
- * routes still match `interstellar` if the systems differ.
+ * routes still match `empire` if the systems differ.
  */
 export function matchesScopeBand(
   originSystemId: string,
@@ -46,12 +53,12 @@ export function matchesScopeBand(
   scope: RouteScopeBand,
 ): boolean {
   if (scope === null) return true;
-  const isLocal = originSystemId === destSystemId;
-  if (scope === "local") return isLocal;
-  if (isLocal) return false;
+  const isSystem = originSystemId === destSystemId;
+  if (scope === "system") return isSystem;
+  if (isSystem) return false;
   const bothEmpiresResolved = originEmpireId !== null && destEmpireId !== null;
-  const isInterEmpire = bothEmpiresResolved && originEmpireId !== destEmpireId;
-  if (scope === "interEmpire") return isInterEmpire;
-  // "interstellar" → cross-system but not cross-empire
-  return !isInterEmpire;
+  const isGalactic = bothEmpiresResolved && originEmpireId !== destEmpireId;
+  if (scope === "galactic") return isGalactic;
+  // "empire" → cross-system but not cross-empire
+  return !isGalactic;
 }


### PR DESCRIPTION
## Summary

Replaces the single inter-system slot pool + flat 50% intra-system revenue cap with three distinct scopes — **system** (intra-system), **empire** (cross-system, same empire), **galactic** (cross-empire). Each scope draws from its own slot pool and applies a per-cargo scope demand multiplier to revenue.

## Why

Two player-facing issues drove this:

1. **"Only a couple non-system routes"** — the route market generator skipped same-system pairs entirely and had no quota across scopes, so empire and galactic candidates rarely surfaced when the candidate pool was small.
2. **"Local routes too profitable"** — the trips-per-turn cap let short routes out-earn long-haul ones even with the flat 0.5× intra-system cap. A per-cargo curve gives a real reason to invest in long-haul without nuking local revenue uniformly.

## What's in this PR

### Mechanics

- **Three slot pools** (system 2, empire 3+1 home bonus, galactic 3). Each tier has a distinct growth path: empire grows through Logistics tech + Hub, galactic grows through diplomacy / contracts, system stays fixed (training-wheel tier).
- **Contracts now carry slot rewards** via a new optional `rewardSlotBonus: { scope, amount }` field paid out on completion:
  - Empire Unlock → +1 galactic
  - Trade Alliance → +1 galactic
  - Passenger Ferry → +1 empire
  - Emergency Supply / Research Courier → none
  
  Visible in the contract reward summary at acceptance time so the player isn't surprise-rewarded.
- **Per-cargo `SCOPE_DEMAND_MULTIPLIERS`** replaces the flat intra-system cap. Heavy goods (raw, food, hazmat) reward system/empire scope; luxury and tech reward galactic scope. Cargo selection in the route market generator is probability-weighted by `scopeMult²` so scope-appropriate cargo dominates without becoming deterministic.
- **Quota-based market generator** — partitions candidate pairs into scope buckets and fills toward `ROUTE_MARKET_SCOPE_QUOTA` (20/40/40), redistributing when a tier has zero candidates so the market never under-fills because one tier is unavailable.
- **`SLOT_PER_EMPIRE_UNLOCK`** deprecated; the bonus now flows through the new `Contract.rewardSlotBonus` field.

### UI

- HUD / Routes / Galaxy Map slot indicators now show `Sys 1/2 · Emp 2/4 · Gal 0/2` so a saturated tier is immediately legible.
- Contract reward summary appends e.g. `+1 Gal slot` so contract-driven slot growth is visible at a glance.

### Future seam

`constants.ts` documents a planned Aerobiz-inspired ship-class haul-band system inline next to `SCOPE_DEMAND_MULTIPLIERS` — `RECOMMENDED_SHIP_CLASSES_BY_SCOPE`, per-class `optimalHaulBand`, and scanner re-weighting. No dead code added; the seam is comment + the three slot pools, with `RouteScope` already exported as the public abstraction.

## Compatibility

- `Contract.rewardSlotBonus` and `GameState.galacticRouteSlots` are optional fields; v6 saves load fine and backfill defaults at read time. No `SAVE_VERSION` bump.
- The legacy `INTRA_SYSTEM_REVENUE_MULTIPLIER` and `LOCAL_ROUTE_REVENUE_CAP` constants are kept exported (deprecated) so older fixtures still compile, but are no longer read by revenue calculations.

## Test plan

- [x] `npm run typecheck` — clean (only pre-existing Phaser 4 `.filters` errors that exist on `main` too)
- [x] `npm run test` — **793/793 passing** (20 new tests covering scope classification, slot pools, demand multipliers, contract slot rewards, and quota-based generation)
- [x] `npm run build` — production build green
- [x] `npm run format` — clean
- [ ] Smoke-test in browser: confirm HUD shows three pool counters; accept a passenger-ferry contract and verify the empire pool bumps on completion; verify the route market shows a mix of scopes once 2+ empires are unlocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)