### PR TITLE
fix(ui): scene-overlay opacity, advisor dismissal, intra-empire route surfacing

### DIFF
--- a/src/game/routes/RouteManager.ts
+++ b/src/game/routes/RouteManager.ts
@@ -1038,22 +1038,26 @@ export function scanAllRouteOpportunities(
   // (typically galactic luxury, often 100+ entries on a fresh standard
   // galaxy) crowd every other cargo out of the top 200 — the player then
   // sees zero raw-materials or hazmat options even though the underlying
-  // opportunities exist. We reserve a per-cargo quota first (top-K by
-  // profit per cargo type), then fill the remaining slots from the global
-  // profit-sorted tail.
+  // opportunities exist. We reserve a per-(scope × cargo) quota first so
+  // intra-empire and intra-system routes survive the truncation alongside
+  // galactic ones (galactic scope's higher revenue multiplier otherwise
+  // sweeps the top-K of every cargo bucket and leaves "Intra Empire"
+  // permanently empty for some seeds), then fill the remaining slots from
+  // the global profit-sorted tail.
   opportunities.sort((a, b) => b.estProfit - a.estProfit);
   const HARD_CAP = 200;
   if (opportunities.length <= HARD_CAP) return opportunities;
 
-  const PER_CARGO_QUOTA = 12;
+  const PER_BUCKET_QUOTA = 6;
   const reserved: RouteOpportunity[] = [];
   const overflow: RouteOpportunity[] = [];
-  const quotaUsed = new Map<CargoType, number>();
+  const quotaUsed = new Map<string, number>();
   for (const opp of opportunities) {
-    const used = quotaUsed.get(opp.bestCargoType) ?? 0;
-    if (used < PER_CARGO_QUOTA) {
+    const key = `${opp.scope}|${opp.bestCargoType}`;
+    const used = quotaUsed.get(key) ?? 0;
+    if (used < PER_BUCKET_QUOTA) {
       reserved.push(opp);
-      quotaUsed.set(opp.bestCargoType, used + 1);
+      quotaUsed.set(key, used + 1);
     } else {
       overflow.push(opp);
     }

--- a/src/game/routes/__tests__/RouteManager.test.ts
+++ b/src/game/routes/__tests__/RouteManager.test.ts
@@ -785,5 +785,30 @@ describe("RouteManager", () => {
       const missing = ALL_CARGO_TYPES.filter((c) => !seenCargoTypes.has(c));
       expect(missing).toEqual([]);
     });
+
+    // Regression for the "Missing Routes always for intra-empire" QA bug:
+    // before the per-(scope × cargo) quota, galactic routes' higher revenue
+    // multiplier swept the top-K of every cargo bucket and the 200-row cap
+    // truncated every intra-empire opportunity, leaving the "Intra Empire"
+    // filter permanently empty on some seeds.
+    it.each([1, 2, 3, 7, 42])(
+      "surfaces at least one intra-empire opportunity at game start (seed %i)",
+      (seed) => {
+        const { state } = createNewGame(seed);
+        const opps = scanAllRouteOpportunities(
+          state.galaxy.planets,
+          state.galaxy.systems,
+          state.fleet,
+          state.market,
+          state.activeRoutes,
+          state.cash,
+          state,
+        );
+        const intraEmpireCount = opps.filter(
+          (o) => o.scope === "empire",
+        ).length;
+        expect(intraEmpireCount).toBeGreaterThan(0);
+      },
+    );
   });
 });

--- a/src/scenes/DilemmaScene.ts
+++ b/src/scenes/DilemmaScene.ts
@@ -172,6 +172,17 @@ export class DilemmaScene extends Phaser.Scene {
     const theme = getTheme();
     const L = getLayout();
 
+    // Two-layer backdrop:
+    //   1. Fully opaque rect blocks GalaxyMapScene's Three.js canvas, which
+    //      kept rendering through the previous semi-transparent overlay
+    //      ("Galaxy bleeding through UI" / "2 Galaxies on bg" QA).
+    //   2. Tinted scrim on top gives the modal-overlay accent without
+    //      letting the live galaxy show through.
+    const solid = this.add
+      .rectangle(0, 0, L.gameWidth, L.gameHeight, theme.colors.background, 1)
+      .setOrigin(0, 0);
+    solid.setDepth(-1);
+
     this.overlay = this.add
       .rectangle(
         0,
@@ -179,7 +190,7 @@ export class DilemmaScene extends Phaser.Scene {
         L.gameWidth,
         L.gameHeight,
         theme.colors.modalOverlay,
-        0.78,
+        0.92,
       )
       .setOrigin(0, 0)
       .setInteractive();
@@ -326,9 +337,10 @@ export class DilemmaScene extends Phaser.Scene {
     card.setDepth(12);
     this.widgets.push(card);
 
-    // Card background
+    // Card background — opaque so neighbouring chips and copy don't read
+    // as "fighting" the panel underneath (QA: dilemma screen cluttered).
     const bg = this.add
-      .rectangle(0, 0, optionWidth, OPTION_HEIGHT, theme.colors.panelBg, 0.55)
+      .rectangle(0, 0, optionWidth, OPTION_HEIGHT, theme.colors.panelBg, 1)
       .setOrigin(0, 0)
       .setStrokeStyle(1, theme.colors.panelBorder);
     card.add(bg);
@@ -346,29 +358,19 @@ export class DilemmaScene extends Phaser.Scene {
     successPct.setOrigin(0.5, 0);
     card.add(successPct);
 
+    // The big success% above already conveys the number — suppress the
+    // bar's own inline label so we don't render "55% / 55%" stacked.
     const bar = new ProgressBar(this, {
       x: colX,
       y: colY + 28,
       width: colWidth,
-      height: 8,
+      height: 6,
       value: success,
       maxValue: 100,
       fillColor: successColor(success, theme),
+      showLabel: false,
     });
     card.add(bar);
-
-    const successHint = this.add.text(
-      colX + colWidth / 2,
-      colY + 42,
-      "outcome strength",
-      {
-        fontSize: `${theme.fonts.caption.size - 1}px`,
-        fontFamily: theme.fonts.caption.family,
-        color: colorToString(theme.colors.textDim),
-      },
-    );
-    successHint.setOrigin(0.5, 0);
-    card.add(successHint);
 
     const choose = new Button(this, {
       x: colX,

--- a/src/scenes/GameHUDScene.ts
+++ b/src/scenes/GameHUDScene.ts
@@ -926,6 +926,13 @@ export class GameHUDScene extends Phaser.Scene {
       gameStore.update({ phase: "simulation" });
       audio.setMusicState("sim");
       audio.sfx("ui_end_turn");
+      // Close + clear the Rex drawer so it doesn't sit open over the
+      // simulation playback. The state-listener-driven clear (lines
+      // 173-176) only fires once `state.turn` advances at the END of
+      // the simulation, but players want the panel out of the way the
+      // moment they hit End Turn.
+      this.adviserPanel?.clear();
+      this.updateAdviserBadge(0);
     } else if (sceneName === "TurnReportScene") {
       // Quarter summary is non-blocking — keep phase as planning so the
       // player can navigate freely while the report is on screen.

--- a/src/scenes/SimSummaryScene.ts
+++ b/src/scenes/SimSummaryScene.ts
@@ -209,6 +209,13 @@ export class SimSummaryScene extends Phaser.Scene {
     const theme = getTheme();
     const L = getLayout();
 
+    // Opaque backdrop blocks any underlying scene's renderer (e.g. the
+    // GalaxyMapScene Three.js canvas) from showing through.
+    this.add
+      .rectangle(0, 0, L.gameWidth, L.gameHeight, theme.colors.background, 1)
+      .setOrigin(0, 0)
+      .setDepth(-200);
+
     createStarfield(this);
 
     // ── Title bar ──────────────────────────────────────────

--- a/src/scenes/TurnReportScene.ts
+++ b/src/scenes/TurnReportScene.ts
@@ -70,6 +70,14 @@ export class TurnReportScene extends Phaser.Scene {
     // Auto-save after each completed turn so the player can resume later
     autoSave(state);
 
+    // Opaque backdrop FIRST, so the underlying GalaxyMapScene's Three.js
+    // canvas can't render through (QA: galaxy bleeding through UI). The
+    // starfield draws on top of it for ambience.
+    this.add
+      .rectangle(0, 0, L.gameWidth, L.gameHeight, theme.colors.background, 1)
+      .setOrigin(0, 0)
+      .setDepth(-200);
+
     // Starfield background
     createStarfield(this);
 
@@ -426,6 +434,8 @@ export class TurnReportScene extends Phaser.Scene {
       ],
     });
 
+    // Top-routes panel is ~60px of content — show the best two so the rows
+    // don't overflow into "Rival Snapshot" below.
     const routeRows = routePerf
       .map((rp) => ({
         route: routeLabelMap.get(rp.routeId) ?? rp.routeId,
@@ -434,7 +444,7 @@ export class TurnReportScene extends Phaser.Scene {
         margin: rp.revenue - rp.fuelCost,
       }))
       .sort((a, b) => b.revenue - a.revenue)
-      .slice(0, 4);
+      .slice(0, 2);
     routeTable.setRows(routeRows);
 
     // -----------------------------------------------------------------------
@@ -478,6 +488,9 @@ export class TurnReportScene extends Phaser.Scene {
         ],
       });
 
+      // Cap visible rivals to what physically fits inside TR_AI_H (~42px of
+      // content). Earlier code requested 5 rows and they spilled into the
+      // Market Changes panel below (QA: "End of Turn Summary Clutter").
       const aiRows = aiSummaries
         .map((s) => ({
           name: s.companyName,
@@ -486,7 +499,7 @@ export class TurnReportScene extends Phaser.Scene {
           status: s.bankrupt ? "BANKRUPT" : "Active",
         }))
         .sort((a, b) => b.cash - a.cash)
-        .slice(0, 5);
+        .slice(0, 2);
       aiTable.setRows(aiRows);
     }
 


### PR DESCRIPTION
## Summary

QA pass covering six issues from the screenshots in the request.

- **Galaxy bleeding through dilemma / quarter summary** — the underlying `GalaxyMapScene` Three.js canvas was rendering through `DilemmaScene` (0.78-alpha overlay, no opaque backdrop) and through `TurnReportScene` / `SimSummaryScene` (only a starfield, no opaque rect). Each overlay scene now draws an opaque full-screen backdrop before any decoration.
- **Dilemma screen cluttered** — `ProgressBar` was drawing its own \"55%\" label below the heading-sized one, reading as duplicated text. Suppressed the bar's inline label, dropped the redundant \"outcome strength\" caption, and made option cards opaque against the panel.
- **End-of-turn summary cluttered** — \"Rival Snapshot\" packed 5 rows into a 42-px content area; rows spilled into the \"Market Changes\" panel below. Capped rivals at 2 and top routes at 2 so each panel's row count matches its physical height.
- **Rex advisor stays open during simulation** — the existing turn-rollover clear only fired *after* the simulation completed. `switchContentScene(\"SimPlaybackScene\")` now calls `adviserPanel.clear()` immediately so the drawer is gone the moment the player hits End Turn.
- **\"Missing Routes always for intra-empire\"** — confirmed via debug test: seeds 2 and 42 produced **zero** intra-empire opportunities. Root cause: `scanAllRouteOpportunities` reserved a per-cargo top-K before its 200-row cap, but galactic routes' higher revenue multiplier swept every cargo bucket. Switched the reservation key from `cargo` to `(scope × cargo)` (quota 6 each) so each scope band survives truncation. Regression test covers seeds 1/2/3/7/42.

## Files changed

- `src/game/routes/RouteManager.ts` — per-(scope × cargo) reservation
- `src/game/routes/__tests__/RouteManager.test.ts` — regression test for intra-empire surfacing
- `src/scenes/DilemmaScene.ts` — opaque backdrop, 0.92 scrim, opaque option cards, drop duplicate progress label
- `src/scenes/GameHUDScene.ts` — clear advisor on SimPlayback transition
- `src/scenes/TurnReportScene.ts` — opaque backdrop, cap rivals/routes to 2 rows each
- `src/scenes/SimSummaryScene.ts` — opaque backdrop

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run test\` 837/837 pass (5 new intra-empire seed tests included)
- [x] \`npm run build\` clean
- [ ] Manual: trigger a dilemma, confirm only one galaxy backdrop + scrim is visible
- [ ] Manual: end a turn, confirm Rex drawer disappears immediately when sim playback starts
- [ ] Manual: open Quarter Summary, confirm panels don't visually overlap
- [ ] Manual: open Route Finder → Intra Empire filter, confirm rows appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)