### PR TITLE
feat(charters): empire-owned route slots + per-empire reputation

### DIFF
--- a/src/data/GameStore.ts
+++ b/src/data/GameStore.ts
@@ -75,6 +75,7 @@ function createDefaultState(): GameState {
     researchEvents: [],
     unlockedNavTabs: ["map", "routes", "fleet", "finance"],
     reputationTier: "unknown",
+    empireReputation: {},
   };
 }
 

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -14,7 +14,7 @@ import {
 
 // ── Save Version ───────────────────────────────────────────────
 /** Increment when GameState shape changes in a save-incompatible way */
-export const SAVE_VERSION = 6;
+export const SAVE_VERSION = 7;
 
 // ── Action Points ──────────────────────────────────────────────
 export const ACTION_POINTS_PER_TURN = 2;
@@ -89,6 +89,36 @@ export const BASE_EMPIRE_ROUTE_SLOTS = 3;
  * Each subsequent empire unlock adds another slot here (see ContractManager).
  */
 export const BASE_GALACTIC_ROUTE_SLOTS = 3;
+
+// ── Charter system (Phase 2) ─────────────────────────────────────────
+//
+// Empires own pools of route charters that companies (player + AI) lease
+// to operate routes. The legacy player-side slot caps above are no longer
+// the gating resource; charters are. Pool sizes per empire are derived
+// from `EmpirePolicyStance` (open/regulated/isolationist).
+
+/** Default route slot pool sizes by empire policy stance. */
+export const DEFAULT_EMPIRE_POOL_BY_STANCE: Record<
+  "isolationist" | "regulated" | "open",
+  { domesticTotal: number; foreignTotal: number }
+> = {
+  isolationist: { domesticTotal: 8, foreignTotal: 1 },
+  regulated: { domesticTotal: 6, foreignTotal: 2 },
+  open: { domesticTotal: 4, foreignTotal: 4 },
+};
+
+/** Player's free starter charters granted at game start (intra-system, in home empire). */
+export const STARTER_CHARTERS_AT_HOME = 2;
+
+/** Per-turn upkeep paid by holders of permanent charters. */
+export const BASE_DOMESTIC_UPKEEP = 800;
+export const BASE_FOREIGN_UPKEEP = 2500;
+
+/** Default lease length for fixed-term (auction-won) charters. */
+export const DEFAULT_AUCTION_TERM_TURNS = 8;
+
+/** Player company id used by charter holderId fields. */
+export const PLAYER_COMPANY_ID = "player";
 
 // ── Future seam: Ship-Class × Scope haul-band system ───────────
 //

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -468,6 +468,27 @@ export interface Sector {
   color: number;
 }
 
+/**
+ * An empire's stance toward foreign trade — drives default pool sizes,
+ * how many slots open per turn, and how often turmoil events trigger
+ * auctions. Distinct from `EmpireDisposition`, which tracks personality.
+ */
+export type EmpirePolicyStance = "isolationist" | "regulated" | "open";
+
+/**
+ * Pool of route charters an empire offers. Domestic = routes wholly within
+ * the empire; foreign = routes that cross the empire's border. `*Total` is
+ * the absolute capacity; `*Open` is the count currently available for grant
+ * (decremented when leased, incremented on forfeiture).
+ */
+export interface EmpireRouteSlotPool {
+  domesticTotal: number;
+  foreignTotal: number;
+  domesticOpen: number;
+  foreignOpen: number;
+  policyStance: EmpirePolicyStance;
+}
+
 export interface Empire {
   id: string;
   name: string;
@@ -477,6 +498,12 @@ export interface Empire {
   homeSystemId: string;
   leaderName: string;
   leaderPortrait: CharacterPortrait;
+  /**
+   * Route charter pool offered by this empire. Optional for backwards
+   * compatibility with v6 saves and existing empire fixtures — callers
+   * should treat `undefined` as a default pool derived from disposition.
+   */
+  routeSlotPool?: EmpireRouteSlotPool;
 }
 
 export interface StarSystem {
@@ -569,6 +596,74 @@ export interface ActiveRoute {
    * older saves.
    */
   paused?: boolean;
+  /**
+   * The charter underwriting this route. Optional for backwards compatibility
+   * with v6 saves and pre-charter routes; new routes (post-Phase 2) will
+   * always have a charter id.
+   */
+  charterId?: string;
+}
+
+/**
+ * Term of a charter. Permanent charters carry recurring per-turn upkeep and
+ * are the reward for trust-building (contract grants, starter charters).
+ * Fixed-term charters carry no upkeep but expire on a specific turn — they
+ * are the reward for opportunism (turmoil-event auctions).
+ */
+export type CharterTerm =
+  | { kind: "permanent"; upkeepPerTurn: number }
+  | { kind: "fixedTerm"; expiresOnTurn: number };
+
+/**
+ * A bid submitted into an open charter auction. Cash is escrowed at submit
+ * time; losing bids are refunded when the auction resolves.
+ */
+export interface CharterBid {
+  bidderId: string;
+  amount: number;
+  /** True for AI-generated bids; helps the UI flag visible competition. */
+  ai: boolean;
+}
+
+/**
+ * A turmoil-event-spawned auction for one charter slot. Players + AI submit
+ * sealed bids during the planning phase of `startedTurn`; the auction
+ * resolves at the end of that turn (or after `durationTurns` if multi-turn).
+ * Highest bid wins; ties broken by per-empire reputation.
+ */
+export interface CharterAuction {
+  id: string;
+  empireId: string;
+  pool: "domestic" | "foreign";
+  startedTurn: number;
+  durationTurns: number;
+  termTurns: number;
+  bids: CharterBid[];
+  status: "open" | "resolved" | "cancelled";
+  /** Set when status === "resolved". */
+  winnerId?: string;
+  /** The narrative trigger — useful for UI copy. */
+  triggerReason?: string;
+}
+
+/**
+ * A lease on one slot from an empire's route slot pool. A holder must own
+ * a matching charter (empire + pool) to operate a route through that empire.
+ * Forfeited charters return their slot to the empire pool and forfeit any
+ * `ActiveRoute` linked via `charterId`.
+ */
+export interface Charter {
+  id: string;
+  empireId: string;
+  pool: "domestic" | "foreign";
+  /** Player company id ("player") or `AICompany.id`. */
+  holderId: string;
+  grantedTurn: number;
+  term: CharterTerm;
+  /** Set when granted via contract reward. */
+  sourceContractId?: string;
+  /** Set when won at a turmoil-event auction. */
+  sourceAuctionId?: string;
 }
 
 export interface GameEvent {
@@ -774,6 +869,8 @@ export interface AICompany {
   contractsCompleted?: number;
   /** Active storyteller-fired narrative effects (buffs/debuffs) ticking down each turn. */
   activeNarrativeEffects?: ActiveAINarrativeEffect[];
+  /** Charters held by this AI company. Optional for v6-save compat. */
+  charters?: Charter[];
 }
 
 // ── Contract types ─────────────────────────────────────────
@@ -810,8 +907,21 @@ export interface Contract {
    * Optional slot-pool bonus paid out on completion. Empire-unlock and
    * trade-alliance contracts grow the galactic pool; passenger-ferry grows the
    * empire pool. Older saves (v6) without this field treat it as null.
+   *
+   * @deprecated Phase 2/3: superseded by `rewardCharter`. Existing contracts
+   * still grant slot bonuses on completion until the legacy player-side slot
+   * fields are removed.
    */
   rewardSlotBonus?: ContractSlotReward | null;
+  /**
+   * Permanent charter granted on completion. The charter is held by whoever
+   * accepted the contract (player or `aiCompanyId`). Term is always permanent
+   * with upkeep computed from the empire and pool at grant time.
+   */
+  rewardCharter?: {
+    empireId: string;
+    pool: "domestic" | "foreign";
+  } | null;
   depositPaid: number;
   status: ContractStatus;
   linkedRouteId: string | null;
@@ -1040,4 +1150,26 @@ export interface GameState {
   unlockedNavTabs: NavTabId[];
   /** Derived reputation tier */
   reputationTier: ReputationTier;
+
+  /**
+   * Per-empire reputation, keyed by empireId. Foundation for the charter system —
+   * companies build standing within each empire independently. The legacy global
+   * `reputation` field is now treated as a derived "fame" reading (see
+   * `computeFameRep` in ReputationEffects). Missing entries default to 50.
+   * Optional for backwards compatibility with v6 saves.
+   */
+  empireReputation?: Record<string, number>;
+
+  /**
+   * Active charters held by the player (and historically). AI companies hold
+   * their own charters on `AICompany.charters`. Optional for v6-save compat.
+   */
+  charters?: Charter[];
+
+  /**
+   * Open and recently-resolved charter auctions. Resolved entries stay in
+   * the array for one turn so the turn report can reference them. Optional
+   * for v6-save compat.
+   */
+  activeAuctions?: CharterAuction[];
 }

--- a/src/game/NewGameSetup.ts
+++ b/src/game/NewGameSetup.ts
@@ -9,6 +9,8 @@ import type {
   StorytellerState,
   AICompany,
   ActiveRoute,
+  Charter,
+  Empire,
   GalaxyShape as GalaxyShapeT,
   TechState,
 } from "../data/types.ts";
@@ -23,6 +25,8 @@ import {
   ACTION_POINTS_PER_TURN,
   LOCAL_ROUTE_SLOTS,
   BASE_GALACTIC_ROUTE_SLOTS,
+  STARTER_CHARTERS_AT_HOME,
+  PLAYER_COMPANY_ID,
 } from "../data/constants.ts";
 import type { GamePreset } from "../data/constants.ts";
 import { findAdjacentEmpires } from "./empire/EmpireAccessManager.ts";
@@ -352,6 +356,33 @@ export function createNewGame(
     diplomacyRng,
   );
 
+  // Phase 7: Grant the player's starter charters in their home empire.
+  // These are permanent, free (zero upkeep) — training-wheel slots that
+  // can never be forfeited for non-payment. Seeded so saves are reproducible.
+  const charterRng = new SeededRNG(seed + 7);
+  const homeEmpire = galaxyData.empires.find((e) => e.id === playerEmpireId);
+  const playerCharters: Charter[] = [];
+  if (homeEmpire?.routeSlotPool) {
+    const granted = Math.min(
+      STARTER_CHARTERS_AT_HOME,
+      homeEmpire.routeSlotPool.domesticOpen,
+    );
+    for (let i = 0; i < granted; i++) {
+      playerCharters.push({
+        id: `charter-starter-${i}-${charterRng.nextInt(0, 1_000_000)}`,
+        empireId: playerEmpireId,
+        pool: "domestic",
+        holderId: PLAYER_COMPANY_ID,
+        grantedTurn: 1,
+        term: { kind: "permanent", upkeepPerTurn: 0 },
+      });
+    }
+    homeEmpire.routeSlotPool = {
+      ...homeEmpire.routeSlotPool,
+      domesticOpen: homeEmpire.routeSlotPool.domesticOpen - granted,
+    };
+  }
+
   // Phase 5: Initialize station hub at the default starting system
   const hubRng = new SeededRNG(seed + 4);
   const availableRoomTypes = selectRunRoomTypes(hubRng);
@@ -424,6 +455,10 @@ export function createNewGame(
     researchEvents: [],
     unlockedNavTabs: ["map", "routes", "fleet", "finance"],
     reputationTier: "unknown",
+    empireReputation: Object.fromEntries(
+      galaxyData.empires.map((e: Empire) => [e.id, 50]),
+    ),
+    charters: playerCharters,
   };
 
   return { state, startingSystemOptions };

--- a/src/game/charters/CharterAuction.ts
+++ b/src/game/charters/CharterAuction.ts
@@ -1,0 +1,521 @@
+import type {
+  AICompany,
+  Charter,
+  CharterAuction,
+  CharterBid,
+  Empire,
+  GameState,
+} from "../../data/types.ts";
+import {
+  DEFAULT_AUCTION_TERM_TURNS,
+  PLAYER_COMPANY_ID,
+} from "../../data/constants.ts";
+import { getEmpireRep } from "../reputation/ReputationEffects.ts";
+import { getEmpirePool, grantCharter } from "./CharterManager.ts";
+
+/**
+ * Charter auctions. Triggered exclusively by turmoil events
+ * (empire_succession, diplomatic_crisis end, signPeace, etc.) — never on a
+ * regular cadence. Auctions are sealed-bid, single-slot, and resolve in the
+ * same turn they spawn unless `durationTurns > 1`.
+ *
+ * All functions here are pure; callers apply returned partial state.
+ */
+
+// ---------------------------------------------------------------------------
+// Pricing helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * The minimum bid an empire will entertain. Acts as a reserve price so
+ * empires don't give slots away during low-activity moments.
+ *
+ * Foreign slots are dramatically more valuable (bigger margins, fewer
+ * substitutes), so the floor scales accordingly.
+ */
+export function calculateMinBid(
+  empire: Empire,
+  pool: "domestic" | "foreign",
+): number {
+  const base = pool === "foreign" ? 25_000 : 6_000;
+  // Tariff-heavy empires charge more upfront; protectionists demand a premium.
+  const tariffMul = 1 + (empire.tariffRate ?? 0);
+  return Math.round(base * tariffMul);
+}
+
+// ---------------------------------------------------------------------------
+// Auction lifecycle
+// ---------------------------------------------------------------------------
+
+export interface StartAuctionArgs {
+  empireId: string;
+  pool: "domestic" | "foreign";
+  durationTurns?: number;
+  termTurns?: number;
+  triggerReason?: string;
+}
+
+export interface StartAuctionResult {
+  auction: CharterAuction | null;
+  /** Reason a start failed; null on success. */
+  error: null | "no-open-slot" | "unknown-empire";
+  /** New activeAuctions list (caller updates state.activeAuctions). */
+  activeAuctions: CharterAuction[];
+  /** Updated empires with the slot reserved (decremented while auction open). */
+  empires: Empire[];
+}
+
+/**
+ * Open an auction. Reserves one slot from the empire's pool while the
+ * auction is open so it cannot be granted by a separate path (contract).
+ * If the auction is cancelled, the slot is returned via `cancelAuction`.
+ */
+export function startAuction(
+  state: GameState,
+  args: StartAuctionArgs,
+): StartAuctionResult {
+  const empire = state.galaxy.empires.find((e) => e.id === args.empireId);
+  if (!empire) {
+    return {
+      auction: null,
+      error: "unknown-empire",
+      activeAuctions: state.activeAuctions ?? [],
+      empires: state.galaxy.empires,
+    };
+  }
+  const pool = getEmpirePool(empire);
+  const openField = args.pool === "foreign" ? "foreignOpen" : "domesticOpen";
+  if (pool[openField] <= 0) {
+    return {
+      auction: null,
+      error: "no-open-slot",
+      activeAuctions: state.activeAuctions ?? [],
+      empires: state.galaxy.empires,
+    };
+  }
+  const empires = state.galaxy.empires.map((e) =>
+    e.id === args.empireId
+      ? { ...e, routeSlotPool: { ...pool, [openField]: pool[openField] - 1 } }
+      : e,
+  );
+  const auction: CharterAuction = {
+    id: `auction-${args.empireId}-${args.pool}-${state.turn}-${randomSuffix()}`,
+    empireId: args.empireId,
+    pool: args.pool,
+    startedTurn: state.turn,
+    durationTurns: Math.max(1, args.durationTurns ?? 1),
+    termTurns: args.termTurns ?? DEFAULT_AUCTION_TERM_TURNS,
+    bids: [],
+    status: "open",
+    triggerReason: args.triggerReason,
+  };
+  return {
+    auction,
+    error: null,
+    activeAuctions: [...(state.activeAuctions ?? []), auction],
+    empires,
+  };
+}
+
+export interface SubmitBidResult {
+  activeAuctions: CharterAuction[];
+  /** Cash deducted from the bidder; caller subtracts this from the holder's cash. */
+  escrow: number;
+  /** Reason a bid was rejected; null on success. */
+  error:
+    | null
+    | "auction-not-found"
+    | "auction-closed"
+    | "below-min-bid"
+    | "duplicate-bidder";
+}
+
+/**
+ * Submit a single sealed bid. The same bidder cannot submit twice in the
+ * same auction — they can only outbid themselves via a new auction.
+ */
+export function submitBid(
+  state: GameState,
+  auctionId: string,
+  bid: CharterBid,
+): SubmitBidResult {
+  const auctions = state.activeAuctions ?? [];
+  const auction = auctions.find((a) => a.id === auctionId);
+  if (!auction) {
+    return {
+      activeAuctions: auctions,
+      escrow: 0,
+      error: "auction-not-found",
+    };
+  }
+  if (auction.status !== "open") {
+    return { activeAuctions: auctions, escrow: 0, error: "auction-closed" };
+  }
+  const empire = state.galaxy.empires.find((e) => e.id === auction.empireId);
+  if (empire && bid.amount < calculateMinBid(empire, auction.pool)) {
+    return { activeAuctions: auctions, escrow: 0, error: "below-min-bid" };
+  }
+  if (auction.bids.some((b) => b.bidderId === bid.bidderId)) {
+    return {
+      activeAuctions: auctions,
+      escrow: 0,
+      error: "duplicate-bidder",
+    };
+  }
+  return {
+    activeAuctions: auctions.map((a) =>
+      a.id === auctionId ? { ...a, bids: [...a.bids, bid] } : a,
+    ),
+    escrow: bid.amount,
+    error: null,
+  };
+}
+
+export interface ResolveAuctionResult {
+  /** Updated auction list (with this auction marked resolved). */
+  activeAuctions: CharterAuction[];
+  /** Updated empires (charter granted = pool stays decremented; nobody bid = slot returns). */
+  empires: Empire[];
+  /** Updated player charters; empty if AI won or nobody bid. */
+  playerCharters: Charter[];
+  /** Updated AI companies (winner gets the charter, losers get refunds). */
+  aiCompanies: AICompany[];
+  /** Cash to credit to the player (if player lost / no winner). */
+  playerRefund: number;
+  /** Winner id; null if no eligible bids. */
+  winnerId: string | null;
+  /** Term in turns the granted charter will last. */
+  termTurns: number;
+}
+
+/**
+ * Resolve an open auction. Highest bid wins; ties broken by per-empire
+ * reputation (player rep is from `state.empireReputation`, AI reputation
+ * from `AICompany.reputation`). The winner gets a fixed-term charter that
+ * expires `termTurns` turns from now. Losers get their bid escrow refunded.
+ *
+ * If no eligible bids, the auction is cancelled and the slot returns to
+ * the empire pool.
+ */
+export function resolveAuction(
+  state: GameState,
+  auctionId: string,
+): ResolveAuctionResult {
+  const auctions = state.activeAuctions ?? [];
+  const auction = auctions.find((a) => a.id === auctionId);
+  if (!auction || auction.status !== "open") {
+    return passThrough(state, auctions);
+  }
+  if (auction.bids.length === 0) {
+    return cancelOpenAuction(state, auctions, auction);
+  }
+
+  // Pick the winner: highest amount, tiebreak by empire reputation.
+  const winner = pickWinner(state, auction);
+
+  // Refund losing bids.
+  let playerRefund = 0;
+  let aiCompanies = state.aiCompanies;
+  for (const bid of auction.bids) {
+    if (bid.bidderId === winner.bidderId) continue;
+    if (bid.bidderId === PLAYER_COMPANY_ID) {
+      playerRefund += bid.amount;
+    } else {
+      aiCompanies = aiCompanies.map((ai) =>
+        ai.id === bid.bidderId ? { ...ai, cash: ai.cash + bid.amount } : ai,
+      );
+    }
+  }
+
+  // Grant the charter (slot is already decremented via startAuction).
+  // Use grantCharter to keep the issuance path uniform, but undo its
+  // pool decrement since startAuction already handled it.
+  const grantResult = grantCharter(
+    {
+      ...state,
+      aiCompanies,
+      activeAuctions: auctions,
+    },
+    {
+      empireId: auction.empireId,
+      pool: auction.pool,
+      holderId: winner.bidderId,
+      term: {
+        kind: "fixedTerm",
+        expiresOnTurn: state.turn + auction.termTurns,
+      },
+      source: { auctionId: auction.id },
+    },
+  );
+
+  // grantCharter decremented the pool again; restore it once.
+  const empires = grantResult.empires.map((e) => {
+    if (e.id !== auction.empireId) return e;
+    const pool = getEmpirePool(e);
+    const openField =
+      auction.pool === "foreign" ? "foreignOpen" : "domesticOpen";
+    const totalField =
+      auction.pool === "foreign" ? "foreignTotal" : "domesticTotal";
+    const next = Math.min(pool[totalField], pool[openField] + 1);
+    return { ...e, routeSlotPool: { ...pool, [openField]: next } };
+  });
+
+  return {
+    activeAuctions: auctions.map((a) =>
+      a.id === auctionId
+        ? { ...a, status: "resolved", winnerId: winner.bidderId }
+        : a,
+    ),
+    empires,
+    playerCharters: grantResult.playerCharters,
+    aiCompanies: grantResult.aiCompanies,
+    playerRefund,
+    winnerId: winner.bidderId,
+    termTurns: auction.termTurns,
+  };
+}
+
+function pickWinner(state: GameState, auction: CharterAuction): CharterBid {
+  const sorted = [...auction.bids].sort((a, b) => {
+    if (b.amount !== a.amount) return b.amount - a.amount;
+    // Tiebreak by per-empire reputation.
+    const repA = repFor(state, a.bidderId, auction.empireId);
+    const repB = repFor(state, b.bidderId, auction.empireId);
+    return repB - repA;
+  });
+  return sorted[0];
+}
+
+function repFor(state: GameState, bidderId: string, empireId: string): number {
+  if (bidderId === PLAYER_COMPANY_ID) return getEmpireRep(state, empireId);
+  return state.aiCompanies.find((ai) => ai.id === bidderId)?.reputation ?? 50;
+}
+
+function cancelOpenAuction(
+  state: GameState,
+  auctions: CharterAuction[],
+  auction: CharterAuction,
+): ResolveAuctionResult {
+  const empires = state.galaxy.empires.map((e) => {
+    if (e.id !== auction.empireId) return e;
+    const pool = getEmpirePool(e);
+    const openField =
+      auction.pool === "foreign" ? "foreignOpen" : "domesticOpen";
+    const totalField =
+      auction.pool === "foreign" ? "foreignTotal" : "domesticTotal";
+    return {
+      ...e,
+      routeSlotPool: {
+        ...pool,
+        [openField]: Math.min(pool[totalField], pool[openField] + 1),
+      },
+    };
+  });
+  return {
+    activeAuctions: auctions.map((a) =>
+      a.id === auction.id ? { ...a, status: "cancelled" } : a,
+    ),
+    empires,
+    playerCharters: state.charters ?? [],
+    aiCompanies: state.aiCompanies,
+    playerRefund: 0,
+    winnerId: null,
+    termTurns: auction.termTurns,
+  };
+}
+
+function passThrough(
+  state: GameState,
+  auctions: CharterAuction[],
+): ResolveAuctionResult {
+  return {
+    activeAuctions: auctions,
+    empires: state.galaxy.empires,
+    playerCharters: state.charters ?? [],
+    aiCompanies: state.aiCompanies,
+    playerRefund: 0,
+    winnerId: null,
+    termTurns: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AI bidding heuristic
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide whether an AI company bids in a given auction, and how much.
+ * Returns null to abstain.
+ *
+ * Heuristic:
+ *   1. Refuse below-floor cash (need 2× minBid as buffer).
+ *   2. Bid more aggressively for charters in the AI's home empire.
+ *   3. Bid more aggressively for the foreign pool (it's rare/valuable).
+ *   4. Cap bid at a fraction of cash to avoid bankrupting the AI.
+ *
+ * Personality flavors the curve:
+ *   - aggressiveExpander: bids hot, up to 30% of cash
+ *   - cherryPicker: bids only on foreign + home-empire deals, ~20% of cash
+ *   - steadyHauler: bids modestly, ~12% of cash
+ */
+export function aiAuctionBid(
+  state: GameState,
+  ai: AICompany,
+  auction: CharterAuction,
+): number | null {
+  const empire = state.galaxy.empires.find((e) => e.id === auction.empireId);
+  if (!empire) return null;
+  const minBid = calculateMinBid(empire, auction.pool);
+  if (ai.cash < minBid * 2) return null;
+
+  const isHomeEmpire = ai.empireId === auction.empireId;
+  const isForeign = auction.pool === "foreign";
+
+  let cashFraction: number;
+  switch (ai.personality) {
+    case "aggressiveExpander":
+      cashFraction = 0.3;
+      break;
+    case "cherryPicker":
+      // Skips deals that aren't either home or foreign-pool.
+      if (!isHomeEmpire && !isForeign) return null;
+      cashFraction = 0.2;
+      break;
+    default: // steadyHauler + future personalities
+      cashFraction = 0.12;
+      break;
+  }
+  // Sweeten home + foreign appetite.
+  if (isHomeEmpire) cashFraction *= 1.3;
+  if (isForeign) cashFraction *= 1.4;
+
+  const bid = Math.round(ai.cash * cashFraction);
+  if (bid < minBid) return null;
+  return bid;
+}
+
+// ---------------------------------------------------------------------------
+// Per-turn driver
+// ---------------------------------------------------------------------------
+
+export interface ProcessAuctionsTurnResult {
+  /** Updated activeAuctions after AI bidding and resolution. */
+  activeAuctions: CharterAuction[];
+  /** Updated empires (slot returns / grants applied). */
+  empires: Empire[];
+  /** Updated player charter list (winners' new charters). */
+  playerCharters: Charter[];
+  /** Updated AI companies (cash adjusted for bids/refunds, charters updated). */
+  aiCompanies: AICompany[];
+  /** Cash to credit to the player (refunded losing bids). */
+  playerRefund: number;
+  /** IDs of auctions that resolved this turn — for turn report. */
+  resolvedAuctionIds: string[];
+}
+
+/**
+ * Per-turn auction driver. Each turn:
+ *   1. AI companies submit bids on currently-open auctions they haven't
+ *      bid in yet (one bid per AI per auction).
+ *   2. Auctions whose bidding window closes this turn resolve.
+ *
+ * An auction's bidding window closes on `startedTurn + durationTurns - 1`
+ * (inclusive). Auctions live one extra turn after resolving so the turn
+ * report can reference them; further cleanup happens in a subsequent turn
+ * (`pruneResolvedAuctions`).
+ *
+ * Pure — caller applies returned partial state.
+ */
+export function processCharterAuctionsTurn(
+  state: GameState,
+): ProcessAuctionsTurnResult {
+  let auctions = state.activeAuctions ?? [];
+  let empires = state.galaxy.empires;
+  let aiCompanies = state.aiCompanies;
+  let playerCharters = state.charters ?? [];
+  let playerRefund = 0;
+  const resolvedAuctionIds: string[] = [];
+
+  // ---- Step 1: AI bidding on open auctions ----
+  for (const auction of auctions) {
+    if (auction.status !== "open") continue;
+    if (state.turn < auction.startedTurn) continue; // Not yet biddable
+    for (const ai of aiCompanies) {
+      if (ai.bankrupt) continue;
+      if (auction.bids.some((b) => b.bidderId === ai.id)) continue;
+      const amount = aiAuctionBid(
+        { ...state, galaxy: { ...state.galaxy, empires } },
+        ai,
+        auction,
+      );
+      if (amount === null) continue;
+      const submit = submitBid(
+        { ...state, activeAuctions: auctions },
+        auction.id,
+        { bidderId: ai.id, amount, ai: true },
+      );
+      if (submit.error !== null) continue;
+      auctions = submit.activeAuctions;
+      // Escrow AI cash now; refunded if they lose.
+      aiCompanies = aiCompanies.map((c) =>
+        c.id === ai.id ? { ...c, cash: c.cash - submit.escrow } : c,
+      );
+    }
+  }
+
+  // ---- Step 2: Resolve auctions whose bidding window closed ----
+  for (const auction of auctions) {
+    if (auction.status !== "open") continue;
+    const lastBidTurn = auction.startedTurn + auction.durationTurns - 1;
+    if (state.turn < lastBidTurn) continue;
+    const r = resolveAuction(
+      {
+        ...state,
+        activeAuctions: auctions,
+        galaxy: { ...state.galaxy, empires },
+        aiCompanies,
+        charters: playerCharters,
+      },
+      auction.id,
+    );
+    auctions = r.activeAuctions;
+    empires = r.empires;
+    aiCompanies = r.aiCompanies;
+    playerCharters = r.playerCharters;
+    playerRefund += r.playerRefund;
+    resolvedAuctionIds.push(auction.id);
+  }
+
+  return {
+    activeAuctions: auctions,
+    empires,
+    playerCharters,
+    aiCompanies,
+    playerRefund,
+    resolvedAuctionIds,
+  };
+}
+
+/**
+ * Drop resolved/cancelled auctions older than `keepFor` turns from the list.
+ * Call this at the end of the turn report so the active list doesn't grow
+ * unbounded. Default keep-for is 1 turn.
+ */
+export function pruneResolvedAuctions(
+  auctions: CharterAuction[],
+  currentTurn: number,
+  keepFor = 1,
+): CharterAuction[] {
+  return auctions.filter((a) => {
+    if (a.status === "open") return true;
+    return a.startedTurn + a.durationTurns + keepFor > currentTurn;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function randomSuffix(): string {
+  return Math.random().toString(36).slice(2, 8);
+}

--- a/src/game/charters/CharterManager.ts
+++ b/src/game/charters/CharterManager.ts
@@ -1,0 +1,532 @@
+import type {
+  Charter,
+  CharterTerm,
+  Empire,
+  EmpireRouteSlotPool,
+  GameState,
+  Planet,
+} from "../../data/types.ts";
+import {
+  BASE_DOMESTIC_UPKEEP,
+  BASE_FOREIGN_UPKEEP,
+  DEFAULT_EMPIRE_POOL_BY_STANCE,
+  PLAYER_COMPANY_ID,
+} from "../../data/constants.ts";
+import { getEmpireRep } from "../reputation/ReputationEffects.ts";
+
+/**
+ * Charter ownership and route gating live here. The empire owns the slot
+ * pool; companies lease individual slots ("charters") to operate routes.
+ *
+ * Pure functions only — call sites apply returned partial state via
+ * `gameStore.update(...)`. No mutation of inputs.
+ */
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the default `EmpireRouteSlotPool` for an empire based on its policy
+ * stance. Used as a fallback for empires saved before the charter system or
+ * created without an explicit pool.
+ */
+export function defaultPoolFor(empire: Empire): EmpireRouteSlotPool {
+  const stance = empire.routeSlotPool?.policyStance ?? "regulated";
+  const sizes = DEFAULT_EMPIRE_POOL_BY_STANCE[stance];
+  return {
+    policyStance: stance,
+    domesticTotal: sizes.domesticTotal,
+    foreignTotal: sizes.foreignTotal,
+    domesticOpen: sizes.domesticTotal,
+    foreignOpen: sizes.foreignTotal,
+  };
+}
+
+/** Read an empire's pool, falling back to the stance-derived default. */
+export function getEmpirePool(empire: Empire): EmpireRouteSlotPool {
+  return empire.routeSlotPool ?? defaultPoolFor(empire);
+}
+
+// ---------------------------------------------------------------------------
+// Lookups
+// ---------------------------------------------------------------------------
+
+/**
+ * All charters held across the game (player + AI). Order: player first,
+ * then each AI company in turn order.
+ */
+export function getAllCharters(state: GameState): Charter[] {
+  const out: Charter[] = [...(state.charters ?? [])];
+  for (const ai of state.aiCompanies) {
+    if (ai.charters) out.push(...ai.charters);
+  }
+  return out;
+}
+
+/** Charters held by a specific company (player or AI). */
+export function getHeldCharters(
+  state: GameState,
+  holderId: string,
+  empireId?: string,
+): Charter[] {
+  if (holderId === PLAYER_COMPANY_ID) {
+    const all = state.charters ?? [];
+    return empireId ? all.filter((c) => c.empireId === empireId) : [...all];
+  }
+  const ai = state.aiCompanies.find((c) => c.id === holderId);
+  if (!ai) return [];
+  const all = ai.charters ?? [];
+  return empireId ? all.filter((c) => c.empireId === empireId) : [...all];
+}
+
+/**
+ * Compute next-turn upkeep for a holder. Sums `term.upkeepPerTurn` across
+ * all permanent charters; fixed-term charters carry no upkeep.
+ */
+export function getUpkeepDue(state: GameState, holderId: string): number {
+  return getHeldCharters(state, holderId).reduce(
+    (sum, c) => sum + (c.term.kind === "permanent" ? c.term.upkeepPerTurn : 0),
+    0,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Pricing
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-turn license upkeep for a permanent charter, scaled by empire tariff
+ * rate and the holder's per-empire reputation tier.
+ *   notorious × 1.30
+ *   unknown   × 1.10
+ *   respected × 1.00
+ *   renowned  × 0.90
+ *   legendary × 0.80
+ *
+ * Foreign pool charters carry the higher base. Tariff rate (0..1) lifts
+ * cost: a 30% tariff empire adds +30%.
+ */
+export function calculateUpkeep(
+  state: GameState,
+  empire: Empire,
+  pool: "domestic" | "foreign",
+  holderId: string,
+): number {
+  const base = pool === "foreign" ? BASE_FOREIGN_UPKEEP : BASE_DOMESTIC_UPKEEP;
+  const tariffMul = 1 + (empire.tariffRate ?? 0);
+  const rep =
+    holderId === PLAYER_COMPANY_ID ? getEmpireRep(state, empire.id) : 50;
+  const repMul =
+    rep >= 90 ? 0.8 : rep >= 75 ? 0.9 : rep >= 50 ? 1.0 : rep >= 25 ? 1.1 : 1.3;
+  return Math.round(base * tariffMul * repMul);
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a route's charter pool requirement from its endpoints. A route
+ * wholly within one empire = domestic; crossing a border = foreign. Returns
+ * `null` only if either planet is missing or has no system mapping (defensive).
+ */
+export function classifyRoutePool(
+  state: GameState,
+  originPlanetId: string,
+  destinationPlanetId: string,
+): { empireId: string; pool: "domestic" | "foreign" } | null {
+  const origin = findEmpireForPlanet(state, originPlanetId);
+  const dest = findEmpireForPlanet(state, destinationPlanetId);
+  if (!origin || !dest) return null;
+  if (origin === dest) {
+    return { empireId: origin, pool: "domestic" };
+  }
+  // Foreign route: charter is held against the destination empire (the one
+  // granting market access). This mirrors how customs/tariffs work in the
+  // existing trade-policy system.
+  return { empireId: dest, pool: "foreign" };
+}
+
+function findEmpireForPlanet(
+  state: GameState,
+  planetId: string,
+): string | null {
+  const planet: Planet | undefined = state.galaxy.planets.find(
+    (p) => p.id === planetId,
+  );
+  if (!planet) return null;
+  const system = state.galaxy.systems.find((s) => s.id === planet.systemId);
+  return system?.empireId ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Mutators (pure — return new pieces of state)
+// ---------------------------------------------------------------------------
+
+export interface GrantCharterArgs {
+  empireId: string;
+  pool: "domestic" | "foreign";
+  holderId: string;
+  term: CharterTerm;
+  source?: { contractId?: string; auctionId?: string };
+}
+
+/**
+ * Result of a grant. Caller is responsible for applying:
+ *   gameStore.update({ galaxy: { ...state.galaxy, empires: result.empires },
+ *                      charters: result.playerCharters,   // if holder = player
+ *                      aiCompanies: result.aiCompanies }) // if holder = AI
+ */
+export interface GrantCharterResult {
+  charter: Charter;
+  empires: Empire[];
+  playerCharters: Charter[];
+  aiCompanies: GameState["aiCompanies"];
+  /** Reason a grant was rejected; null on success. */
+  error: null | "no-open-slot" | "unknown-empire";
+}
+
+export function grantCharter(
+  state: GameState,
+  args: GrantCharterArgs,
+): GrantCharterResult {
+  const empire = state.galaxy.empires.find((e) => e.id === args.empireId);
+  if (!empire) {
+    return failResult(state, "unknown-empire");
+  }
+  const pool = getEmpirePool(empire);
+  const openField = args.pool === "foreign" ? "foreignOpen" : "domesticOpen";
+  if (pool[openField] <= 0) {
+    return failResult(state, "no-open-slot");
+  }
+  const charter: Charter = {
+    id: `charter-${args.empireId}-${args.pool}-${state.turn}-${randomSuffix()}`,
+    empireId: args.empireId,
+    pool: args.pool,
+    holderId: args.holderId,
+    grantedTurn: state.turn,
+    term: args.term,
+    sourceContractId: args.source?.contractId,
+    sourceAuctionId: args.source?.auctionId,
+  };
+  const nextEmpires = state.galaxy.empires.map((e) =>
+    e.id === args.empireId
+      ? { ...e, routeSlotPool: { ...pool, [openField]: pool[openField] - 1 } }
+      : e,
+  );
+  const playerCharters = [...(state.charters ?? [])];
+  let aiCompanies = state.aiCompanies;
+  if (args.holderId === PLAYER_COMPANY_ID) {
+    playerCharters.push(charter);
+  } else {
+    aiCompanies = state.aiCompanies.map((ai) =>
+      ai.id === args.holderId
+        ? { ...ai, charters: [...(ai.charters ?? []), charter] }
+        : ai,
+    );
+  }
+  return {
+    charter,
+    empires: nextEmpires,
+    playerCharters,
+    aiCompanies,
+    error: null,
+  };
+}
+
+export interface ForfeitCharterResult {
+  empires: Empire[];
+  playerCharters: Charter[];
+  aiCompanies: GameState["aiCompanies"];
+  /** Routes that lost their charter and should be deleted by the caller. */
+  forfeitedRouteIds: string[];
+  /** True if the charter was found and forfeited. */
+  found: boolean;
+}
+
+/**
+ * Forfeit a charter. Slot returns to the empire pool. Any `ActiveRoute`
+ * linked via `charterId` is reported back so the caller can delete or
+ * pause it as part of the same state update.
+ */
+export function forfeitCharter(
+  state: GameState,
+  charterId: string,
+): ForfeitCharterResult {
+  const all = getAllCharters(state);
+  const target = all.find((c) => c.id === charterId);
+  if (!target) {
+    return {
+      empires: state.galaxy.empires,
+      playerCharters: state.charters ?? [],
+      aiCompanies: state.aiCompanies,
+      forfeitedRouteIds: [],
+      found: false,
+    };
+  }
+  const openField = target.pool === "foreign" ? "foreignOpen" : "domesticOpen";
+  const totalField =
+    target.pool === "foreign" ? "foreignTotal" : "domesticTotal";
+  const empires = state.galaxy.empires.map((e) => {
+    if (e.id !== target.empireId) return e;
+    const pool = getEmpirePool(e);
+    // Don't push open above total (defensive against double-forfeit).
+    const nextOpen = Math.min(pool[totalField], pool[openField] + 1);
+    return { ...e, routeSlotPool: { ...pool, [openField]: nextOpen } };
+  });
+  let playerCharters = state.charters ?? [];
+  let aiCompanies = state.aiCompanies;
+  if (target.holderId === PLAYER_COMPANY_ID) {
+    playerCharters = playerCharters.filter((c) => c.id !== charterId);
+  } else {
+    aiCompanies = state.aiCompanies.map((ai) =>
+      ai.id === target.holderId
+        ? {
+            ...ai,
+            charters: (ai.charters ?? []).filter((c) => c.id !== charterId),
+          }
+        : ai,
+    );
+  }
+  // Player-side route forfeits surface to the caller.
+  const forfeitedRouteIds = state.activeRoutes
+    .filter((r) => r.charterId === charterId)
+    .map((r) => r.id);
+  return {
+    empires,
+    playerCharters,
+    aiCompanies,
+    forfeitedRouteIds,
+    found: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route-creation gating
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether the holder can underwrite a new route between the given
+ * planets — returns the matching held charter id, or a reason it cannot.
+ *
+ * A holder can use the same charter for multiple routes (the charter is the
+ * lease, not the route). If they don't hold a matching charter, they need
+ * to acquire one (contract, auction, or — for the player at game start —
+ * starter grant).
+ */
+export function findChartersForRoute(
+  state: GameState,
+  holderId: string,
+  originPlanetId: string,
+  destinationPlanetId: string,
+): { charterId: string } | { error: "no-matching-charter" | "invalid-route" } {
+  const cls = classifyRoutePool(state, originPlanetId, destinationPlanetId);
+  if (!cls) return { error: "invalid-route" };
+  const held = getHeldCharters(state, holderId, cls.empireId);
+  const match = held.find((c) => c.pool === cls.pool);
+  if (!match) return { error: "no-matching-charter" };
+  return { charterId: match.id };
+}
+
+// ---------------------------------------------------------------------------
+// Per-turn lifecycle (upkeep + fixed-term expiry)
+// ---------------------------------------------------------------------------
+
+export interface CharterTurnEvent {
+  type: "upkeepPaid" | "forfeitedNoPay" | "forfeitedExpired";
+  charterId: string;
+  empireId: string;
+  pool: "domestic" | "foreign";
+  holderId: string;
+  amount?: number;
+}
+
+export interface CharterTurnResult {
+  /** Total upkeep paid by the player this turn (subtract from cash). */
+  playerUpkeep: number;
+  /** Updated player charter list after forfeitures. */
+  playerCharters: Charter[];
+  /** Updated empires (with pools refilled by forfeitures). */
+  empires: Empire[];
+  /** Updated AI companies (with their charters/cash adjusted). */
+  aiCompanies: GameState["aiCompanies"];
+  /** Active routes that lost their charter and should be deleted by caller. */
+  forfeitedRouteIds: string[];
+  /** Per-charter events for the turn report. */
+  events: CharterTurnEvent[];
+}
+
+/**
+ * Apply per-turn charter lifecycle: collect upkeep from permanent charters,
+ * expire fixed-term charters that hit their term. Pure — caller applies the
+ * returned partial state.
+ *
+ * Player can't pay → forfeit cheapest-revenue charters first (deterministic).
+ * AI can't pay → forfeit one of theirs and accept the cash hit.
+ *
+ * The current turn (`state.turn`) is treated as "now": fixed-term charters
+ * expire when `expiresOnTurn <= state.turn`.
+ */
+export function applyCharterTurn(state: GameState): CharterTurnResult {
+  const events: CharterTurnEvent[] = [];
+  const playerCharters = state.charters ?? [];
+  let empires = state.galaxy.empires;
+  let aiCompanies = state.aiCompanies;
+  const forfeitedRouteIds: string[] = [];
+
+  // ---- Player upkeep ----
+  let playerUpkeep = 0;
+  const survivingPlayerCharters: Charter[] = [];
+  let playerCash = state.cash;
+  for (const c of playerCharters) {
+    // Expire fixed-term first
+    if (c.term.kind === "fixedTerm" && c.term.expiresOnTurn <= state.turn) {
+      const r = forfeitCharter(
+        { ...state, charters: survivingPlayerCharters },
+        c.id,
+      );
+      // r mutates empires/forfeitedRouteIds via local state; just track the event.
+      events.push({
+        type: "forfeitedExpired",
+        charterId: c.id,
+        empireId: c.empireId,
+        pool: c.pool,
+        holderId: c.holderId,
+      });
+      empires = applyPoolRefund(empires, c.empireId, c.pool);
+      // Routes attached to this charter get reported for caller cleanup
+      const linked = state.activeRoutes
+        .filter((r2) => r2.charterId === c.id)
+        .map((r2) => r2.id);
+      forfeitedRouteIds.push(...linked);
+      void r;
+      continue;
+    }
+    if (c.term.kind === "permanent") {
+      const cost = c.term.upkeepPerTurn;
+      if (playerCash >= cost) {
+        playerCash -= cost;
+        playerUpkeep += cost;
+        survivingPlayerCharters.push(c);
+        events.push({
+          type: "upkeepPaid",
+          charterId: c.id,
+          empireId: c.empireId,
+          pool: c.pool,
+          holderId: c.holderId,
+          amount: cost,
+        });
+      } else {
+        // Insufficient cash — forfeit charter, slot returns to empire pool.
+        events.push({
+          type: "forfeitedNoPay",
+          charterId: c.id,
+          empireId: c.empireId,
+          pool: c.pool,
+          holderId: c.holderId,
+        });
+        empires = applyPoolRefund(empires, c.empireId, c.pool);
+        const linked = state.activeRoutes
+          .filter((r2) => r2.charterId === c.id)
+          .map((r2) => r2.id);
+        forfeitedRouteIds.push(...linked);
+      }
+      continue;
+    }
+    // Fixed-term, not yet expired
+    survivingPlayerCharters.push(c);
+  }
+
+  // ---- AI upkeep ----
+  aiCompanies = aiCompanies.map((ai) => {
+    if (ai.bankrupt || !ai.charters || ai.charters.length === 0) return ai;
+    let aiCash = ai.cash;
+    const surviving: Charter[] = [];
+    for (const c of ai.charters) {
+      if (c.term.kind === "fixedTerm" && c.term.expiresOnTurn <= state.turn) {
+        events.push({
+          type: "forfeitedExpired",
+          charterId: c.id,
+          empireId: c.empireId,
+          pool: c.pool,
+          holderId: c.holderId,
+        });
+        empires = applyPoolRefund(empires, c.empireId, c.pool);
+        continue;
+      }
+      if (c.term.kind === "permanent") {
+        const cost = c.term.upkeepPerTurn;
+        if (aiCash >= cost) {
+          aiCash -= cost;
+          surviving.push(c);
+          events.push({
+            type: "upkeepPaid",
+            charterId: c.id,
+            empireId: c.empireId,
+            pool: c.pool,
+            holderId: c.holderId,
+            amount: cost,
+          });
+        } else {
+          events.push({
+            type: "forfeitedNoPay",
+            charterId: c.id,
+            empireId: c.empireId,
+            pool: c.pool,
+            holderId: c.holderId,
+          });
+          empires = applyPoolRefund(empires, c.empireId, c.pool);
+        }
+        continue;
+      }
+      surviving.push(c);
+    }
+    return { ...ai, cash: aiCash, charters: surviving };
+  });
+
+  return {
+    playerUpkeep,
+    playerCharters: survivingPlayerCharters,
+    empires,
+    aiCompanies,
+    forfeitedRouteIds,
+    events,
+  };
+}
+
+function applyPoolRefund(
+  empires: Empire[],
+  empireId: string,
+  pool: "domestic" | "foreign",
+): Empire[] {
+  return empires.map((e) => {
+    if (e.id !== empireId) return e;
+    const p = getEmpirePool(e);
+    const openField = pool === "foreign" ? "foreignOpen" : "domesticOpen";
+    const totalField = pool === "foreign" ? "foreignTotal" : "domesticTotal";
+    const next = Math.min(p[totalField], p[openField] + 1);
+    return { ...e, routeSlotPool: { ...p, [openField]: next } };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function randomSuffix(): string {
+  return Math.random().toString(36).slice(2, 8);
+}
+
+function failResult(
+  state: GameState,
+  error: NonNullable<GrantCharterResult["error"]>,
+): GrantCharterResult {
+  return {
+    charter: null as unknown as Charter,
+    empires: state.galaxy.empires,
+    playerCharters: state.charters ?? [],
+    aiCompanies: state.aiCompanies,
+    error,
+  };
+}

--- a/src/game/charters/__tests__/CharterAuction.test.ts
+++ b/src/game/charters/__tests__/CharterAuction.test.ts
@@ -1,0 +1,436 @@
+import { describe, it, expect } from "vitest";
+import type {
+  AICompany,
+  Charter,
+  CharterAuction,
+  Empire,
+  GameState,
+} from "../../../data/types.ts";
+import { PLAYER_COMPANY_ID } from "../../../data/constants.ts";
+import {
+  aiAuctionBid,
+  calculateMinBid,
+  resolveAuction,
+  startAuction,
+  submitBid,
+} from "../CharterAuction.ts";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeEmpire(
+  id: string,
+  policyStance: "isolationist" | "regulated" | "open" = "regulated",
+  tariffRate = 0.1,
+): Empire {
+  const totals =
+    policyStance === "open"
+      ? { d: 4, f: 4 }
+      : policyStance === "isolationist"
+        ? { d: 8, f: 1 }
+        : { d: 6, f: 2 };
+  return {
+    id,
+    name: id.toUpperCase(),
+    color: 0,
+    tariffRate,
+    disposition: "neutral",
+    homeSystemId: `${id}-home`,
+    leaderName: "L",
+    leaderPortrait: { portraitId: "p", category: "human" },
+    routeSlotPool: {
+      policyStance,
+      domesticTotal: totals.d,
+      foreignTotal: totals.f,
+      domesticOpen: totals.d,
+      foreignOpen: totals.f,
+    },
+  };
+}
+
+function makeAI(
+  id: string,
+  empireId: string,
+  opts: Partial<AICompany> = {},
+): AICompany {
+  return {
+    id,
+    name: id,
+    empireId,
+    cash: 200_000,
+    fleet: [],
+    activeRoutes: [],
+    reputation: 55,
+    totalCargoDelivered: 0,
+    personality: "steadyHauler",
+    bankrupt: false,
+    ceoName: "AI",
+    ceoPortrait: { portraitId: "p", category: "human" },
+    ...opts,
+  };
+}
+
+function makeState(opts: {
+  empires: Empire[];
+  aiCompanies?: AICompany[];
+  charters?: Charter[];
+  activeAuctions?: CharterAuction[];
+  empireReputation?: Record<string, number>;
+  cash?: number;
+  turn?: number;
+}): GameState {
+  return {
+    turn: opts.turn ?? 5,
+    cash: opts.cash ?? 100_000,
+    galaxy: {
+      sectors: [],
+      empires: opts.empires,
+      systems: [],
+      planets: [],
+    },
+    aiCompanies: opts.aiCompanies ?? [],
+    charters: opts.charters ?? [],
+    activeAuctions: opts.activeAuctions ?? [],
+    empireReputation: opts.empireReputation ?? {},
+    reputation: 50,
+  } as unknown as GameState;
+}
+
+// ---------------------------------------------------------------------------
+// calculateMinBid
+// ---------------------------------------------------------------------------
+
+describe("calculateMinBid", () => {
+  it("foreign minimum is materially higher than domestic", () => {
+    const e = makeEmpire("solaris", "regulated", 0);
+    expect(calculateMinBid(e, "foreign")).toBeGreaterThan(
+      calculateMinBid(e, "domestic") * 3,
+    );
+  });
+
+  it("scales with tariff rate", () => {
+    const cheap = makeEmpire("a", "regulated", 0);
+    const pricey = makeEmpire("b", "regulated", 0.4);
+    expect(calculateMinBid(pricey, "foreign")).toBeGreaterThan(
+      calculateMinBid(cheap, "foreign"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startAuction
+// ---------------------------------------------------------------------------
+
+describe("startAuction", () => {
+  it("opens an auction and reserves the slot from the empire pool", () => {
+    const state = makeState({ empires: [makeEmpire("solaris")] });
+    const result = startAuction(state, {
+      empireId: "solaris",
+      pool: "foreign",
+      triggerReason: "diplomatic_crisis_end",
+    });
+    expect(result.error).toBeNull();
+    expect(result.auction?.status).toBe("open");
+    expect(result.auction?.triggerReason).toBe("diplomatic_crisis_end");
+    expect(result.empires[0].routeSlotPool?.foreignOpen).toBe(1);
+  });
+
+  it("rejects when the empire has no open slots in the requested pool", () => {
+    const empire = makeEmpire("solaris");
+    const drained: Empire = {
+      ...empire,
+      routeSlotPool: { ...empire.routeSlotPool!, foreignOpen: 0 },
+    };
+    const state = makeState({ empires: [drained] });
+    const result = startAuction(state, {
+      empireId: "solaris",
+      pool: "foreign",
+    });
+    expect(result.error).toBe("no-open-slot");
+    expect(result.auction).toBeNull();
+  });
+
+  it("rejects unknown empires", () => {
+    const state = makeState({ empires: [] });
+    const result = startAuction(state, { empireId: "nope", pool: "domestic" });
+    expect(result.error).toBe("unknown-empire");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submitBid
+// ---------------------------------------------------------------------------
+
+describe("submitBid", () => {
+  function setup() {
+    const state0 = makeState({ empires: [makeEmpire("solaris")] });
+    const start = startAuction(state0, {
+      empireId: "solaris",
+      pool: "foreign",
+    });
+    return {
+      state: {
+        ...state0,
+        activeAuctions: start.activeAuctions,
+        galaxy: { ...state0.galaxy, empires: start.empires },
+      } as GameState,
+      auctionId: start.auction!.id,
+    };
+  }
+
+  it("accepts a valid bid above the minimum", () => {
+    const { state, auctionId } = setup();
+    const minBid = calculateMinBid(state.galaxy.empires[0], "foreign");
+    const r = submitBid(state, auctionId, {
+      bidderId: PLAYER_COMPANY_ID,
+      amount: minBid + 1000,
+      ai: false,
+    });
+    expect(r.error).toBeNull();
+    expect(r.escrow).toBe(minBid + 1000);
+    expect(r.activeAuctions[0].bids).toHaveLength(1);
+  });
+
+  it("rejects bids below the minimum", () => {
+    const { state, auctionId } = setup();
+    const r = submitBid(state, auctionId, {
+      bidderId: PLAYER_COMPANY_ID,
+      amount: 1,
+      ai: false,
+    });
+    expect(r.error).toBe("below-min-bid");
+  });
+
+  it("rejects duplicate bids from the same bidder", () => {
+    const { state, auctionId } = setup();
+    const minBid = calculateMinBid(state.galaxy.empires[0], "foreign");
+    const r1 = submitBid(state, auctionId, {
+      bidderId: PLAYER_COMPANY_ID,
+      amount: minBid + 1000,
+      ai: false,
+    });
+    const state2 = { ...state, activeAuctions: r1.activeAuctions };
+    const r2 = submitBid(state2, auctionId, {
+      bidderId: PLAYER_COMPANY_ID,
+      amount: minBid + 5000,
+      ai: false,
+    });
+    expect(r2.error).toBe("duplicate-bidder");
+  });
+
+  it("rejects unknown auction ids", () => {
+    const { state } = setup();
+    const r = submitBid(state, "ghost", {
+      bidderId: PLAYER_COMPANY_ID,
+      amount: 100_000,
+      ai: false,
+    });
+    expect(r.error).toBe("auction-not-found");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAuction
+// ---------------------------------------------------------------------------
+
+describe("resolveAuction", () => {
+  it("highest bidder wins and receives a fixed-term charter", () => {
+    const ai = makeAI("ai-1", "solaris", { cash: 500_000 });
+    let state = makeState({
+      empires: [makeEmpire("solaris")],
+      aiCompanies: [ai],
+    });
+    const start = startAuction(state, {
+      empireId: "solaris",
+      pool: "foreign",
+    });
+    state = {
+      ...state,
+      activeAuctions: start.activeAuctions,
+      galaxy: { ...state.galaxy, empires: start.empires },
+    };
+    const auctionId = start.auction!.id;
+
+    state = applyBid(state, auctionId, PLAYER_COMPANY_ID, 100_000);
+    state = applyBid(state, auctionId, "ai-1", 60_000);
+
+    const r = resolveAuction(state, auctionId);
+    expect(r.winnerId).toBe(PLAYER_COMPANY_ID);
+    expect(r.playerCharters).toHaveLength(1);
+    expect(r.playerCharters[0].term.kind).toBe("fixedTerm");
+    if (r.playerCharters[0].term.kind === "fixedTerm") {
+      expect(r.playerCharters[0].term.expiresOnTurn).toBe(
+        state.turn + r.termTurns,
+      );
+    }
+    // The losing AI bid is refunded.
+    expect(r.aiCompanies[0].cash).toBe(500_000 + 60_000);
+    // The winning auction stays in the list, marked resolved.
+    const resolved = r.activeAuctions.find((a) => a.id === auctionId);
+    expect(resolved?.status).toBe("resolved");
+  });
+
+  it("cancels and returns the slot when no bids were submitted", () => {
+    let state = makeState({ empires: [makeEmpire("solaris")] });
+    const start = startAuction(state, {
+      empireId: "solaris",
+      pool: "domestic",
+    });
+    state = {
+      ...state,
+      activeAuctions: start.activeAuctions,
+      galaxy: { ...state.galaxy, empires: start.empires },
+    };
+    const auctionId = start.auction!.id;
+    expect(state.galaxy.empires[0].routeSlotPool?.domesticOpen).toBe(5);
+
+    const r = resolveAuction(state, auctionId);
+    expect(r.winnerId).toBeNull();
+    expect(r.activeAuctions[0].status).toBe("cancelled");
+    expect(r.empires[0].routeSlotPool?.domesticOpen).toBe(6);
+  });
+
+  it("breaks ties by per-empire reputation", () => {
+    const aiHi = makeAI("ai-hi", "solaris", { reputation: 80 });
+    const aiLo = makeAI("ai-lo", "solaris", { reputation: 20 });
+    let state = makeState({
+      empires: [makeEmpire("solaris")],
+      aiCompanies: [aiHi, aiLo],
+    });
+    const start = startAuction(state, {
+      empireId: "solaris",
+      pool: "domestic",
+    });
+    state = {
+      ...state,
+      activeAuctions: start.activeAuctions,
+      galaxy: { ...state.galaxy, empires: start.empires },
+    };
+    const auctionId = start.auction!.id;
+    const minBid = calculateMinBid(state.galaxy.empires[0], "domestic");
+    state = applyBid(state, auctionId, "ai-hi", minBid + 100);
+    state = applyBid(state, auctionId, "ai-lo", minBid + 100);
+
+    const r = resolveAuction(state, auctionId);
+    expect(r.winnerId).toBe("ai-hi");
+  });
+
+  it("refunds the player's losing bid", () => {
+    const ai = makeAI("ai-1", "solaris", { cash: 1_000_000 });
+    let state = makeState({
+      empires: [makeEmpire("solaris")],
+      aiCompanies: [ai],
+    });
+    const start = startAuction(state, { empireId: "solaris", pool: "foreign" });
+    state = {
+      ...state,
+      activeAuctions: start.activeAuctions,
+      galaxy: { ...state.galaxy, empires: start.empires },
+    };
+    const auctionId = start.auction!.id;
+    state = applyBid(state, auctionId, PLAYER_COMPANY_ID, 60_000);
+    state = applyBid(state, auctionId, "ai-1", 200_000);
+
+    const r = resolveAuction(state, auctionId);
+    expect(r.winnerId).toBe("ai-1");
+    expect(r.playerRefund).toBe(60_000);
+  });
+});
+
+function applyBid(
+  state: GameState,
+  auctionId: string,
+  bidderId: string,
+  amount: number,
+): GameState {
+  const r = submitBid(state, auctionId, {
+    bidderId,
+    amount,
+    ai: bidderId !== PLAYER_COMPANY_ID,
+  });
+  return { ...state, activeAuctions: r.activeAuctions } as GameState;
+}
+
+// ---------------------------------------------------------------------------
+// aiAuctionBid heuristic
+// ---------------------------------------------------------------------------
+
+describe("aiAuctionBid", () => {
+  function buildAuction(
+    empireId: string,
+    pool: "domestic" | "foreign",
+  ): CharterAuction {
+    return {
+      id: "auction-x",
+      empireId,
+      pool,
+      startedTurn: 1,
+      durationTurns: 1,
+      termTurns: 8,
+      bids: [],
+      status: "open",
+    };
+  }
+
+  it("returns null when AI is below cash floor", () => {
+    const ai = makeAI("a", "solaris", { cash: 1000 });
+    const state = makeState({
+      empires: [makeEmpire("solaris")],
+      aiCompanies: [ai],
+    });
+    expect(
+      aiAuctionBid(state, ai, buildAuction("solaris", "foreign")),
+    ).toBeNull();
+  });
+
+  it("bids more in home empire than abroad", () => {
+    const ai = makeAI("a", "solaris", { cash: 500_000 });
+    const state = makeState({
+      empires: [makeEmpire("solaris"), makeEmpire("vex")],
+      aiCompanies: [ai],
+    });
+    const home = aiAuctionBid(state, ai, buildAuction("solaris", "domestic"));
+    const abroad = aiAuctionBid(state, ai, buildAuction("vex", "domestic"));
+    expect(home).not.toBeNull();
+    expect(abroad).not.toBeNull();
+    expect(home!).toBeGreaterThan(abroad!);
+  });
+
+  it("aggressive personality bids materially higher than steady", () => {
+    const aiAgg = makeAI("agg", "solaris", {
+      cash: 500_000,
+      personality: "aggressiveExpander",
+    });
+    const aiSteady = makeAI("steady", "solaris", {
+      cash: 500_000,
+      personality: "steadyHauler",
+    });
+    const state = makeState({
+      empires: [makeEmpire("solaris")],
+      aiCompanies: [aiAgg, aiSteady],
+    });
+    const auction = buildAuction("solaris", "foreign");
+    const aBid = aiAuctionBid(state, aiAgg, auction);
+    const sBid = aiAuctionBid(state, aiSteady, auction);
+    expect(aBid!).toBeGreaterThan(sBid!);
+  });
+
+  it("cherry picker abstains from non-home, non-foreign deals", () => {
+    const ai = makeAI("cp", "solaris", {
+      cash: 500_000,
+      personality: "cherryPicker",
+    });
+    const state = makeState({
+      empires: [makeEmpire("solaris"), makeEmpire("vex")],
+      aiCompanies: [ai],
+    });
+    expect(aiAuctionBid(state, ai, buildAuction("vex", "domestic"))).toBeNull();
+    expect(
+      aiAuctionBid(state, ai, buildAuction("vex", "foreign")),
+    ).not.toBeNull();
+    expect(
+      aiAuctionBid(state, ai, buildAuction("solaris", "domestic")),
+    ).not.toBeNull();
+  });
+});

--- a/src/game/charters/__tests__/CharterManager.test.ts
+++ b/src/game/charters/__tests__/CharterManager.test.ts
@@ -1,0 +1,646 @@
+import { describe, it, expect } from "vitest";
+import type {
+  AICompany,
+  ActiveRoute,
+  Charter,
+  Empire,
+  EmpireRouteSlotPool,
+  GameState,
+  Planet,
+  StarSystem,
+} from "../../../data/types.ts";
+import {
+  PLAYER_COMPANY_ID,
+  DEFAULT_EMPIRE_POOL_BY_STANCE,
+} from "../../../data/constants.ts";
+import {
+  classifyRoutePool,
+  defaultPoolFor,
+  findChartersForRoute,
+  forfeitCharter,
+  getEmpirePool,
+  getHeldCharters,
+  getUpkeepDue,
+  grantCharter,
+  calculateUpkeep,
+} from "../CharterManager.ts";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeEmpire(
+  id: string,
+  pool?: Partial<EmpireRouteSlotPool>,
+  tariffRate = 0,
+): Empire {
+  return {
+    id,
+    name: id.toUpperCase(),
+    color: 0xffffff,
+    tariffRate,
+    disposition: "neutral",
+    homeSystemId: `${id}-home`,
+    leaderName: `${id}-leader`,
+    leaderPortrait: { portraitId: "p", category: "human" },
+    routeSlotPool: pool
+      ? {
+          policyStance: "regulated",
+          domesticTotal: 4,
+          foreignTotal: 2,
+          domesticOpen: 4,
+          foreignOpen: 2,
+          ...pool,
+        }
+      : undefined,
+  };
+}
+
+function makeSystem(id: string, empireId: string): StarSystem {
+  return {
+    id,
+    name: id,
+    sectorId: "s",
+    empireId,
+    x: 0,
+    y: 0,
+    starColor: 0,
+  };
+}
+
+function makePlanet(id: string, systemId: string): Planet {
+  return {
+    id,
+    name: id,
+    systemId,
+    type: "terran",
+    x: 0,
+    y: 0,
+    population: 1_000_000,
+  };
+}
+
+function makeAI(id: string, empireId: string): AICompany {
+  return {
+    id,
+    name: id,
+    empireId,
+    cash: 100000,
+    fleet: [],
+    activeRoutes: [],
+    reputation: 50,
+    totalCargoDelivered: 0,
+    personality: "steadyHauler",
+    bankrupt: false,
+    ceoName: "AI",
+    ceoPortrait: { portraitId: "p", category: "human" },
+  };
+}
+
+function makeState(opts: {
+  empires: Empire[];
+  systems: StarSystem[];
+  planets: Planet[];
+  aiCompanies?: AICompany[];
+  charters?: Charter[];
+  empireReputation?: Record<string, number>;
+  activeRoutes?: ActiveRoute[];
+  turn?: number;
+}): GameState {
+  return {
+    turn: opts.turn ?? 1,
+    galaxy: {
+      sectors: [],
+      empires: opts.empires,
+      systems: opts.systems,
+      planets: opts.planets,
+    },
+    aiCompanies: opts.aiCompanies ?? [],
+    charters: opts.charters ?? [],
+    activeRoutes: opts.activeRoutes ?? [],
+    empireReputation: opts.empireReputation ?? {},
+    reputation: 50,
+  } as unknown as GameState;
+}
+
+// ---------------------------------------------------------------------------
+// defaultPoolFor / getEmpirePool
+// ---------------------------------------------------------------------------
+
+describe("defaultPoolFor", () => {
+  it("uses the regulated stance when no pool is set", () => {
+    const empire = makeEmpire("solaris");
+    const pool = defaultPoolFor(empire);
+    expect(pool.policyStance).toBe("regulated");
+    expect(pool.domesticTotal).toBe(
+      DEFAULT_EMPIRE_POOL_BY_STANCE.regulated.domesticTotal,
+    );
+    expect(pool.domesticOpen).toBe(pool.domesticTotal);
+    expect(pool.foreignOpen).toBe(pool.foreignTotal);
+  });
+
+  it("respects an explicit policyStance when present", () => {
+    const empire: Empire = {
+      ...makeEmpire("vex"),
+      routeSlotPool: {
+        policyStance: "isolationist",
+      } as unknown as EmpireRouteSlotPool,
+    };
+    const pool = defaultPoolFor(empire);
+    expect(pool.policyStance).toBe("isolationist");
+    expect(pool.domesticTotal).toBe(
+      DEFAULT_EMPIRE_POOL_BY_STANCE.isolationist.domesticTotal,
+    );
+    expect(pool.foreignTotal).toBe(
+      DEFAULT_EMPIRE_POOL_BY_STANCE.isolationist.foreignTotal,
+    );
+  });
+});
+
+describe("getEmpirePool", () => {
+  it("returns the explicit pool when present", () => {
+    const empire = makeEmpire("solaris", {
+      domesticTotal: 7,
+      foreignTotal: 3,
+      domesticOpen: 5,
+      foreignOpen: 1,
+    });
+    expect(getEmpirePool(empire).domesticTotal).toBe(7);
+    expect(getEmpirePool(empire).foreignOpen).toBe(1);
+  });
+
+  it("falls back to the default for empires without an explicit pool", () => {
+    const empire = makeEmpire("krell");
+    expect(getEmpirePool(empire).domesticOpen).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyRoutePool
+// ---------------------------------------------------------------------------
+
+describe("classifyRoutePool", () => {
+  it("returns domestic when both planets are in the same empire", () => {
+    const state = makeState({
+      empires: [makeEmpire("solaris")],
+      systems: [makeSystem("sys-a", "solaris"), makeSystem("sys-b", "solaris")],
+      planets: [makePlanet("p1", "sys-a"), makePlanet("p2", "sys-b")],
+    });
+    const cls = classifyRoutePool(state, "p1", "p2");
+    expect(cls).toEqual({ empireId: "solaris", pool: "domestic" });
+  });
+
+  it("returns foreign keyed to destination empire when crossing borders", () => {
+    const state = makeState({
+      empires: [makeEmpire("solaris"), makeEmpire("vex")],
+      systems: [makeSystem("sys-a", "solaris"), makeSystem("sys-b", "vex")],
+      planets: [makePlanet("p1", "sys-a"), makePlanet("p2", "sys-b")],
+    });
+    const cls = classifyRoutePool(state, "p1", "p2");
+    expect(cls).toEqual({ empireId: "vex", pool: "foreign" });
+  });
+
+  it("returns null when a planet is missing", () => {
+    const state = makeState({
+      empires: [makeEmpire("solaris")],
+      systems: [makeSystem("sys-a", "solaris")],
+      planets: [makePlanet("p1", "sys-a")],
+    });
+    expect(classifyRoutePool(state, "p1", "missing")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// grantCharter
+// ---------------------------------------------------------------------------
+
+describe("grantCharter", () => {
+  it("grants a permanent player charter and decrements the empire pool", () => {
+    const state = makeState({
+      empires: [makeEmpire("solaris", { domesticOpen: 3, domesticTotal: 4 })],
+      systems: [],
+      planets: [],
+    });
+    const result = grantCharter(state, {
+      empireId: "solaris",
+      pool: "domestic",
+      holderId: PLAYER_COMPANY_ID,
+      term: { kind: "permanent", upkeepPerTurn: 800 },
+    });
+    expect(result.error).toBeNull();
+    expect(result.playerCharters).toHaveLength(1);
+    expect(result.playerCharters[0].pool).toBe("domestic");
+    const empire = result.empires.find((e) => e.id === "solaris");
+    expect(empire?.routeSlotPool?.domesticOpen).toBe(2);
+  });
+
+  it("attaches the contract source when provided", () => {
+    const state = makeState({
+      empires: [makeEmpire("solaris", { domesticOpen: 1, domesticTotal: 1 })],
+      systems: [],
+      planets: [],
+    });
+    const result = grantCharter(state, {
+      empireId: "solaris",
+      pool: "domestic",
+      holderId: PLAYER_COMPANY_ID,
+      term: { kind: "permanent", upkeepPerTurn: 800 },
+      source: { contractId: "contract-42" },
+    });
+    expect(result.charter.sourceContractId).toBe("contract-42");
+    expect(result.charter.sourceAuctionId).toBeUndefined();
+  });
+
+  it("rejects when the empire has no open slots", () => {
+    const state = makeState({
+      empires: [makeEmpire("solaris", { domesticOpen: 0, domesticTotal: 4 })],
+      systems: [],
+      planets: [],
+    });
+    const result = grantCharter(state, {
+      empireId: "solaris",
+      pool: "domestic",
+      holderId: PLAYER_COMPANY_ID,
+      term: { kind: "permanent", upkeepPerTurn: 800 },
+    });
+    expect(result.error).toBe("no-open-slot");
+    expect(result.playerCharters).toHaveLength(0);
+  });
+
+  it("rejects when the empire is unknown", () => {
+    const state = makeState({ empires: [], systems: [], planets: [] });
+    const result = grantCharter(state, {
+      empireId: "nope",
+      pool: "domestic",
+      holderId: PLAYER_COMPANY_ID,
+      term: { kind: "permanent", upkeepPerTurn: 800 },
+    });
+    expect(result.error).toBe("unknown-empire");
+  });
+
+  it("grants to AI companies and updates their charters list", () => {
+    const ai = makeAI("ai-1", "solaris");
+    const state = makeState({
+      empires: [makeEmpire("solaris", { foreignOpen: 2, foreignTotal: 2 })],
+      systems: [],
+      planets: [],
+      aiCompanies: [ai],
+    });
+    const result = grantCharter(state, {
+      empireId: "solaris",
+      pool: "foreign",
+      holderId: "ai-1",
+      term: { kind: "fixedTerm", expiresOnTurn: 9 },
+      source: { auctionId: "auction-3" },
+    });
+    expect(result.error).toBeNull();
+    expect(result.playerCharters).toHaveLength(0);
+    const updated = result.aiCompanies.find((c) => c.id === "ai-1");
+    expect(updated?.charters).toHaveLength(1);
+    expect(updated?.charters?.[0].sourceAuctionId).toBe("auction-3");
+  });
+
+  it("does not mutate the input state", () => {
+    const state = makeState({
+      empires: [makeEmpire("solaris", { domesticOpen: 4, domesticTotal: 4 })],
+      systems: [],
+      planets: [],
+    });
+    const before = JSON.stringify(state);
+    grantCharter(state, {
+      empireId: "solaris",
+      pool: "domestic",
+      holderId: PLAYER_COMPANY_ID,
+      term: { kind: "permanent", upkeepPerTurn: 800 },
+    });
+    expect(JSON.stringify(state)).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// forfeitCharter
+// ---------------------------------------------------------------------------
+
+describe("forfeitCharter", () => {
+  it("returns the slot to the empire pool", () => {
+    const charter: Charter = {
+      id: "ch-1",
+      empireId: "solaris",
+      pool: "domestic",
+      holderId: PLAYER_COMPANY_ID,
+      grantedTurn: 1,
+      term: { kind: "permanent", upkeepPerTurn: 800 },
+    };
+    const state = makeState({
+      empires: [makeEmpire("solaris", { domesticOpen: 3, domesticTotal: 4 })],
+      systems: [],
+      planets: [],
+      charters: [charter],
+    });
+    const result = forfeitCharter(state, "ch-1");
+    expect(result.found).toBe(true);
+    expect(result.playerCharters).toHaveLength(0);
+    expect(result.empires[0].routeSlotPool?.domesticOpen).toBe(4);
+  });
+
+  it("does not push open above total (defensive double-forfeit)", () => {
+    const charter: Charter = {
+      id: "ch-1",
+      empireId: "solaris",
+      pool: "foreign",
+      holderId: PLAYER_COMPANY_ID,
+      grantedTurn: 1,
+      term: { kind: "permanent", upkeepPerTurn: 2500 },
+    };
+    const state = makeState({
+      empires: [makeEmpire("solaris", { foreignOpen: 2, foreignTotal: 2 })],
+      systems: [],
+      planets: [],
+      charters: [charter],
+    });
+    const result = forfeitCharter(state, "ch-1");
+    expect(result.empires[0].routeSlotPool?.foreignOpen).toBe(2);
+  });
+
+  it("reports linked active route ids for caller cleanup", () => {
+    const charter: Charter = {
+      id: "ch-1",
+      empireId: "solaris",
+      pool: "domestic",
+      holderId: PLAYER_COMPANY_ID,
+      grantedTurn: 1,
+      term: { kind: "permanent", upkeepPerTurn: 800 },
+    };
+    const state = makeState({
+      empires: [makeEmpire("solaris", { domesticOpen: 3, domesticTotal: 4 })],
+      systems: [],
+      planets: [],
+      charters: [charter],
+      activeRoutes: [
+        {
+          id: "route-a",
+          originPlanetId: "p1",
+          destinationPlanetId: "p2",
+          distance: 5,
+          assignedShipIds: [],
+          cargoType: null,
+          charterId: "ch-1",
+        },
+        {
+          id: "route-b",
+          originPlanetId: "p3",
+          destinationPlanetId: "p4",
+          distance: 5,
+          assignedShipIds: [],
+          cargoType: null,
+          charterId: "other",
+        },
+      ],
+    });
+    const result = forfeitCharter(state, "ch-1");
+    expect(result.forfeitedRouteIds).toEqual(["route-a"]);
+  });
+
+  it("returns found=false when charter id is unknown", () => {
+    const state = makeState({
+      empires: [makeEmpire("solaris")],
+      systems: [],
+      planets: [],
+    });
+    const result = forfeitCharter(state, "missing");
+    expect(result.found).toBe(false);
+    expect(result.forfeitedRouteIds).toEqual([]);
+  });
+
+  it("forfeits AI charters and refunds the right pool", () => {
+    const charter: Charter = {
+      id: "ai-ch-1",
+      empireId: "solaris",
+      pool: "foreign",
+      holderId: "ai-1",
+      grantedTurn: 1,
+      term: { kind: "fixedTerm", expiresOnTurn: 5 },
+    };
+    const ai = { ...makeAI("ai-1", "solaris"), charters: [charter] };
+    const state = makeState({
+      empires: [makeEmpire("solaris", { foreignOpen: 1, foreignTotal: 2 })],
+      systems: [],
+      planets: [],
+      aiCompanies: [ai],
+    });
+    const result = forfeitCharter(state, "ai-ch-1");
+    expect(result.found).toBe(true);
+    expect(result.aiCompanies[0].charters).toHaveLength(0);
+    expect(result.empires[0].routeSlotPool?.foreignOpen).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findChartersForRoute
+// ---------------------------------------------------------------------------
+
+describe("findChartersForRoute", () => {
+  function setupTwoEmpireState(charters: Charter[] = []): GameState {
+    return makeState({
+      empires: [makeEmpire("solaris"), makeEmpire("vex")],
+      systems: [makeSystem("sys-a", "solaris"), makeSystem("sys-b", "vex")],
+      planets: [makePlanet("p1", "sys-a"), makePlanet("p2", "sys-b")],
+      charters,
+    });
+  }
+
+  it("returns the matching charter id for a domestic route", () => {
+    const state = setupTwoEmpireState([
+      {
+        id: "ch-1",
+        empireId: "solaris",
+        pool: "domestic",
+        holderId: PLAYER_COMPANY_ID,
+        grantedTurn: 1,
+        term: { kind: "permanent", upkeepPerTurn: 800 },
+      },
+    ]);
+    const result = findChartersForRoute(state, PLAYER_COMPANY_ID, "p1", "p1");
+    expect(result).toEqual({ charterId: "ch-1" });
+  });
+
+  it("rejects a foreign route when only a domestic charter is held", () => {
+    const state = setupTwoEmpireState([
+      {
+        id: "ch-1",
+        empireId: "vex",
+        pool: "domestic",
+        holderId: PLAYER_COMPANY_ID,
+        grantedTurn: 1,
+        term: { kind: "permanent", upkeepPerTurn: 800 },
+      },
+    ]);
+    const result = findChartersForRoute(state, PLAYER_COMPANY_ID, "p1", "p2");
+    expect(result).toEqual({ error: "no-matching-charter" });
+  });
+
+  it("accepts a foreign route when matching foreign charter is held", () => {
+    const state = setupTwoEmpireState([
+      {
+        id: "ch-fgn",
+        empireId: "vex",
+        pool: "foreign",
+        holderId: PLAYER_COMPANY_ID,
+        grantedTurn: 1,
+        term: { kind: "fixedTerm", expiresOnTurn: 8 },
+      },
+    ]);
+    const result = findChartersForRoute(state, PLAYER_COMPANY_ID, "p1", "p2");
+    expect(result).toEqual({ charterId: "ch-fgn" });
+  });
+
+  it("flags invalid routes when an endpoint is missing", () => {
+    const state = setupTwoEmpireState();
+    const result = findChartersForRoute(
+      state,
+      PLAYER_COMPANY_ID,
+      "p1",
+      "ghost",
+    );
+    expect(result).toEqual({ error: "invalid-route" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// calculateUpkeep
+// ---------------------------------------------------------------------------
+
+describe("calculateUpkeep", () => {
+  it("scales by tariff rate", () => {
+    const empireZero = makeEmpire("solaris", undefined, 0);
+    const empireHi = makeEmpire("krell", undefined, 0.3);
+    const state = makeState({
+      empires: [empireZero, empireHi],
+      systems: [],
+      planets: [],
+      empireReputation: { solaris: 50, krell: 50 },
+    });
+    const baseDom = calculateUpkeep(
+      state,
+      empireZero,
+      "domestic",
+      PLAYER_COMPANY_ID,
+    );
+    const hiDom = calculateUpkeep(
+      state,
+      empireHi,
+      "domestic",
+      PLAYER_COMPANY_ID,
+    );
+    expect(hiDom).toBeGreaterThan(baseDom);
+    expect(hiDom / baseDom).toBeCloseTo(1.3, 1);
+  });
+
+  it("discounts for renowned/legendary reputation", () => {
+    const empire = makeEmpire("solaris");
+    const stateLow = makeState({
+      empires: [empire],
+      systems: [],
+      planets: [],
+      empireReputation: { solaris: 10 },
+    });
+    const stateHi = makeState({
+      empires: [empire],
+      systems: [],
+      planets: [],
+      empireReputation: { solaris: 95 },
+    });
+    const low = calculateUpkeep(
+      stateLow,
+      empire,
+      "domestic",
+      PLAYER_COMPANY_ID,
+    );
+    const hi = calculateUpkeep(stateHi, empire, "domestic", PLAYER_COMPANY_ID);
+    expect(hi).toBeLessThan(low);
+  });
+
+  it("foreign upkeep is materially higher than domestic at the same rep/tariff", () => {
+    const empire = makeEmpire("solaris");
+    const state = makeState({
+      empires: [empire],
+      systems: [],
+      planets: [],
+      empireReputation: { solaris: 50 },
+    });
+    const dom = calculateUpkeep(state, empire, "domestic", PLAYER_COMPANY_ID);
+    const fgn = calculateUpkeep(state, empire, "foreign", PLAYER_COMPANY_ID);
+    expect(fgn).toBeGreaterThan(dom * 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getHeldCharters / getUpkeepDue
+// ---------------------------------------------------------------------------
+
+describe("getHeldCharters", () => {
+  it("filters by empire when provided", () => {
+    const state = makeState({
+      empires: [makeEmpire("solaris"), makeEmpire("vex")],
+      systems: [],
+      planets: [],
+      charters: [
+        {
+          id: "ch-1",
+          empireId: "solaris",
+          pool: "domestic",
+          holderId: PLAYER_COMPANY_ID,
+          grantedTurn: 1,
+          term: { kind: "permanent", upkeepPerTurn: 800 },
+        },
+        {
+          id: "ch-2",
+          empireId: "vex",
+          pool: "foreign",
+          holderId: PLAYER_COMPANY_ID,
+          grantedTurn: 1,
+          term: { kind: "fixedTerm", expiresOnTurn: 5 },
+        },
+      ],
+    });
+    expect(getHeldCharters(state, PLAYER_COMPANY_ID)).toHaveLength(2);
+    expect(getHeldCharters(state, PLAYER_COMPANY_ID, "vex")).toHaveLength(1);
+  });
+});
+
+describe("getUpkeepDue", () => {
+  it("sums permanent charter upkeep and ignores fixed-term charters", () => {
+    const state = makeState({
+      empires: [makeEmpire("solaris")],
+      systems: [],
+      planets: [],
+      charters: [
+        {
+          id: "ch-1",
+          empireId: "solaris",
+          pool: "domestic",
+          holderId: PLAYER_COMPANY_ID,
+          grantedTurn: 1,
+          term: { kind: "permanent", upkeepPerTurn: 800 },
+        },
+        {
+          id: "ch-2",
+          empireId: "solaris",
+          pool: "foreign",
+          holderId: PLAYER_COMPANY_ID,
+          grantedTurn: 1,
+          term: { kind: "permanent", upkeepPerTurn: 2500 },
+        },
+        {
+          id: "ch-3",
+          empireId: "solaris",
+          pool: "foreign",
+          holderId: PLAYER_COMPANY_ID,
+          grantedTurn: 1,
+          term: { kind: "fixedTerm", expiresOnTurn: 8 },
+        },
+      ],
+    });
+    expect(getUpkeepDue(state, PLAYER_COMPANY_ID)).toBe(3300);
+  });
+});

--- a/src/game/contracts/ContractManager.ts
+++ b/src/game/contracts/ContractManager.ts
@@ -1,13 +1,15 @@
-import type { GameState, Contract } from "../../data/types.ts";
+import type { GameState, Contract, Charter, Empire } from "../../data/types.ts";
 import { ContractType, ContractStatus, RouteScope } from "../../data/types.ts";
 import {
   CONTRACT_FAILURE_REP_PENALTY,
   CONTRACT_UNASSIGNED_SHIP_LIMIT,
   BASE_GALACTIC_ROUTE_SLOTS,
   BASE_SYSTEM_ROUTE_SLOTS,
+  PLAYER_COMPANY_ID,
 } from "../../data/constants.ts";
 import { createRoute } from "../routes/RouteManager.ts";
 import { calculateDistance } from "../routes/RouteManager.ts";
+import { calculateUpkeep, grantCharter } from "../charters/CharterManager.ts";
 import type { NegotiationChoice } from "./ContractNegotiation.ts";
 import { applyNegotiation } from "./ContractNegotiation.ts";
 import {
@@ -95,6 +97,11 @@ export function processContracts(state: GameState): Partial<GameState> {
     state.galacticRouteSlots ?? BASE_GALACTIC_ROUTE_SLOTS;
   let unlockedEmpireIds = [...state.unlockedEmpireIds];
   let activeRoutes = [...state.activeRoutes];
+  // Charter grants need a rolling state view so back-to-back grants on the
+  // same contract pass see each other's pool decrements.
+  let chartersAcc: Charter[] = state.charters ? [...state.charters] : [];
+  let aiCompaniesAcc = state.aiCompanies;
+  let empiresAcc: Empire[] = state.galaxy.empires;
 
   for (let i = 0; i < updatedContracts.length; i++) {
     const c = updatedContracts[i];
@@ -160,6 +167,44 @@ export function processContracts(state: GameState): Partial<GameState> {
         }
       }
 
+      // Charter grant — Phase 3. Permanent term with upkeep priced from the
+      // empire's tariff and the holder's per-empire reputation. Pool may be
+      // exhausted by the time the contract resolves; in that case we silently
+      // skip the grant (matches design — empires don't owe charters they no
+      // longer have capacity for).
+      if (c.rewardCharter) {
+        const holderId = c.aiCompanyId ?? PLAYER_COMPANY_ID;
+        const empire = empiresAcc.find(
+          (e) => e.id === c.rewardCharter!.empireId,
+        );
+        if (empire) {
+          const upkeep = calculateUpkeep(
+            { ...state, galaxy: { ...state.galaxy, empires: empiresAcc } },
+            empire,
+            c.rewardCharter.pool,
+            holderId,
+          );
+          const grantState: GameState = {
+            ...state,
+            galaxy: { ...state.galaxy, empires: empiresAcc },
+            charters: chartersAcc,
+            aiCompanies: aiCompaniesAcc,
+          };
+          const result = grantCharter(grantState, {
+            empireId: c.rewardCharter.empireId,
+            pool: c.rewardCharter.pool,
+            holderId,
+            term: { kind: "permanent", upkeepPerTurn: upkeep },
+            source: { contractId: c.id },
+          });
+          if (result.error === null) {
+            chartersAcc = result.playerCharters;
+            aiCompaniesAcc = result.aiCompanies;
+            empiresAcc = result.empires;
+          }
+        }
+      }
+
       updatedContracts[i] = {
         ...c,
         turnsRemaining: 0,
@@ -181,6 +226,9 @@ export function processContracts(state: GameState): Partial<GameState> {
     unlockedEmpireIds,
     activeRoutes,
     tech: { ...state.tech, researchPoints },
+    charters: chartersAcc,
+    aiCompanies: aiCompaniesAcc,
+    galaxy: { ...state.galaxy, empires: empiresAcc },
   };
 }
 

--- a/src/game/contracts/__tests__/ContractManager.test.ts
+++ b/src/game/contracts/__tests__/ContractManager.test.ts
@@ -427,5 +427,156 @@ describe("Contract Lifecycle", () => {
       expect(result.galacticRouteSlots).toBe(state.galacticRouteSlots ?? 3);
       expect(result.localRouteSlots).toBe(state.localRouteSlots ?? 2);
     });
+
+    it("rewardCharter grants a permanent player charter and decrements empire pool on completion", () => {
+      const contract = makeContract({
+        type: ContractType.PassengerFerry,
+        status: ContractStatus.Active,
+        linkedRouteId: "route-1",
+        turnsRemaining: 1,
+        rewardCharter: { empireId: "empire-1", pool: "domestic" },
+      });
+      const route: ActiveRoute = {
+        id: "route-1",
+        originPlanetId: "planet-1",
+        destinationPlanetId: "planet-2",
+        distance: 10,
+        cargoType: CargoType.Passengers,
+        assignedShipIds: ["ship-1"],
+      };
+      const state = createTestState({
+        contracts: [contract],
+        activeRoutes: [route],
+        charters: [],
+        empireReputation: { "empire-1": 50 },
+        galaxy: {
+          sectors: [],
+          empires: [
+            {
+              id: "empire-1",
+              name: "Empire One",
+              color: 0xffffff,
+              tariffRate: 0.1,
+              disposition: "neutral",
+              homeSystemId: "system-1",
+              leaderName: "Leader",
+              leaderPortrait: { portraitId: "p", category: "human" },
+              routeSlotPool: {
+                policyStance: "regulated",
+                domesticTotal: 6,
+                foreignTotal: 2,
+                domesticOpen: 5,
+                foreignOpen: 2,
+              },
+            },
+          ],
+          systems: [
+            {
+              id: "system-1",
+              name: "S1",
+              sectorId: "sector-1",
+              empireId: "empire-1",
+              x: 0,
+              y: 0,
+              starColor: 0xffffff,
+            },
+          ],
+          planets: [
+            {
+              id: "planet-1",
+              name: "P1",
+              systemId: "system-1",
+              type: "terran",
+              x: 0,
+              y: 0,
+              population: 1000,
+            },
+          ],
+        },
+      });
+
+      const result = processContracts(state);
+      expect(result.charters).toHaveLength(1);
+      const charter = result.charters![0];
+      expect(charter.empireId).toBe("empire-1");
+      expect(charter.pool).toBe("domestic");
+      expect(charter.term.kind).toBe("permanent");
+      if (charter.term.kind === "permanent") {
+        expect(charter.term.upkeepPerTurn).toBeGreaterThan(0);
+      }
+      expect(charter.sourceContractId).toBe(contract.id);
+      const empire = result.galaxy!.empires[0];
+      expect(empire.routeSlotPool?.domesticOpen).toBe(4);
+    });
+
+    it("rewardCharter on AI-accepted contract grants to the AI company", () => {
+      const contract = makeContract({
+        type: ContractType.PassengerFerry,
+        status: ContractStatus.Active,
+        linkedRouteId: "route-ai-1",
+        turnsRemaining: 1,
+        aiCompanyId: "ai-1",
+        rewardCharter: { empireId: "empire-1", pool: "foreign" },
+      });
+      const route: ActiveRoute = {
+        id: "route-ai-1",
+        originPlanetId: "planet-1",
+        destinationPlanetId: "planet-2",
+        distance: 10,
+        cargoType: CargoType.Passengers,
+        assignedShipIds: ["ai-ship-1"],
+      };
+      const state = createTestState({
+        contracts: [contract],
+        activeRoutes: [route],
+        charters: [],
+        empireReputation: { "empire-1": 50 },
+        aiCompanies: [
+          {
+            id: "ai-1",
+            name: "AI",
+            empireId: "empire-1",
+            cash: 100000,
+            fleet: [],
+            activeRoutes: [],
+            reputation: 50,
+            totalCargoDelivered: 0,
+            personality: "steadyHauler",
+            bankrupt: false,
+            ceoName: "AI",
+            ceoPortrait: { portraitId: "p", category: "human" },
+          },
+        ],
+        galaxy: {
+          sectors: [],
+          empires: [
+            {
+              id: "empire-1",
+              name: "Empire One",
+              color: 0xffffff,
+              tariffRate: 0,
+              disposition: "neutral",
+              homeSystemId: "system-1",
+              leaderName: "Leader",
+              leaderPortrait: { portraitId: "p", category: "human" },
+              routeSlotPool: {
+                policyStance: "regulated",
+                domesticTotal: 6,
+                foreignTotal: 2,
+                domesticOpen: 6,
+                foreignOpen: 2,
+              },
+            },
+          ],
+          systems: [],
+          planets: [],
+        },
+      });
+
+      const result = processContracts(state);
+      expect(result.charters).toHaveLength(0);
+      expect(result.aiCompanies![0].charters).toHaveLength(1);
+      expect(result.aiCompanies![0].charters![0].pool).toBe("foreign");
+    });
   });
 });

--- a/src/game/reputation/ReputationEffects.ts
+++ b/src/game/reputation/ReputationEffects.ts
@@ -106,6 +106,62 @@ export function makePremiumContract(baseContract: Contract): Contract {
 // State Helper
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Per-Empire Reputation
+// ---------------------------------------------------------------------------
+
+/** Default reputation for an empire the player has no recorded standing with. */
+export const DEFAULT_EMPIRE_REPUTATION = 50;
+
+/**
+ * Read the player's reputation with a specific empire. Falls back to the
+ * default neutral value when the entry is missing (e.g. v6 saves, or an
+ * empire the player has never interacted with).
+ */
+export function getEmpireRep(state: GameState, empireId: string): number {
+  return state.empireReputation?.[empireId] ?? DEFAULT_EMPIRE_REPUTATION;
+}
+
+/**
+ * Return a new `empireReputation` map with the given empire's reputation
+ * adjusted by `delta`, clamped to [0, 100]. Pure — does not mutate state.
+ * Callers should pass the result to `gameStore.update({ empireReputation: ... })`.
+ */
+export function adjustEmpireRep(
+  state: GameState,
+  empireId: string,
+  delta: number,
+): Record<string, number> {
+  const current = getEmpireRep(state, empireId);
+  const next = Math.max(0, Math.min(100, current + delta));
+  return { ...(state.empireReputation ?? {}), [empireId]: next };
+}
+
+/**
+ * Compute the "fame" reputation — a single global score derived from the
+ * player's standing across all empires. Used for cross-empire gates that
+ * don't have a single subject empire (premium contract access, scoring,
+ * portrait expressions, etc.).
+ *
+ * Strategy: weighted blend of mean and max. The mean keeps notorious players
+ * from gaming the system by being legendary in one empire; the max ensures
+ * a player respected nowhere but legendary in their home empire still feels
+ * recognised.
+ *   fame = 0.6 * mean + 0.4 * max
+ *
+ * When `empireReputation` is empty/missing, falls back to the legacy global
+ * `state.reputation` so Phase 1 does not change any gameplay numbers.
+ */
+export function computeFameRep(state: GameState): number {
+  const map = state.empireReputation;
+  if (!map) return state.reputation;
+  const values = Object.values(map);
+  if (values.length === 0) return state.reputation;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  const max = values.reduce((a, b) => Math.max(a, b), 0);
+  return Math.round(0.6 * mean + 0.4 * max);
+}
+
 /**
  * Derive reputation tier from game state history.
  * Returns the letter grade corresponding to the last turn's net profit,

--- a/src/game/reputation/__tests__/ReputationEffects.test.ts
+++ b/src/game/reputation/__tests__/ReputationEffects.test.ts
@@ -5,8 +5,12 @@ import {
   getReputationTariffMultiplier,
   hasPremiumContractAccess,
   makePremiumContract,
+  getEmpireRep,
+  adjustEmpireRep,
+  computeFameRep,
+  DEFAULT_EMPIRE_REPUTATION,
 } from "../ReputationEffects.ts";
-import type { Contract } from "../../../data/types.ts";
+import type { Contract, GameState } from "../../../data/types.ts";
 import { ContractStatus } from "../../../data/types.ts";
 
 // ── computeReputationTier ────────────────────────────────────────────────────
@@ -206,5 +210,103 @@ describe("makePremiumContract", () => {
     };
     const premium = makePremiumContract(shortContract);
     expect(premium.durationTurns).toBe(1);
+  });
+});
+
+// ── Per-Empire Reputation ────────────────────────────────────────────────────
+
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    reputation: 50,
+    empireReputation: {},
+    ...overrides,
+  } as GameState;
+}
+
+describe("getEmpireRep", () => {
+  it("returns the stored value when present", () => {
+    const state = makeState({ empireReputation: { solaris: 72 } });
+    expect(getEmpireRep(state, "solaris")).toBe(72);
+  });
+
+  it("returns the default when empire is missing", () => {
+    const state = makeState({ empireReputation: {} });
+    expect(getEmpireRep(state, "solaris")).toBe(DEFAULT_EMPIRE_REPUTATION);
+  });
+
+  it("returns the default when empireReputation map is undefined (v6 saves)", () => {
+    const state = makeState();
+    delete (state as Partial<GameState>).empireReputation;
+    expect(getEmpireRep(state, "solaris")).toBe(50);
+  });
+});
+
+describe("adjustEmpireRep", () => {
+  it("adds delta to existing reputation", () => {
+    const state = makeState({ empireReputation: { solaris: 60 } });
+    expect(adjustEmpireRep(state, "solaris", 5).solaris).toBe(65);
+  });
+
+  it("starts from default for an empire with no record", () => {
+    const state = makeState({ empireReputation: {} });
+    expect(adjustEmpireRep(state, "vex", 10).vex).toBe(60);
+  });
+
+  it("clamps to [0, 100]", () => {
+    const state = makeState({ empireReputation: { a: 5, b: 95 } });
+    expect(adjustEmpireRep(state, "a", -50).a).toBe(0);
+    expect(adjustEmpireRep(state, "b", 50).b).toBe(100);
+  });
+
+  it("does not mutate the input map", () => {
+    const map = { solaris: 50 };
+    const state = makeState({ empireReputation: map });
+    adjustEmpireRep(state, "solaris", 10);
+    expect(map.solaris).toBe(50);
+  });
+
+  it("preserves other empires' reputation", () => {
+    const state = makeState({
+      empireReputation: { solaris: 50, vex: 30, krell: 80 },
+    });
+    const next = adjustEmpireRep(state, "solaris", 10);
+    expect(next).toEqual({ solaris: 60, vex: 30, krell: 80 });
+  });
+});
+
+describe("computeFameRep", () => {
+  it("falls back to legacy state.reputation when map is empty", () => {
+    const state = makeState({ reputation: 73, empireReputation: {} });
+    expect(computeFameRep(state)).toBe(73);
+  });
+
+  it("falls back to legacy state.reputation when map is undefined", () => {
+    const state = makeState({ reputation: 42 });
+    delete (state as Partial<GameState>).empireReputation;
+    expect(computeFameRep(state)).toBe(42);
+  });
+
+  it("blends mean and max (0.6 mean + 0.4 max)", () => {
+    const state = makeState({
+      reputation: 99, // ignored when map present
+      empireReputation: { a: 50, b: 50, c: 80 },
+    });
+    // mean = 60, max = 80 -> 0.6*60 + 0.4*80 = 36 + 32 = 68
+    expect(computeFameRep(state)).toBe(68);
+  });
+
+  it("collapses to the single value when only one empire is recorded", () => {
+    const state = makeState({
+      empireReputation: { solo: 70 },
+    });
+    expect(computeFameRep(state)).toBe(70);
+  });
+
+  it("rewards a single legendary standing without ignoring weak rest", () => {
+    const lopsided = makeState({
+      empireReputation: { home: 95, a: 10, b: 10, c: 10 },
+    });
+    // mean = 31.25, max = 95 -> 0.6*31.25 + 0.4*95 = 18.75 + 38 = 56.75 -> 57
+    expect(computeFameRep(lopsided)).toBe(57);
   });
 });

--- a/src/game/routes/RouteManager.ts
+++ b/src/game/routes/RouteManager.ts
@@ -643,6 +643,7 @@ export function createRoute(
   destId: string,
   distance: number,
   cargoType: CargoType | null,
+  charterId?: string,
 ): ActiveRoute {
   return {
     id: `route-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
@@ -651,6 +652,7 @@ export function createRoute(
     distance,
     assignedShipIds: [],
     cargoType,
+    charterId,
   };
 }
 

--- a/src/game/simulation/TurnSimulator.ts
+++ b/src/game/simulation/TurnSimulator.ts
@@ -38,6 +38,11 @@ import {
   getRouteSpeedModifier,
   isPassengerRouteBlocked,
 } from "../events/EventEngine.ts";
+import { applyCharterTurn } from "../charters/CharterManager.ts";
+import {
+  processCharterAuctionsTurn,
+  pruneResolvedAuctions,
+} from "../charters/CharterAuction.ts";
 import {
   tickEventChains,
   checkChainTriggers,
@@ -496,6 +501,51 @@ export function simulateTurn(state: GameState, rng: SeededRNG): GameState {
     ? getHubUpkeep(nextState.stationHub)
     : 0;
 
+  // ----- Step 4b2: Charter auction driver (AI bids + resolution) -----
+  // Run BEFORE charter upkeep so a player who just won a fixed-term charter
+  // doesn't immediately face an upkeep tick (fixed-term has no upkeep anyway,
+  // but order keeps semantics clean). Pure — caller applies the partial state.
+  const auctionTurn = processCharterAuctionsTurn(nextState);
+  if (
+    auctionTurn.playerRefund > 0 ||
+    auctionTurn.resolvedAuctionIds.length > 0 ||
+    auctionTurn.activeAuctions !== (nextState.activeAuctions ?? [])
+  ) {
+    nextState = {
+      ...nextState,
+      activeAuctions: pruneResolvedAuctions(
+        auctionTurn.activeAuctions,
+        nextState.turn,
+      ),
+      galaxy: { ...nextState.galaxy, empires: auctionTurn.empires },
+      charters: auctionTurn.playerCharters,
+      aiCompanies: auctionTurn.aiCompanies,
+      cash: nextState.cash + auctionTurn.playerRefund,
+    };
+  }
+
+  // ----- Step 4c: Charter lifecycle (per-turn upkeep + fixed-term expiry) -----
+  // Pure step — applies forfeits to empire pools and refunds open slots when
+  // charters expire or fail to pay. Linked routes are deleted in the same
+  // pass so the player isn't left with phantom routes. AI cash and charters
+  // are updated in-place via the returned aiCompanies list.
+  const charterTurn = applyCharterTurn(nextState);
+  const charterUpkeep = charterTurn.playerUpkeep;
+  if (charterTurn.forfeitedRouteIds.length > 0) {
+    nextState = {
+      ...nextState,
+      activeRoutes: nextState.activeRoutes.filter(
+        (r) => !charterTurn.forfeitedRouteIds.includes(r.id),
+      ),
+    };
+  }
+  nextState = {
+    ...nextState,
+    charters: charterTurn.playerCharters,
+    aiCompanies: charterTurn.aiCompanies,
+    galaxy: { ...nextState.galaxy, empires: charterTurn.empires },
+  };
+
   // ----- Step 5: Process loans -----
   const { updatedLoans, totalInterest } = processLoans(nextState.loans);
   nextState = { ...nextState, loans: updatedLoans };
@@ -632,7 +682,8 @@ export function simulateTurn(state: GameState, rng: SeededRNG): GameState {
     totalInterest -
     totalTariffCosts -
     totalMothballFees -
-    hubUpkeep;
+    hubUpkeep -
+    charterUpkeep;
   const newCash = nextState.cash + netProfit;
   nextState = { ...nextState, cash: Math.round(newCash * 100) / 100 };
 
@@ -661,7 +712,7 @@ export function simulateTurn(state: GameState, rng: SeededRNG): GameState {
     maintenanceCosts: Math.round(maintenanceCosts * 100) / 100,
     loanPayments: totalInterest,
     tariffCosts: totalTariffCosts,
-    otherCosts: totalMothballFees + hubUpkeep,
+    otherCosts: totalMothballFees + hubUpkeep + charterUpkeep,
     netProfit: Math.round(netProfit * 100) / 100,
     cashAtEnd: nextState.cash,
     cargoDelivered,

--- a/src/generation/GalaxyGenerator.ts
+++ b/src/generation/GalaxyGenerator.ts
@@ -30,6 +30,7 @@ import {
   HYPERLANE_DENSITY_CONFIGS,
   HYPERLANE_SHAPE_BIAS,
   HYPERLANE_MIN_CONNECTIONS,
+  DEFAULT_EMPIRE_POOL_BY_STANCE,
 } from "../data/constants.ts";
 import type { GamePreset } from "../data/constants.ts";
 
@@ -666,6 +667,18 @@ export function generateGalaxy(
       }
     }
 
+    // Charter pool stance is loosely correlated with disposition:
+    //   friendly  → open       (more foreign charters, fewer domestic)
+    //   hostile   → isolationist (mostly domestic, almost no foreign)
+    //   else      → regulated   (balanced)
+    const policyStance: "isolationist" | "regulated" | "open" =
+      disposition === "friendly"
+        ? "open"
+        : disposition === "hostile"
+          ? "isolationist"
+          : "regulated";
+    const poolSizes = DEFAULT_EMPIRE_POOL_BY_STANCE[policyStance];
+
     const empire: Empire = {
       id: empireId,
       name: empireName,
@@ -675,6 +688,13 @@ export function generateGalaxy(
       homeSystemId,
       leaderName: generateLeaderName(rng),
       leaderPortrait: pickRandomLeaderPortrait(rng),
+      routeSlotPool: {
+        policyStance,
+        domesticTotal: poolSizes.domesticTotal,
+        foreignTotal: poolSizes.foreignTotal,
+        domesticOpen: poolSizes.domesticTotal,
+        foreignOpen: poolSizes.foreignTotal,
+      },
     };
     empires.push(empire);
   }

--- a/src/scenes/EmpireScene.ts
+++ b/src/scenes/EmpireScene.ts
@@ -228,12 +228,30 @@ export class EmpireScene extends Phaser.Scene {
       empireSystems.some((s) => s.id === p.systemId),
     );
 
+    // Charter standing in this empire — visible at-a-glance so the player
+    // sees both their footprint here and how much room is left to grow.
+    const playerCharters = (state.charters ?? []).filter(
+      (c) => c.empireId === empireId,
+    );
+    const playerDom = playerCharters.filter(
+      (c) => c.pool === "domestic",
+    ).length;
+    const playerFgn = playerCharters.filter((c) => c.pool === "foreign").length;
+    const pool = empire.routeSlotPool;
+    const repInThisEmpire = state.empireReputation?.[empireId] ?? 50;
+
     this.portrait.showEmpireLeader(empire, [
       { label: "Empire", value: empire.name },
       { label: "Systems", value: String(empireSystems.length) },
       { label: "Planets", value: String(empirePlanets.length) },
       { label: "Tariff", value: `${(empire.tariffRate * 100).toFixed(0)}%` },
       { label: "Disposition", value: empire.disposition },
+      { label: "Your rep", value: String(Math.round(repInThisEmpire)) },
+      { label: "Your charters", value: `${playerDom}D / ${playerFgn}F` },
+      {
+        label: "Open slots",
+        value: pool ? `${pool.domesticOpen}D / ${pool.foreignOpen}F` : "—",
+      },
     ]);
   }
 }

--- a/src/scenes/GameHUDScene.ts
+++ b/src/scenes/GameHUDScene.ts
@@ -20,38 +20,37 @@ import type {
   NavTabId,
 } from "../data/types.ts";
 import { TUTORIAL_STEPS } from "../game/adviser/TutorialDefinitions.ts";
-import {
-  getAvailableRouteSlots,
-  getUsedRouteSlots,
-  getAvailableLocalRouteSlots,
-  getUsedLocalRouteSlots,
-  getAvailableGalacticRouteSlots,
-  getUsedGalacticRouteSlots,
-} from "../game/routes/RouteManager.ts";
 import type { GameState } from "../data/types.ts";
 import { generateTickerFeed } from "../generation/news/tickerFeed.ts";
 
 /**
- * Compact "Sys 1/2 · Emp 2/4 · Gal 0/2" string for the HUD route-slot
- * indicator. Three pools displayed inline so the player sees at-a-glance
- * which tier is saturated.
+ * Compact "Charters: 3 (2P/1F) · Upkeep: §2,400" string for the HUD.
+ * Replaces the legacy three-tier slot indicator now that empires own slot
+ * pools and players hold charters. The P/F suffix splits permanent vs
+ * fixed-term so an upcoming auction expiry is easy to spot.
  */
 function formatSlotSummary(state: GameState): {
   text: string;
   anySaturated: boolean;
 } {
-  const sysUsed = getUsedLocalRouteSlots(state);
-  const sysTot = getAvailableLocalRouteSlots(state);
-  const empUsed = getUsedRouteSlots(state);
-  const empTot = getAvailableRouteSlots(state);
-  const galUsed = getUsedGalacticRouteSlots(state);
-  const galTot = getAvailableGalacticRouteSlots(state);
-  const anySaturated =
-    sysUsed >= sysTot || empUsed >= empTot || galUsed >= galTot;
-  return {
-    text: `Sys ${sysUsed}/${sysTot} · Emp ${empUsed}/${empTot} · Gal ${galUsed}/${galTot}`,
-    anySaturated,
-  };
+  const charters = state.charters ?? [];
+  const permanent = charters.filter((c) => c.term.kind === "permanent").length;
+  const fixedTerm = charters.filter((c) => c.term.kind === "fixedTerm").length;
+  const upkeep = charters.reduce(
+    (sum, c) => sum + (c.term.kind === "permanent" ? c.term.upkeepPerTurn : 0),
+    0,
+  );
+  // Saturation = upcoming upkeep exceeds current cash, or a fixed-term
+  // charter expires within 2 turns.
+  const cantPay = upkeep > state.cash;
+  const expiringSoon = charters.some(
+    (c) =>
+      c.term.kind === "fixedTerm" && c.term.expiresOnTurn - state.turn <= 2,
+  );
+  const text = `Charters: ${charters.length} (${permanent}P/${fixedTerm}F) · Upkeep: §${Math.round(
+    upkeep,
+  ).toLocaleString("en-US")}`;
+  return { text, anySaturated: cantPay || expiringSoon };
 }
 import { getPortraitTextureKey } from "../data/portraits.ts";
 import {

--- a/src/ui/RouteBuilderPanel.ts
+++ b/src/ui/RouteBuilderPanel.ts
@@ -23,6 +23,8 @@ import {
   validateRouteCreation,
   getEmpireForPlanet,
 } from "../game/empire/EmpireAccessManager.ts";
+import { findChartersForRoute } from "../game/charters/CharterManager.ts";
+import { PLAYER_COMPANY_ID } from "../data/constants.ts";
 import { getLayout } from "./Layout.ts";
 import { Button } from "./Button.ts";
 import { Label } from "./Label.ts";
@@ -987,6 +989,39 @@ class RouteBuilderPanel {
       return;
     }
 
+    // Charter check — every new route must be backed by a held charter
+    // matching the route's empire and pool (domestic / foreign).
+    const charterMatch = findChartersForRoute(
+      latestState,
+      PLAYER_COMPANY_ID,
+      origin.id,
+      destination.id,
+    );
+    if ("error" in charterMatch) {
+      const destEmpireId = getEmpireForPlanet(
+        destination.id,
+        latestState.galaxy.systems,
+        latestState.galaxy.planets,
+      );
+      const destEmpire = (latestState.galaxy.empires ?? []).find(
+        (e) => e.id === destEmpireId,
+      );
+      const empireName = destEmpire?.name ?? "this empire";
+      const message =
+        charterMatch.error === "no-matching-charter"
+          ? `You don't hold a charter in ${empireName}. Acquire one through a contract or auction before opening this route.`
+          : "Route endpoints could not be classified into an empire pool.";
+      this.statusValue.setText(`⚠ ${message}`);
+      this.statusValue.setLabelColor(getTheme().colors.loss);
+      const errModal2 = new Modal(this.scene, {
+        title: "Charter Required",
+        body: message,
+        onOk: () => errModal2.destroy(),
+      });
+      errModal2.show();
+      return;
+    }
+
     const distance = calculateDistance(
       origin,
       destination,
@@ -1013,7 +1048,13 @@ class RouteBuilderPanel {
       return;
     }
 
-    const route = createRoute(origin.id, destination.id, distance, cargo);
+    const route = createRoute(
+      origin.id,
+      destination.id,
+      distance,
+      cargo,
+      charterMatch.charterId,
+    );
 
     let updatedFleet = [...latestState.fleet];
     let updatedRoutes = [...latestState.activeRoutes, route];


### PR DESCRIPTION
## Summary

Flip route-slot ownership: **empires** now own pools of route charters that companies (player + AI) lease, paying recurring upkeep. Player-side slot caps no longer gate route creation. Per-empire reputation replaces the single global rep score for empire-specific gating.

This addresses the player feedback that fixed slot caps felt artificial and that the game lacked a scarce resource to compete over with rival companies.

## What's new

**Data model**
- `Charter`, `EmpireRouteSlotPool`, `CharterAuction` types
- Two charter terms:
  - `permanent` — recurring upkeep, granted by contracts
  - `fixedTerm` — no upkeep, expires after N turns, won at auction
- Per-empire reputation (`state.empireReputation`) — global `state.reputation` stays as derived "fame" reading
- `SAVE_VERSION` bumped to 7 (pre-release; no migration)

**Logic**
- `CharterManager` — grant/forfeit, route gating (`findChartersForRoute`), per-turn upkeep & fixed-term expiry
- `CharterAuction` — sealed-bid resolver, AI bidding heuristic flavored by personality, per-turn driver
- `ContractManager` — new `Contract.rewardCharter` field grants permanent charters on completion
- `NewGameSetup` — grants 2 free starter charters in player's home empire (zero upkeep)
- `GalaxyGenerator` — picks `policyStance` per empire from disposition (friendly→open, hostile→isolationist, else regulated); pool sizes follow

**UI**
- HUD: \`Charters: N (P/F) · Upkeep: §X\` replaces old `Sys/Emp/Gal` triple; turns red when upkeep > cash or fixed-term expires within 2 turns
- Route Builder: requires a held charter for the route's empire/pool, shows "Acquire charter in [Empire]" CTA otherwise
- Empire Scene sidebar: per-empire rep, your charters (D/F), empire's open slots

## Why

- Removes the artificial player-only cap on routes
- Creates a real scarce resource that drives conflict between companies
- Foundation for the zero-to-hero progression arc (intra-system → home regional → cross-border → galactic) gated by per-empire rep + upkeep affordability
- Sets up character-driven UI hooks (per-empire rep enables "renowned in Solaris, hated in Vex" stories)

## Deferred (clean seams left for follow-up PR)

- `EventEngine` turmoil triggers — `empire_succession`, `signPeace`, `closeBorders` should call `startAuction`. Hooks don't exist yet, but `startAuction` is fully tested and ready.
- `CharterAuctionPanel` modal — auctions don't trigger automatically yet, so the modal would have nothing to display in the live game flow.

## Test plan

- [x] \`npm run check\` — 896 tests pass, typecheck clean, prod build succeeds
- [x] 53 new tests across CharterManager, CharterAuction, ContractManager, ReputationEffects
- [x] Dev server boots; new game flow produces correct state (verified via runtime eval): `saveVersion: 7`, 2 starter charters, per-empire rep populated for all 8 empires, varied pool sizes per disposition
- [ ] Manual playthrough of several turns to confirm upkeep deducts and HUD updates correctly
- [ ] Reviewer to sanity-check upkeep balance constants (`BASE_DOMESTIC_UPKEEP=800`, `BASE_FOREIGN_UPKEEP=2500`) at standard preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)