### PR TITLE
style: format GalaxyMapScene.ts to fix CI prettier check

### DIFF
--- a/src/scenes/GalaxyMapScene.ts
+++ b/src/scenes/GalaxyMapScene.ts
@@ -31,10 +31,7 @@ import {
 } from "../game/routes/RouteManager.ts";
 import type { RouteTrafficVisual } from "../game/routes/RouteManager.ts";
 import { GalaxyView3D } from "./galaxy3d/GalaxyView3D.ts";
-import type {
-  ProjectedScreen,
-  Vec3,
-} from "./galaxy3d/GalaxyView3D.ts";
+import type { ProjectedScreen, Vec3 } from "./galaxy3d/GalaxyView3D.ts";
 
 import type { GameHUDScene } from "./GameHUDScene.ts";
 import type { Empire, GameState, Ship, StarSystem } from "../data/types.ts";


### PR DESCRIPTION
## Summary
- Fixes the failing `Quality gates` CI job on `main` (run [25014274126](https://github.com/ianlintner/space-tycoon/actions/runs/25014274126/job/73257857550)).
- Root cause: `prettier --check` failed on `src/scenes/GalaxyMapScene.ts` (multiline type import that prettier wanted on a single line).
- Ran `prettier --write` to apply the canonical formatting; snip no logic changes.

## Verification
- `npm run check` (typecheck + lint + format:check + test + build) passes locally.

## Diff
1 file changed, 1 insertion(+), 4 deletions(-) — `src/scenes/GalaxyMapScene.ts` type import collapsed onto one line.