### PR TITLE
fix(audio): preserve user-gesture activation when starting BGM

### DIFF
--- a/src/audio/AudioDirector.ts
+++ b/src/audio/AudioDirector.ts
@@ -417,10 +417,17 @@ class AudioDirector {
   async resume(): Promise<void> {
     this.ensureInitialized();
     if (!this.ctx) return;
+
+    // Invoke play() synchronously inside the user-gesture task so Chrome's
+    // autoplay policy keeps user activation. Awaiting ctx.resume() first
+    // revokes activation and causes play() to reject with NotAllowedError.
+    const bgmPromise = this.playExternalBgmIfNeeded();
+
     if (this.ctx.state === "suspended") {
       await this.ctx.resume();
     }
-    await this.playExternalBgmIfNeeded();
+
+    await bgmPromise;
   }
 
   setMusicState(state: MusicState): void {
@@ -1021,7 +1028,7 @@ class AudioDirector {
         EXTERNAL_BGM_PLAYLIST[this.externalBgmTrackIndex].url,
       );
       bgm.loop = false;
-      bgm.preload = "metadata"; // fetch only headers at init; stream on play
+      bgm.preload = "none"; // fetch happens lazily inside load()/play()
       bgm.volume = 0;
       bgm.addEventListener("ended", () => this.onExternalTrackEnded());
       this.externalBgm = bgm;


### PR DESCRIPTION
## Summary

- **Root cause:** in `AudioDirector.resume()`, awaiting `ctx.resume()` *before* invoking `audio.play()` revokes Chrome's user-activation token across the await boundary. `play()` then rejects with `NotAllowedError`, which is silently swallowed (intentionally — real autoplay blocks should also be silent).
- **Why #85 didn't fix it:** the previous patch added `load()` before `play()` but didn't change the call order. Manual track switching worked because `switchExternalTrack()` invokes `play()` synchronously inside the click handler with no preceding await — so user activation was preserved on that path only.
- **Fix:** kick off `playExternalBgmIfNeeded()` synchronously at the top of `resume()`, then await `ctx.resume()` and the play promise in parallel. `HTMLAudioElement.play()` and `AudioContext.resume()` are independent audio paths — order swap is safe.
- **Bonus:** swapped `preload="metadata"` → `preload="none"` so we no longer kick off the initial range fetch that shows up as the aborted `206 Partial Content` in production HARs. The fetch now happens lazily inside `load()`/`play()` like everywhere else.

Reported symptom matches exactly: BGM never starts on page load, but opening the music menu and clicking "next track" makes everything play correctly.

## Test plan

- [x] `npm run check` — typecheck (0 errors), 824 tests pass, production build clean
- [x] Dev-server smoke test — confirmed `.play()` now triggers a real network fetch on first click (it didn't before, because `NotAllowedError` short-circuited it). Headless preview can't actually play audio (Chrome treats headless tabs as backgrounded for media), but the failure mode shifted from "no fetch" to "fetch then `AbortError`" — strong structural evidence the gesture handoff is fixed.
- [ ] **Manual verification on production / staging recommended:** the bug only reproduces with a real foregrounded tab against the CDN that serves 206 partial-range responses (`cdn.cat-herding.net`). Vite dev serves full files and headless Chrome auto-pauses media regardless.
- [x] Manual track switching path unchanged (`switchExternalTrack` untouched), so existing behavior is preserved.

## Reviewer notes

- The `NotAllowedError` filter at line 1048 stays — autoplay blocks on browsers without any user activation are still a real scenario, just not the one that was biting us here.
- No changes to `staticwebapp.config.json`, the playlist, or CDN config.
- Builds on top of #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)