### PR TITLE
fix(hud): persistent news ticker, dilemma sizing, end-turn QA

### DIFF
--- a/packages/spacebiz-ui/src/Layout.ts
+++ b/packages/spacebiz-ui/src/Layout.ts
@@ -17,6 +17,8 @@ export interface LayoutMetrics {
   contentGap: number;
   hudTopBarHeight: number;
   hudBottomBarHeight: number;
+  hudTickerHeight: number;
+  hudBottomBarTop: number;
   navSidebarWidth: number;
   contentTop: number;
   contentHeight: number;
@@ -38,6 +40,7 @@ function computeMetrics(w: number, h: number): LayoutMetrics {
   const navSidebarWidth = isPortrait ? 0 : 56;
   const hudTopBarHeight = 56;
   const hudBottomBarHeight = 52;
+  const hudTickerHeight = 20;
   const contentGap = 12;
 
   // Scale content to fill available space, keeping small margins on each side.
@@ -46,7 +49,8 @@ function computeMetrics(w: number, h: number): LayoutMetrics {
   const contentLeft = Math.floor((w - maxContentWidth) / 2);
 
   const contentTop = hudTopBarHeight;
-  const contentHeight = h - hudTopBarHeight - hudBottomBarHeight;
+  const contentHeight =
+    h - hudTopBarHeight - hudBottomBarHeight - hudTickerHeight;
 
   const sidebarLeft = contentLeft;
   const mainContentLeft = isCompact
@@ -56,6 +60,8 @@ function computeMetrics(w: number, h: number): LayoutMetrics {
     ? maxContentWidth
     : maxContentWidth - sidebarWidth - contentGap;
 
+  const hudBottomBarTop = h - hudBottomBarHeight - hudTickerHeight;
+
   return {
     gameWidth: w,
     gameHeight: h,
@@ -64,6 +70,8 @@ function computeMetrics(w: number, h: number): LayoutMetrics {
     contentGap,
     hudTopBarHeight,
     hudBottomBarHeight,
+    hudTickerHeight,
+    hudBottomBarTop,
     navSidebarWidth,
     contentTop,
     contentHeight,
@@ -99,10 +107,11 @@ export const SIDEBAR_WIDTH = 240;
 export const CONTENT_GAP = 12;
 export const HUD_TOP_BAR_HEIGHT = 56;
 export const HUD_BOTTOM_BAR_HEIGHT = 52;
+export const HUD_TICKER_HEIGHT = 20;
 export const NAV_SIDEBAR_WIDTH = 56;
 export const CONTENT_TOP = HUD_TOP_BAR_HEIGHT;
 export const CONTENT_HEIGHT =
-  GAME_HEIGHT - HUD_TOP_BAR_HEIGHT - HUD_BOTTOM_BAR_HEIGHT;
+  GAME_HEIGHT - HUD_TOP_BAR_HEIGHT - HUD_BOTTOM_BAR_HEIGHT - HUD_TICKER_HEIGHT;
 export const CONTENT_LEFT = Math.floor((GAME_WIDTH - MAX_CONTENT_WIDTH) / 2);
 export const SIDEBAR_LEFT = CONTENT_LEFT;
 export const MAIN_CONTENT_LEFT = SIDEBAR_LEFT + SIDEBAR_WIDTH + CONTENT_GAP;

--- a/src/scenes/DilemmaScene.ts
+++ b/src/scenes/DilemmaScene.ts
@@ -27,12 +27,12 @@ const HEADER_HEIGHT = 56;
 const PADDING = 18;
 
 const BANNER_W = 480;
-const BANNER_H = 180;
-const BANNER_GAP = 14;
+const BANNER_H = 80;
+const BANNER_GAP = 10;
 
 const PROMPT_HEIGHT = 78;
-const OPTION_HEIGHT = 116;
-const OPTION_GAP = 10;
+const OPTION_HEIGHT = 90;
+const OPTION_GAP = 8;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/scenes/GameHUDScene.ts
+++ b/src/scenes/GameHUDScene.ts
@@ -10,6 +10,7 @@ import {
   FloatingText,
   AdviserPanel,
 } from "../ui/index.ts";
+import { HorizontalNewsTicker } from "../ui/HorizontalNewsTicker.ts";
 import { gameStore } from "../data/GameStore.ts";
 import { getAudioDirector } from "../audio/AudioDirector.ts";
 import { checkTutorialAdvancement } from "../game/adviser/AdviserEngine.ts";
@@ -28,6 +29,7 @@ import {
   getUsedGalacticRouteSlots,
 } from "../game/routes/RouteManager.ts";
 import type { GameState } from "../data/types.ts";
+import { generateTickerFeed } from "../generation/news/tickerFeed.ts";
 
 /**
  * Compact "Sys 1/2 · Emp 2/4 · Gal 0/2" string for the HUD route-slot
@@ -124,6 +126,7 @@ export class GameHUDScene extends Phaser.Scene {
   private apBadgeLabel!: Label;
   private navBadges = new Map<string, Phaser.GameObjects.Arc>();
   private endTurnModal: Modal | null = null;
+  private newsTicker: HorizontalNewsTicker | null = null;
   private readonly navIconButtonSize = 46;
   private readonly navIconSpacing = 8;
   private readonly navHitHeight = 50;
@@ -162,6 +165,9 @@ export class GameHUDScene extends Phaser.Scene {
   private stateListener = (_data: unknown) => {
     this.updateHUD();
     this.maybeShowDilemma();
+    if (this.newsTicker) {
+      this.newsTicker.updateItems(this.buildTickerItems(gameStore.getState()));
+    }
   };
 
   constructor() {
@@ -347,7 +353,7 @@ export class GameHUDScene extends Phaser.Scene {
     ];
 
     const navSidebarTop = L.hudTopBarHeight;
-    const navSidebarH = L.gameHeight - L.hudTopBarHeight - L.hudBottomBarHeight;
+    const navSidebarH = L.hudBottomBarTop - L.hudTopBarHeight;
 
     // Sidebar background strip
     this.add
@@ -547,7 +553,8 @@ export class GameHUDScene extends Phaser.Scene {
     });
 
     // ── Bottom Bar ───────────────────────────────────────────
-    const bottomBarY = L.gameHeight - L.hudBottomBarHeight;
+    const bottomBarY = L.hudBottomBarTop;
+    const bottomBarMidY = bottomBarY + L.hudBottomBarHeight / 2;
 
     this.add
       .nineslice(
@@ -568,7 +575,7 @@ export class GameHUDScene extends Phaser.Scene {
     // Phase indicator (left side of bottom bar)
     this.phaseLabel = new Label(this, {
       x: 20,
-      y: L.gameHeight - L.hudBottomBarHeight / 2,
+      y: bottomBarMidY,
       text: `Phase: ${state.phase}`,
       style: "caption",
     });
@@ -577,7 +584,7 @@ export class GameHUDScene extends Phaser.Scene {
     // Action prompt (right of phase label, with enough clearance)
     this.actionPromptLabel = new Label(this, {
       x: 200,
-      y: L.gameHeight - L.hudBottomBarHeight / 2,
+      y: bottomBarMidY,
       text: "",
       style: "caption",
       color: theme.colors.textDim,
@@ -589,7 +596,7 @@ export class GameHUDScene extends Phaser.Scene {
     const slotSummary = formatSlotSummary(state);
     this.routeSlotLabel = new Label(this, {
       x: L.gameWidth - 200,
-      y: L.gameHeight - L.hudBottomBarHeight / 2 - 8,
+      y: bottomBarMidY - 8,
       text: slotSummary.text,
       style: "caption",
       color: slotSummary.anySaturated
@@ -605,7 +612,7 @@ export class GameHUDScene extends Phaser.Scene {
       : "No research";
     this.researchLabel = new Label(this, {
       x: L.gameWidth - 200,
-      y: L.gameHeight - L.hudBottomBarHeight / 2 + 8,
+      y: bottomBarMidY + 8,
       text: researchText,
       style: "caption",
       color: techState?.currentResearchId
@@ -643,6 +650,33 @@ export class GameHUDScene extends Phaser.Scene {
       },
     });
     this.endTurnButton.setVisible(state.phase === "planning");
+
+    // ── Horizontal News Ticker strip (below bottom bar) ──
+    const tickerY = L.gameHeight - L.hudTickerHeight;
+    this.add
+      .rectangle(
+        0,
+        tickerY,
+        L.gameWidth,
+        L.hudTickerHeight,
+        theme.colors.background,
+      )
+      .setOrigin(0, 0)
+      .setAlpha(0.97)
+      .setDepth(290);
+    // 1px top border
+    this.add
+      .rectangle(0, tickerY, L.gameWidth, 1, theme.colors.panelBorder)
+      .setOrigin(0, 0)
+      .setDepth(291);
+    this.newsTicker = new HorizontalNewsTicker(
+      this,
+      L.navSidebarWidth,
+      tickerY,
+      L.gameWidth - L.navSidebarWidth,
+      L.hudTickerHeight,
+    );
+    this.newsTicker.updateItems(this.buildTickerItems(state));
 
     // ── Adviser Panel (drawer-style, upper-right) ──
     // Tab (36px) is at x=0 of the container, panel body at x=36.
@@ -700,6 +734,8 @@ export class GameHUDScene extends Phaser.Scene {
       this.scale.off("resize", onResize);
       gameStore.off("stateChanged", this.stateListener);
       this.destroyAudioPanel();
+      this.newsTicker?.destroy();
+      this.newsTicker = null;
     });
 
     // Launch content scene (restored on resize, default GalaxyMapScene)
@@ -850,9 +886,16 @@ export class GameHUDScene extends Phaser.Scene {
       this.destroyAudioPanel();
     }
 
-    // Stop overlay scenes that might be stacked on top
+    // Stop overlay scenes that might be stacked on top.
+    // DilemmaScene is exempt if it has pending choices — it closes itself.
     for (const key of this.overlaySceneKeys) {
       if (this.scene.isActive(key)) {
+        if (key === "DilemmaScene") {
+          const hasPending = gameStore
+            .getState()
+            .pendingChoiceEvents.some((e) => e.dilemmaId !== undefined);
+          if (hasPending) continue;
+        }
         this.scene.stop(key);
       }
     }
@@ -1656,6 +1699,12 @@ export class GameHUDScene extends Phaser.Scene {
       },
     });
     this.endTurnModal.setDepth(500);
+  }
+
+  private buildTickerItems(state: GameState) {
+    const lastTurn = state.history[state.history.length - 1];
+    if (!lastTurn) return [];
+    return generateTickerFeed(state, lastTurn);
   }
 
   /** Determine the best scene to show after a turn report, based on game state. */

--- a/src/scenes/RoutesScene.ts
+++ b/src/scenes/RoutesScene.ts
@@ -239,7 +239,8 @@ export class RoutesScene extends Phaser.Scene {
       })),
       defaultIndex: 0,
       onChange: (value) => {
-        this.finderCargoFilter = value === "" ? null : (value as CargoTypeValue);
+        this.finderCargoFilter =
+          value === "" ? null : (value as CargoTypeValue);
         this.refreshFinderTable();
       },
     });
@@ -289,9 +290,7 @@ export class RoutesScene extends Phaser.Scene {
       })),
       defaultIndex: 0,
       onChange: (value) => {
-        this.finderScopeBand = (
-          value === "" ? null : value
-        ) as RouteScopeBand;
+        this.finderScopeBand = (value === "" ? null : value) as RouteScopeBand;
         this.refreshFinderTable();
       },
     });

--- a/src/scenes/TurnReportScene.ts
+++ b/src/scenes/TurnReportScene.ts
@@ -11,8 +11,6 @@ import {
   MilestoneOverlay,
   getLayout,
 } from "../ui/index.ts";
-import { GalacticNewsPanel } from "../ui/GalacticNewsPanel.ts";
-import { generateTickerFeed } from "../generation/news/tickerFeed.ts";
 import { autoSave } from "../game/SaveManager.ts";
 import type { TurnResult } from "../data/types.ts";
 import type { GameHUDScene } from "./GameHUDScene.ts";
@@ -493,27 +491,15 @@ export class TurnReportScene extends Phaser.Scene {
     }
 
     // -----------------------------------------------------------------------
-    // Bottom row: Galactic News Network (left) + Market Changes (right)
+    // Bottom row: Market Changes (full width — ticker moved to global HUD)
     // -----------------------------------------------------------------------
     const bottomY =
       aiSummaries.length > 0 ? TR_AI_Y + TR_AI_H + TR_GAP : TR_AI_Y;
-    const halfWidth = L.mainContentWidth / 2 - 5;
 
-    // Galactic News Network ticker (bottom-left)
-    const tickerItems = generateTickerFeed(state, lastTurn);
-    new GalacticNewsPanel(this, {
+    const marketPanel = new Panel(this, {
       x: L.mainContentLeft,
       y: bottomY,
-      width: halfWidth,
-      height: TR_BOTTOM_H,
-      items: tickerItems,
-    });
-
-    // Market Changes (bottom-right)
-    const marketPanel = new Panel(this, {
-      x: L.mainContentLeft + L.mainContentWidth / 2 + 5,
-      y: bottomY,
-      width: halfWidth,
+      width: L.mainContentWidth,
       height: TR_BOTTOM_H,
       title: "Market Changes",
     });
@@ -533,11 +519,11 @@ export class TurnReportScene extends Phaser.Scene {
     );
     marketPanel.add(fuelLabel);
 
-    // Show summary of cargo delivered this turn
+    // Show summary of cargo delivered this turn (more rows now that panel is full width)
     const cargoEntries = Object.entries(lastTurn.cargoDelivered)
       .filter(([, amount]) => amount > 0)
       .sort((a, b) => (b[1] as number) - (a[1] as number))
-      .slice(0, 3);
+      .slice(0, 6);
     let marketY = mpContent.y + 32;
     if (cargoEntries.length > 0) {
       const cargoHeader = this.add.text(
@@ -553,10 +539,14 @@ export class TurnReportScene extends Phaser.Scene {
       marketPanel.add(cargoHeader);
       marketY += 20;
 
-      for (const [cargoType, amount] of cargoEntries) {
+      const colCount = Math.min(3, cargoEntries.length);
+      const colWidth = Math.floor(mpContent.width / colCount);
+      cargoEntries.forEach(([cargoType, amount], idx) => {
+        const col = idx % colCount;
+        const row = Math.floor(idx / colCount);
         const cargoLine = this.add.text(
-          mpContent.x + 16,
-          marketY,
+          mpContent.x + 8 + col * colWidth,
+          marketY + row * 18,
           `${cargoType}: ${(amount as number).toLocaleString("en-US")} units`,
           {
             fontSize: `${theme.fonts.caption.size}px`,
@@ -565,8 +555,8 @@ export class TurnReportScene extends Phaser.Scene {
           },
         );
         marketPanel.add(cargoLine);
-        marketY += 18;
-      }
+      });
+      marketY += Math.ceil(cargoEntries.length / colCount) * 18;
     }
 
     if (lastTurn.passengersTransported > 0) {

--- a/src/ui/HorizontalNewsTicker.ts
+++ b/src/ui/HorizontalNewsTicker.ts
@@ -1,0 +1,118 @@
+import * as Phaser from "phaser";
+import { getTheme, colorToString } from "./index.ts";
+import type { TickerItem } from "../generation/news/types.ts";
+import { CATEGORY_META } from "../generation/news/categories.ts";
+
+const SCROLL_SPEED = 80; // px per second
+const ITEM_SEPARATOR = "   •   ";
+const FONT_SIZE = 11;
+
+function buildMarqueeString(items: TickerItem[]): string {
+  if (items.length === 0)
+    return "GALACTIC NEWS NETWORK — Stand by for updates…";
+  return items
+    .map((item) => {
+      const badge = CATEGORY_META[item.category]?.badge ?? "GNN";
+      return `[${badge}] ${item.text}`;
+    })
+    .join(ITEM_SEPARATOR);
+}
+
+/**
+ * Persistent horizontal news crawl rendered in GameHUDScene's ticker strip.
+ * Items scroll right-to-left at a constant speed, looping continuously.
+ */
+export class HorizontalNewsTicker {
+  private readonly scene: Phaser.Scene;
+  private readonly x: number;
+  private readonly y: number;
+  private readonly width: number;
+  private readonly height: number;
+
+  private maskShape: Phaser.GameObjects.Graphics | null = null;
+  private marqueeText: Phaser.GameObjects.Text | null = null;
+  private scrollTween: Phaser.Tweens.Tween | null = null;
+
+  constructor(
+    scene: Phaser.Scene,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  ) {
+    this.scene = scene;
+    this.x = x;
+    this.y = y;
+    this.width = width;
+    this.height = height;
+
+    this.buildMask();
+  }
+
+  private buildMask(): void {
+    this.maskShape = this.scene.add.graphics();
+    this.maskShape.fillStyle(0xffffff, 1);
+    this.maskShape.fillRect(this.x, this.y, this.width, this.height);
+    this.maskShape.setVisible(false);
+  }
+
+  updateItems(items: TickerItem[]): void {
+    this.scrollTween?.stop();
+    this.scrollTween = null;
+    this.marqueeText?.destroy();
+    this.marqueeText = null;
+
+    const theme = getTheme();
+    const text = buildMarqueeString(items);
+
+    // Determine color from first item, fall back to textDim.
+    const firstColor =
+      items.length > 0
+        ? (items[0].color ?? theme.colors.textDim)
+        : theme.colors.textDim;
+
+    const textY = this.y + this.height / 2;
+
+    this.marqueeText = this.scene.add.text(this.x + this.width, textY, text, {
+      fontSize: `${FONT_SIZE}px`,
+      fontFamily: "monospace",
+      color: colorToString(firstColor),
+    });
+    this.marqueeText.setOrigin(0, 0.5);
+    this.marqueeText.setDepth(300);
+
+    // Apply mask so text doesn't bleed outside the strip.
+    if (this.maskShape) {
+      const geomMask = this.maskShape.createGeometryMask();
+      this.marqueeText.setMask(geomMask);
+    }
+
+    const textWidth = this.marqueeText.width;
+    const totalTravel = this.width + textWidth;
+    const duration = (totalTravel / SCROLL_SPEED) * 1000;
+
+    // Scroll from right edge to fully off-screen left, then repeat.
+    this.scrollTween = this.scene.tweens.add({
+      targets: this.marqueeText,
+      x: this.x - textWidth,
+      duration,
+      ease: "Linear",
+      repeat: -1,
+      onRepeat: () => {
+        // Reset to right edge for next cycle.
+        if (this.marqueeText) {
+          this.marqueeText.setX(this.x + this.width);
+        }
+      },
+    });
+  }
+
+  destroy(): void {
+    this.scrollTween?.stop();
+    this.scrollTween = null;
+    this.marqueeText?.destroy();
+    this.marqueeText = null;
+    this.maskShape?.destroy();
+    this.maskShape = null;
+  }
+}


### PR DESCRIPTION
## Summary

- **Persistent news ticker**: New `HorizontalNewsTicker` component renders a TV-style scrolling crawl in a 20px strip below the bottom bar — always visible across planning/simulation/review phases, not just `TurnReportScene`.
- **Dilemma stays on screen**: `GameHUDScene.switchContentScene()` no longer stops `DilemmaScene` when transitioning SimPlayback → TurnReport while a dilemma is still pending — it lets the scene close itself once the player picks an option.
- **Dilemma fits the viewport**: Shrunk banner (180→80) and option cards (116→90) so a 3-option dilemma is ~564px tall (was ~750px, overflowing the 720px canvas).
- **TurnReportScene QA**: Removed the now-redundant `GalacticNewsPanel`; expanded **Market Changes** to span the full content width with a 3-column cargo grid showing up to 6 rows.

## Layout changes

`LayoutMetrics` gains `hudTickerHeight: 20` and `hudBottomBarTop`. Bottom bar moves from y=668 to y=648; ticker strip occupies y=700–720. Content height drops by 20px (612 → 592), inherited by every scene via `getLayout()`.

## Test plan

- [x] `npm run check` passes (typecheck + 824 tests + production build)
- [x] Verified ticker is visible at bottom of `GameHUDScene` — "GALACTIC NEWS NETWORK — Stand by for updates…" placeholder scrolls until first turn completes
- [x] No console errors/warnings in dev mode
- [ ] Trigger a dilemma event mid-turn and confirm the modal stays on screen during SimPlayback → TurnReport transition
- [ ] Confirm Choose button closes the dilemma cleanly and pending dilemmas chain correctly
- [ ] Resize to ~960px width and confirm ticker + dilemma still lay out correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)