### PR TITLE
fix(audio): register first-gesture listener at window level (BGM still not starting)

### DIFF
--- a/src/audio/AudioDirector.ts
+++ b/src/audio/AudioDirector.ts
@@ -339,15 +339,30 @@ class AudioDirector {
   private scoreTimerId: number | null = null;
 
   private game: Phaser.Game | null = null;
+  private firstGestureListenerInstalled = false;
 
   attachScene(scene: Phaser.Scene): void {
     this.game = scene.game;
     this.ensureInitialized();
+    this.installFirstGestureListener();
+  }
 
-    // Unlock audio context on the first user gesture.
-    scene.input.once("pointerdown", () => {
+  // Register a window-level gesture listener. attachScene() runs in BootScene,
+  // which transitions away ~200ms after preload — a per-scene listener almost
+  // never fires before being torn down, so resume() never runs and BGM never
+  // starts on auto-load. A DOM listener survives scene transitions.
+  private installFirstGestureListener(): void {
+    if (this.firstGestureListenerInstalled) return;
+    if (typeof window === "undefined") return;
+    this.firstGestureListenerInstalled = true;
+
+    const handler = (): void => {
       void this.resume();
-    });
+    };
+    const opts: AddEventListenerOptions = { once: true, capture: true };
+    window.addEventListener("pointerdown", handler, opts);
+    window.addEventListener("keydown", handler, opts);
+    window.addEventListener("touchstart", handler, { ...opts, passive: true });
   }
 
   setEnabled(enabled: boolean): void {

--- a/src/audio/AudioDirector.ts
+++ b/src/audio/AudioDirector.ts
@@ -417,10 +417,17 @@ class AudioDirector {
   async resume(): Promise<void> {
     this.ensureInitialized();
     if (!this.ctx) return;
+
+    // Invoke play() synchronously inside the user-gesture task so Chrome's
+    // autoplay policy keeps user activation. Awaiting ctx.resume() first
+    // revokes activation and causes play() to reject with NotAllowedError.
+    const bgmPromise = this.playExternalBgmIfNeeded();
+
     if (this.ctx.state === "suspended") {
       await this.ctx.resume();
     }
-    await this.playExternalBgmIfNeeded();
+
+    await bgmPromise;
   }
 
   setMusicState(state: MusicState): void {
@@ -1021,7 +1028,7 @@ class AudioDirector {
         EXTERNAL_BGM_PLAYLIST[this.externalBgmTrackIndex].url,
       );
       bgm.loop = false;
-      bgm.preload = "metadata"; // fetch only headers at init; stream on play
+      bgm.preload = "none"; // fetch happens lazily inside load()/play()
       bgm.volume = 0;
       bgm.addEventListener("ended", () => this.onExternalTrackEnded());
       this.externalBgm = bgm;


### PR DESCRIPTION
## Summary

Follow-up to #87. The user reported BGM still didn't auto-play after #87 landed, and **no MP3 request appeared in the network tab even after clicking** — meaning `.play()` was never being invoked.

**Root cause:** `attachScene()` is only called from `BootScene.create()`. It registered the user-gesture listener via `scene.input.once("pointerdown", ...)`. But BootScene fades out in 200ms and immediately starts MainMenuScene — the user almost never clicks during that 200ms boot screen. Once BootScene is destroyed, its Phaser input subsystem is destroyed too, and the listener never fires. `resume()` is never called, so BGM never starts.

Manual track switching kept working because clicking the music-menu button goes through a different code path (`switchExternalTrack` → `playExternalBgmIfNeeded`), and by then Chrome has lifted its autoplay block due to the user's other clicks on the page.

**Fix:** register the listener at the `window` level (pointerdown + keydown + touchstart, all `{ once: true, capture: true }`) so it survives scene transitions. The handler still calls `resume()`, which preserves user activation via the call-order swap from #87.

## Test plan

- [x] `npm run check` — typecheck (0 errors), tests pass, build clean
- [ ] **Production verification needed:** load `https://space-tycoon.cat-herding.net/` after deploy, click anywhere on the canvas after boot completes, confirm an MP3 request appears in network tab and music starts playing within ~1s. No need to open the music menu.

## Reviewer notes

- Headless preview can't reliably verify (synthetic events lack user activation, hidden tabs auto-pause media), so this is a code-reading + production-test fix.
- The previous per-scene listener registration is fully replaced — no need to keep both because the window listener fires for any pointerdown, regardless of which scene is mounted.
- `{ capture: true }` on the listeners ensures we get the event before any inner element's `stopPropagation()` could swallow it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)