### PR TITLE
fix(ui): restore clipping masks broken by Phaser 4 API mismatch

### DIFF
--- a/packages/spacebiz-ui/src/DataTable.ts
+++ b/packages/spacebiz-ui/src/DataTable.ts
@@ -1,6 +1,7 @@
 import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import { playUiSfx } from "./UiSound.ts";
+import { applyClippingMask } from "./MaskUtils.ts";
 
 export interface ColumnDef {
   key: string;
@@ -95,7 +96,11 @@ export class DataTable extends Phaser.GameObjects.Container {
     this.addAt(this.wheelHitArea, 0);
     this.wheelHitArea.setData("consumesWheel", true);
 
-    // Mask for body scrolling
+    // Mask for body scrolling. Prefer Phaser 4's filter-based mask, but fall
+    // back to Phaser 3's setMask(createGeometryMask) when the filters API is
+    // unavailable (e.g. during dev when node_modules is still on Phaser 3.x).
+    // Without the fallback, optional chaining silently no-ops and rows render
+    // past the table frame into surrounding UI.
     this.maskShape = scene.make.graphics({});
     this.maskShape.fillStyle(0xffffff);
     this.maskShape.fillRect(
@@ -105,7 +110,7 @@ export class DataTable extends Phaser.GameObjects.Container {
       config.height - this.headerHeight,
     );
     this.maskShape.setPosition(config.x, config.y);
-    this.bodyContainer.filters?.internal.addMask(this.maskShape);
+    applyClippingMask(this.bodyContainer, this.maskShape);
 
     // Scroll indicator (visual-only, not interactive)
     const trackHeight = config.height - this.headerHeight;
@@ -320,6 +325,13 @@ export class DataTable extends Phaser.GameObjects.Container {
     }
     this.selectedRowIndicator = null;
     this.renderBody();
+    // Force the clipping mask back to the current world position. setRows is
+    // typically called from a filter change or tab switch, both of which can
+    // leave the mask one frame stale (it's normally only resync'd on
+    // preupdate). The visible symptom: rows render correctly inside body
+    // space, but appear cropped to nothing because the mask rectangle is
+    // still aligned to the previous tab's transform.
+    this.syncMaskPosition();
   }
 
   private renderBody(): void {

--- a/packages/spacebiz-ui/src/MaskUtils.ts
+++ b/packages/spacebiz-ui/src/MaskUtils.ts
@@ -1,0 +1,35 @@
+import * as Phaser from "phaser";
+
+/**
+ * Apply a clipping geometry mask to a GameObject in a way that works on both
+ * Phaser 4 (filter-based mask) and Phaser 3 (legacy `setMask` API).
+ *
+ * Why: this codebase targets Phaser 4 (`filters?.internal.addMask(...)`), but
+ * during dev / CI / installs that lag behind the lockfile, `node_modules`
+ * may resolve to Phaser 3.x where `filters` is `undefined` and the optional
+ * chain silently no-ops. Without a fallback, masks never apply and content
+ * (table rows, portrait stats) renders outside its frame.
+ */
+export function applyClippingMask(
+  target: Phaser.GameObjects.GameObject,
+  maskShape: Phaser.GameObjects.Graphics,
+): void {
+  // Phaser 4: filter-based mask
+  const filters = (
+    target as unknown as {
+      filters?: { internal?: { addMask?: (m: unknown) => void } };
+    }
+  ).filters;
+  if (filters?.internal?.addMask) {
+    filters.internal.addMask(maskShape);
+    return;
+  }
+
+  // Phaser 3: classic geometry mask
+  const t = target as unknown as {
+    setMask?: (mask: Phaser.Display.Masks.GeometryMask) => unknown;
+  };
+  if (typeof t.setMask === "function") {
+    t.setMask(maskShape.createGeometryMask());
+  }
+}

--- a/packages/spacebiz-ui/src/ScrollableList.ts
+++ b/packages/spacebiz-ui/src/ScrollableList.ts
@@ -1,5 +1,6 @@
 import * as Phaser from "phaser";
 import { getTheme } from "./Theme.ts";
+import { applyClippingMask } from "./MaskUtils.ts";
 
 export interface ScrollableListConfig {
   x: number;
@@ -45,7 +46,7 @@ export class ScrollableList extends Phaser.GameObjects.Container {
     this.maskGraphics.setPosition(config.x, config.y);
 
     this.contentContainer = scene.add.container(0, 0);
-    this.contentContainer.filters?.internal.addMask(this.maskGraphics);
+    applyClippingMask(this.contentContainer, this.maskGraphics);
     this.add(this.contentContainer);
 
     // Wheel capture area (kept behind list content so it doesn't block row clicks)

--- a/packages/spacebiz-ui/src/index.ts
+++ b/packages/spacebiz-ui/src/index.ts
@@ -53,6 +53,8 @@ export type { TabGroupConfig, TabConfig } from "./TabGroup.ts";
 export { DataTable } from "./DataTable.ts";
 export type { DataTableConfig, ColumnDef } from "./DataTable.ts";
 
+export { applyClippingMask } from "./MaskUtils.ts";
+
 // Ambient / visual effects
 export { createStarfield } from "./Starfield.ts";
 export type { StarfieldConfig } from "./Starfield.ts";

--- a/src/ui/PortraitPanel.ts
+++ b/src/ui/PortraitPanel.ts
@@ -22,6 +22,7 @@ import { getPlanetPortraitTextureKey } from "../data/planetPortraits.ts";
 import { getPortraitTextureKey } from "../data/portraits.ts";
 import { getLeaderTextureKey } from "../data/empireLeaderPortraits.ts";
 import { portraitLoader } from "../game/PortraitLoader.ts";
+import { applyClippingMask } from "@spacebiz/ui";
 
 function fitImageContain(
   image: Phaser.GameObjects.Image,
@@ -51,9 +52,12 @@ export class PortraitPanel extends Phaser.GameObjects.Container {
   private portraitWidth: number;
   private portraitHeight: number;
   private panelWidth: number;
+  private panelHeight: number;
+  private statRowSpacing: number;
 
-  // portrait area = top 55% of content area
-  // name + stats = bottom 45%
+  // Portrait image area + name/stats area share the panel height. Ratio is
+  // tuned so a 9-stat list (RoutesScene route opportunity) still fits at the
+  // smallest sidebar height (~454px when a 158px minimap is reserved).
 
   constructor(scene: Phaser.Scene, config: PortraitPanelConfig) {
     super(scene, config.x, config.y);
@@ -64,7 +68,9 @@ export class PortraitPanel extends Phaser.GameObjects.Container {
     const panelHeight = config.height ?? L.contentHeight;
 
     this.portraitWidth = this.panelWidth - theme.spacing.sm * 2;
-    this.portraitHeight = Math.floor(panelHeight * 0.55);
+    this.portraitHeight = Math.floor(panelHeight * 0.5);
+    this.panelHeight = panelHeight;
+    this.statRowSpacing = 20;
     this.statLabels = [];
 
     // Glass-styled panel background
@@ -87,7 +93,9 @@ export class PortraitPanel extends Phaser.GameObjects.Container {
     // Created on demand in updatePortrait when a loaded texture is available
     this.portraitImage = null;
 
-    // Geometry mask to clip portrait within panel bounds (Phaser 4 Mask filter)
+    // Geometry mask to clip portrait within panel bounds. Uses applyClippingMask
+    // so the legacy Phaser 3 setMask path is reachable when the filters API
+    // isn't available (the optional chain alone silently no-ops).
     this.portraitMaskShape = scene.make.graphics({});
     this.portraitMaskShape.fillStyle(0xffffff, 1);
     this.portraitMaskShape.fillRect(
@@ -96,7 +104,7 @@ export class PortraitPanel extends Phaser.GameObjects.Container {
       this.portraitWidth,
       this.portraitHeight,
     );
-    this.portraitGraphics.filters?.internal.addMask(this.portraitMaskShape);
+    applyClippingMask(this.portraitGraphics, this.portraitMaskShape);
 
     // Name label — below portrait area, centered, heading + accent
     const nameLabelY =
@@ -114,11 +122,13 @@ export class PortraitPanel extends Phaser.GameObjects.Container {
     scene.children.remove(this.nameLabel);
     this.add(this.nameLabel);
 
-    // Clip all content (stats, name, portrait) to panel bounds (Phaser 4 Mask filter)
+    // Clip all content (stats, name, portrait) to panel bounds. Without this
+    // (working) clip mask, long stat lists overflow the panel into the minimap
+    // below. Falls back to Phaser 3 setMask when filters isn't available.
     const clipShape = scene.make.graphics({});
     clipShape.fillStyle(0xffffff, 1);
     clipShape.fillRect(config.x, config.y, this.panelWidth, panelHeight);
-    this.filters?.internal.addMask(clipShape);
+    applyClippingMask(this, clipShape);
 
     scene.add.existing(this);
   }
@@ -154,7 +164,7 @@ export class PortraitPanel extends Phaser.GameObjects.Container {
           theme.spacing.sm + this.portraitHeight / 2,
           texKey,
         );
-        this.portraitImage.filters?.internal.addMask(this.portraitMaskShape);
+        applyClippingMask(this.portraitImage, this.portraitMaskShape);
         this.add(this.portraitImage);
       } else {
         this.portraitImage.setTexture(texKey);
@@ -350,12 +360,23 @@ export class PortraitPanel extends Phaser.GameObjects.Container {
       theme.spacing.md +
       this.nameLabel.height;
     const startY = nameLabelBottom + theme.spacing.sm;
-    const rowSpacing = 24;
+    const rowSpacing = this.statRowSpacing;
     const leftX = theme.spacing.md;
     const rightX = this.panelWidth - theme.spacing.md;
+    // Cap how many rows we draw so stats can't extend past the panel into
+    // whatever sits below it (e.g. the routes-screen minimap). The clipping
+    // mask is the visual safety net; this is the layout-time guard.
+    const maxRowsByHeight = Math.max(
+      0,
+      Math.floor((this.panelHeight - startY - theme.spacing.sm) / rowSpacing),
+    );
+    const visibleStats = stats.slice(
+      0,
+      Math.min(stats.length, maxRowsByHeight),
+    );
 
-    for (let i = 0; i < stats.length; i++) {
-      const stat = stats[i];
+    for (let i = 0; i < visibleStats.length; i++) {
+      const stat = visibleStats[i];
       const rowY = startY + i * rowSpacing;
 
       // Label (left-aligned, caption style, textDim)


### PR DESCRIPTION
## Summary

Restores clipping behavior for the route table, scrollable lists, and the portrait panel — fixes the Route Finder UI issues from the Q1Y1 screenshot:

- Table rows render through the *Create Route* button and past the panel border (mask wasn't clipping).
- Portrait stat rows overflow into the routes minimap below the sidebar.
- Filters occasionally leave an empty grid until a different action triggers a re-render.

## Root cause

`DataTable`, `ScrollableList`, and `PortraitPanel` used Phaser 4's filter-based mask API:

```ts
container.filters?.internal.addMask(maskShape)
```

When `node_modules/phaser` is still on Phaser 3.x (e.g. when a lockfile bump to `phaser@4` hasn't been followed by `npm install`), `container.filters` is `undefined` and the optional chain silently no-ops — **no mask is ever applied**.

## What changed

- New `applyClippingMask()` helper in [`packages/spacebiz-ui/src/MaskUtils.ts`](packages/spacebiz-ui/src/MaskUtils.ts) — tries the Phaser 4 filter path first, falls back to Phaser 3's `setMask(createGeometryMask())`.
- `DataTable.ts`, `ScrollableList.ts`, and `PortraitPanel.ts` now route their masks through the helper.
- `DataTable.setRows()` resyncs the mask position synchronously after a render, so filter changes / tab switches can't leave the mask one frame stale (visible symptom: rows render but appear cropped to nothing).
- `PortraitPanel`: portrait image area trimmed from 55% → 50% of panel height; stat row spacing 24 → 20px; row count clamped to what actually fits inside `panelHeight`. The clip mask is the visual safety net; the row cap is the layout-time guarantee that 9-stat lists fit at 720p.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test` (vitest) — 824/824 passing
- [x] `npx eslint` on touched files — clean
- [ ] Manual: open Route Finder, confirm rows clip at the *Create Route* button row
- [ ] Manual: select a route, confirm stat rows stop above the minimap
- [ ] Manual: change filters rapidly, confirm grid never goes empty until you've genuinely filtered everything out
- [ ] Manual: switch tabs (Route Finder ↔ Active Routes) and back, confirm rows are visible immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)