### PR TITLE
fix(qa): route table mask + Rex queue cap + Quarter Summary layout

### DIFF
--- a/packages/spacebiz-ui/src/MaskUtils.ts
+++ b/packages/spacebiz-ui/src/MaskUtils.ts
@@ -9,23 +9,34 @@ import * as Phaser from "phaser";
  * may resolve to Phaser 3.x where `filters` is `undefined` and the optional
  * chain silently no-ops. Without a fallback, masks never apply and content
  * (table rows, portrait stats) renders outside its frame.
+ *
+ * Container caveat: in Phaser 4 the filter-based mask attached to a Container
+ * does not propagate to its child renderables, so DataTable rows escape the
+ * frame on scroll. For Containers we fall through to the legacy
+ * `setMask(createGeometryMask())` path which still functions in Phaser 4
+ * (deprecation warning is acceptable and recognised by the team).
  */
 export function applyClippingMask(
   target: Phaser.GameObjects.GameObject,
   maskShape: Phaser.GameObjects.Graphics,
 ): void {
-  // Phaser 4: filter-based mask
-  const filters = (
-    target as unknown as {
-      filters?: { internal?: { addMask?: (m: unknown) => void } };
+  const isContainer = target instanceof Phaser.GameObjects.Container;
+
+  // Phaser 4 filter masks don't clip Container children — use the legacy
+  // geometry mask path for Containers, which clips descendants correctly.
+  if (!isContainer) {
+    const filters = (
+      target as unknown as {
+        filters?: { internal?: { addMask?: (m: unknown) => void } };
+      }
+    ).filters;
+    if (filters?.internal?.addMask) {
+      filters.internal.addMask(maskShape);
+      return;
     }
-  ).filters;
-  if (filters?.internal?.addMask) {
-    filters.internal.addMask(maskShape);
-    return;
   }
 
-  // Phaser 3: classic geometry mask
+  // Phaser 3 / Phaser 4 Container fallback: classic geometry mask
   const t = target as unknown as {
     setMask?: (mask: Phaser.Display.Masks.GeometryMask) => unknown;
   };

--- a/src/game/adviser/AdviserEngine.ts
+++ b/src/game/adviser/AdviserEngine.ts
@@ -211,7 +211,8 @@ export function checkTutorialAdvancement(
     ...adviser,
     tutorialStepIndex: nextIndex,
     tutorialComplete: isComplete,
-    pendingMessages: [...adviser.pendingMessages, msg],
+    // Cap the queue defensively (matches TurnSimulator).
+    pendingMessages: [...adviser.pendingMessages, msg].slice(-12),
   };
 }
 

--- a/src/game/simulation/TurnSimulator.ts
+++ b/src/game/simulation/TurnSimulator.ts
@@ -677,7 +677,10 @@ export function simulateTurn(state: GameState, rng: SeededRNG): GameState {
   };
 
   // ----- Step 11b: Generate adviser messages -----
+  // Cap the queue so a player who never opens Rex's drawer doesn't accumulate
+  // 30+ stale messages over many turns.
   const adviserMessages = generateTurnMessages(nextState, turnResult);
+  const ADVISER_QUEUE_CAP = 12;
   nextState = {
     ...nextState,
     adviser: {
@@ -685,7 +688,7 @@ export function simulateTurn(state: GameState, rng: SeededRNG): GameState {
       pendingMessages: [
         ...nextState.adviser.pendingMessages,
         ...adviserMessages,
-      ],
+      ].slice(-ADVISER_QUEUE_CAP),
     },
   };
 

--- a/src/scenes/GameHUDScene.ts
+++ b/src/scenes/GameHUDScene.ts
@@ -169,11 +169,18 @@ export class GameHUDScene extends Phaser.Scene {
     const state = gameStore.getState();
     // Clear stale adviser messages when the turn advances. Without this the
     // drawer accumulates dozens of messages across turns and the player has
-    // to mash Next to dismiss them all.
+    // to mash Next to dismiss them all. We also wipe `state.adviser
+    // .pendingMessages` so the queue doesn't keep growing in the background
+    // (Rex was reaching 30+ announcements after a few turns).
     if (state.turn !== this.lastSeenTurn && this.adviserPanel) {
       this.lastSeenTurn = state.turn;
       this.adviserPanel.clear();
       this.updateAdviserBadge(0);
+      if (state.adviser.pendingMessages.length > 0) {
+        gameStore.update({
+          adviser: { ...state.adviser, pendingMessages: [] },
+        });
+      }
     }
     this.updateHUD();
     this.maybeShowDilemma();

--- a/src/scenes/TurnReportScene.ts
+++ b/src/scenes/TurnReportScene.ts
@@ -63,7 +63,7 @@ export class TurnReportScene extends Phaser.Scene {
     //   - Market:       72 →  20 content, fuel-price line only (cargo +
     //                  passengers detail moved to the global ticker).
     const TR_GAP = 8;
-    const TR_PL_H = 192;
+    const TR_PL_H = 220;
     const TR_ROUTE_H = 152;
     const TR_AI_H = 152;
     const TR_BOTTOM_H = 72;
@@ -303,20 +303,22 @@ export class TurnReportScene extends Phaser.Scene {
     });
 
     // ── Performance grade badge ────────────────────────────────────────────
+    // Lives in the panel title bar (top-right) so it never overlaps P&L rows.
     const { grade, color: gradeColor } = getTurnGrade(
       lastTurn.netProfit,
       lastTurn.revenue,
     );
+    const titleBarH = theme.panel.titleHeight;
     const gradeLabel = this.add
-      .text(plContent.x + plContent.width - 8, plContent.y + 4, grade, {
-        fontSize: "42px",
+      .text(L.mainContentWidth - theme.spacing.md, titleBarH / 2, grade, {
+        fontSize: "24px",
         fontFamily: theme.fonts.heading.family,
         fontStyle: "bold",
         color: "#" + gradeColor.toString(16).padStart(6, "0"),
         stroke: "#000000",
-        strokeThickness: 3,
+        strokeThickness: 2,
       })
-      .setOrigin(1, 0)
+      .setOrigin(1, 0.5)
       .setAlpha(0)
       .setScale(1.5);
     plPanel.add(gradeLabel);
@@ -331,17 +333,24 @@ export class TurnReportScene extends Phaser.Scene {
     });
 
     // ── Streak badge ───────────────────────────────────────────────────────
+    // Sits below the Net Profit row so the fire emoji can't overlap the cash
+    // value. TR_PL_H bumped to 220 to make room.
     const streakTurns = state.storyteller.consecutiveProfitTurns;
     if (streakTurns >= 2) {
       const streakText = `\uD83D\uDD25 ${streakTurns}-Turn Streak!`;
       const streakBadge = this.add
-        .text(plContent.x + plContent.width / 2, rowY, streakText, {
-          fontSize: `${theme.fonts.caption.size}px`,
-          fontFamily: theme.fonts.caption.family,
-          color: colorToString(theme.colors.accent),
-          stroke: "#000000",
-          strokeThickness: 2,
-        })
+        .text(
+          plContent.x + plContent.width / 2,
+          rowY + theme.fonts.value.size + 8,
+          streakText,
+          {
+            fontSize: `${theme.fonts.caption.size}px`,
+            fontFamily: theme.fonts.caption.family,
+            color: colorToString(theme.colors.accent),
+            stroke: "#000000",
+            strokeThickness: 2,
+          },
+        )
         .setOrigin(0.5, 0)
         .setAlpha(0);
       plPanel.add(streakBadge);


### PR DESCRIPTION
Fixes four QA issues in one PR.

## Route finder grid mask
`packages/spacebiz-ui/src/MaskUtils.ts` — Phaser 4 filter masks don't clip the children of a `Phaser.GameObjects.Container`, so DataTable rows escaped the panel when scrolled and 'covered the whole screen'. Now falls through to legacy `setMask(createGeometryMask())` for Container targets, which still clips correctly in Phaser 4 (the deprecation warning is expected and harmless).

## Rex 34-announcement queue
- `src/scenes/GameHUDScene.ts` — when the turn advances, also wipe `state.adviser.pendingMessages` so the queue doesn't accumulate unread messages every turn.
- `src/game/simulation/TurnSimulator.ts` + `src/game/adviser/AdviserEngine.ts` — defensive `.slice(-12)` cap on every append so even if a future scene path skips the HUD clear, the queue can't grow without bound.

## Quarter Summary layout (`src/scenes/TurnReportScene.ts`)
- Letter grade moves into the panel title bar (top-right corner), 24px instead of 42px, so it no longer overlaps the P&L rows on the right.
- 🔥 streak badge moves below the Net Profit row so the fire emoji can't cover the cash value.
- `TR_PL_H` 192 → 220 to give the streak room beneath the cash line.

## CI gates
`npm run check` passes locally (typecheck, lint, format:check, 837/837 tests, build).