### PR TITLE
fix(galaxy): destroy SimPlayback 3D canvas on shutdown

### DIFF
--- a/src/scenes/SimPlaybackScene.ts
+++ b/src/scenes/SimPlaybackScene.ts
@@ -617,6 +617,14 @@ export class SimPlaybackScene extends Phaser.Scene {
 
     // No dual-camera filter needed — the HUD chrome and ships all render on
     // the single Phaser camera; the 3D galaxy renders on its own canvas.
+
+    // Wire teardown via the SHUTDOWN event. Phaser's Systems.shutdown only
+    // emits this event — it does NOT auto-invoke a `shutdown()` method on
+    // user Scene classes. Without this listener the 3D galaxy canvas would
+    // leak into the DOM every turn, stacking up behind GalaxyMapScene.
+    const cleanup = (): void => this.cleanup();
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, cleanup);
+    this.events.once(Phaser.Scenes.Events.DESTROY, cleanup);
   }
 
   // ── Speed control ─────────────────────────────────────────────────────────
@@ -751,7 +759,15 @@ export class SimPlaybackScene extends Phaser.Scene {
     }
   }
 
-  shutdown(): void {
+  /**
+   * Tear down the playback scene's owned resources. Registered via
+   * `events.once("shutdown", ...)` in create() because Phaser does NOT call
+   * a user-defined `shutdown()` method on the Scene class — Systems.shutdown
+   * only emits the SHUTDOWN event. A regular method here would be dead code,
+   * leaking the 3D galaxy canvas every turn (visible as two galaxies stacked
+   * once the player returns to GalaxyMapScene).
+   */
+  private cleanup(): void {
     for (const ps of this.playbackShips) {
       ps.mainSprite.destroy();
       ps.glow.destroy();

--- a/src/scenes/galaxy3d/GalaxyView3D.ts
+++ b/src/scenes/galaxy3d/GalaxyView3D.ts
@@ -154,6 +154,15 @@ export class GalaxyView3D {
     if (!parent.style.position) {
       parent.style.position = "relative";
     }
+    // Defensive: remove any orphaned 3D galaxy canvases that a previous scene
+    // failed to clean up. There can only ever be one active galaxy view at a
+    // time, so a stale sibling here is always a leak (e.g. a Scene whose
+    // shutdown handler didn't fire). Without this, the new canvas would
+    // stack on top of the orphan and the player would see two galaxies.
+    const orphans = parent.querySelectorAll<HTMLCanvasElement>(
+      `.${GALAXY_3D_CANVAS_CLASS}`,
+    );
+    orphans.forEach((el) => el.remove());
     parent.appendChild(this.canvas);
 
     this.renderer = new THREE.WebGLRenderer({


### PR DESCRIPTION
## Bug
After running a turn, the Galaxy screen shows **two galaxies** stacked on top of each other.

## Root cause
`SimPlaybackScene` defined a `shutdown(): void` method intended to destroy its `GalaxyView3D` instance. **Phaser does not call user-defined `shutdown()` methods on Scene classes.** `Phaser.Scenes.Systems.shutdown` only emits the `SHUTDOWN` event — every other content scene in the project hooks into it via `this.events.once('shutdown', ...)`. `SimPlaybackScene` was the only outlier, so its Three.js canvas leaked into the DOM every turn. When the player returned to `GalaxyMapScene`, a fresh canvas was appended on top of the orphan, producing two visible galaxies.

## Fix
1. **`SimPlaybackScene`**: rename `shutdown()` → `cleanup()` (private) and register it via `events.once(SHUTDOWN/DESTROY, cleanup)` at the end of `create()`, matching the pattern used elsewhere in the codebase (e.g. `GalaxyMapScene`).
2. **`GalaxyView3D` constructor**: defensively remove any orphaned `.galaxy-3d-canvas` siblings from the parent before mounting. There can only ever be one active galaxy view, so a stale sibling is always a leak.

The defensive cleanup also guards against future regressions if another scene forgets to wire its shutdown handler.

## Verification
- `npm run check` (typecheck + lint + format:check + tests + build) passes locally
- Diff: 2 files changed, +26/-1
- The `update()` loop already short-circuits when `view3D` is null, so there's no race during shutdown