### PR TITLE
fix(audio): BGM not starting on game load in production

### DIFF
--- a/public/staticwebapp.config.json
+++ b/public/staticwebapp.config.json
@@ -34,8 +34,7 @@
     {
       "route": "/concepts/audio/*",
       "headers": {
-        "Cache-Control": "public, max-age=31536000, immutable",
-        "Accept-Ranges": "bytes"
+        "Cache-Control": "public, max-age=31536000, immutable"
       }
     },
     {

--- a/src/audio/AudioDirector.ts
+++ b/src/audio/AudioDirector.ts
@@ -1035,16 +1035,20 @@ class AudioDirector {
   private async playExternalBgmIfNeeded(): Promise<void> {
     if (!this.externalBgm || !this.enabled) return;
     if (!this.externalBgm.paused) return;
-    // iOS Safari leaves the element in a broken state after a failed play() —
-    // subsequent play() calls also fail until load() resets it.
-    if (this.externalBgmPlayAttempted) {
-      this.externalBgm.load();
-    }
+    // Always reset before play — avoids stale partial-range state left by
+    // the preload="metadata" background fetch in production (Azure SWA range
+    // responses leave the element unable to stream without a load() reset).
+    // switchExternalTrack() already calls load() and clears externalBgmPlayAttempted,
+    // so a double load() on manual track switch is harmless.
+    this.externalBgm.load();
     this.externalBgmPlayAttempted = true;
     try {
       await this.externalBgm.play();
-    } catch {
-      // Browser autoplay rules can block this until a user gesture.
+    } catch (err) {
+      // NotAllowedError = autoplay blocked until user gesture; everything else is real.
+      if (err instanceof DOMException && err.name !== "NotAllowedError") {
+        console.warn("[AudioDirector] BGM play failed:", err.name, err.message);
+      }
     }
   }
 

--- a/src/audio/AudioDirector.ts
+++ b/src/audio/AudioDirector.ts
@@ -279,7 +279,7 @@ class AudioDirector {
   private usingExternalBgm = false;
   private externalBgm: HTMLAudioElement | null = null;
   private externalBgmTrackIndex = 0;
-  private externalBgmPlayAttempted = false;
+
   private settingsHydrated = false;
   private currentState: MusicState = "menu";
   private currentPlanningSubstate: PlanningSubstate = "galaxy";
@@ -1038,10 +1038,9 @@ class AudioDirector {
     // Always reset before play — avoids stale partial-range state left by
     // the preload="metadata" background fetch in production (Azure SWA range
     // responses leave the element unable to stream without a load() reset).
-    // switchExternalTrack() already calls load() and clears externalBgmPlayAttempted,
+    // switchExternalTrack() already calls load() before delegating here,
     // so a double load() on manual track switch is harmless.
     this.externalBgm.load();
-    this.externalBgmPlayAttempted = true;
     try {
       await this.externalBgm.play();
     } catch (err) {
@@ -1075,7 +1074,6 @@ class AudioDirector {
     this.externalBgm.src = track.url;
     this.externalBgm.currentTime = 0;
     this.externalBgm.load();
-    this.externalBgmPlayAttempted = false; // load() already called; no pre-load needed
 
     if (shouldPlay) {
       void this.playExternalBgmIfNeeded();


### PR DESCRIPTION
## Summary

- **Root cause**: `playExternalBgmIfNeeded()` skipped `load()` on the first play attempt. In production (Azure Static Web Apps), `new Audio(url)` with `preload="metadata"` triggers a range request; the response can leave the `HTMLAudioElement` in a state where `play()` fails silently.
- **Why manual track changes worked**: `switchExternalTrack()` always calls `load()` before playing, which resets the element and makes a clean streaming request — aligned the startup path to do the same.
- **Secondary**: Removed manually-set `Accept-Ranges: bytes` from `staticwebapp.config.json`; Azure SWA provides this natively and duplicate values can confuse CDN edge nodes.

## Changes

- `src/audio/AudioDirector.ts` — `playExternalBgmIfNeeded()` now unconditionally calls `load()` before `play()`. Non-autoplay errors are now surfaced as `console.warn` instead of silently swallowed.
- `public/staticwebapp.config.json` — Removed redundant `Accept-Ranges: bytes` header from `/concepts/audio/*` route.

## Test plan

- [ ] `npm run build && npm run preview` — music starts after first user gesture (click canvas)
- [ ] Manual track prev/next still works correctly
- [ ] Deploy to production and verify music starts at `space-tycoon.cat-herding.net` on fresh load
- [ ] DevTools Network: first `.mp3` request returns `200 OK` with `Content-Type: audio/mpeg`
- [ ] DevTools Console: no `[AudioDirector] BGM play failed:` warnings on normal flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)