### PR TITLE
fix(ui): migrate news ticker + panel off Phaser 3 setMask

### DIFF
--- a/src/ui/GalacticNewsPanel.ts
+++ b/src/ui/GalacticNewsPanel.ts
@@ -1,5 +1,6 @@
 import * as Phaser from "phaser";
 import { Panel, getTheme, colorToString } from "./index.ts";
+import { applyClippingMask } from "@spacebiz/ui";
 import type { TickerItem } from "../generation/news/types.ts";
 import { CATEGORY_META } from "../generation/news/categories.ts";
 
@@ -24,7 +25,6 @@ export interface GalacticNewsPanelConfig {
  */
 export class GalacticNewsPanel extends Panel {
   private inner: Phaser.GameObjects.Container;
-  private geometryMask: Phaser.Display.Masks.GeometryMask | null = null;
   private maskShape: Phaser.GameObjects.Graphics | null = null;
   private scrollTween: Phaser.Tweens.Tween | null = null;
   private isHovered = false;
@@ -57,19 +57,7 @@ export class GalacticNewsPanel extends Panel {
     maskShape.setVisible(false);
     this.maskShape = maskShape;
 
-    // Phaser 4: prefer the filter API; fall back to setMask if filters absent
-    // (defensive — current Phaser 4 RC supports both).
-    const innerWithFilters = this.inner as unknown as {
-      filters?: {
-        internal: { addMask(shape: Phaser.GameObjects.Graphics): void };
-      };
-    };
-    if (innerWithFilters.filters?.internal?.addMask) {
-      innerWithFilters.filters.internal.addMask(maskShape);
-    } else {
-      this.geometryMask = maskShape.createGeometryMask();
-      this.inner.setMask(this.geometryMask);
-    }
+    applyClippingMask(this.inner, maskShape);
 
     // Render the lines stacked vertically.
     const lineHeight = theme.fonts.body.size + 6;
@@ -152,10 +140,6 @@ export class GalacticNewsPanel extends Panel {
   private cleanup(): void {
     this.scrollTween?.stop();
     this.scrollTween = null;
-    if (this.geometryMask) {
-      this.geometryMask.destroy();
-      this.geometryMask = null;
-    }
     this.maskShape?.destroy();
     this.maskShape = null;
   }

--- a/src/ui/HorizontalNewsTicker.ts
+++ b/src/ui/HorizontalNewsTicker.ts
@@ -1,5 +1,6 @@
 import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./index.ts";
+import { applyClippingMask } from "@spacebiz/ui";
 import type { TickerItem } from "../generation/news/types.ts";
 import { CATEGORY_META } from "../generation/news/categories.ts";
 
@@ -20,7 +21,12 @@ function buildMarqueeString(items: TickerItem[]): string {
 
 /**
  * Persistent horizontal news crawl rendered in GameHUDScene's ticker strip.
- * Items scroll right-to-left at a constant speed, looping continuously.
+ * Items scroll right-to-left at a constant speed.
+ *
+ * `updateItems` does NOT interrupt the in-flight scroll. Incoming items become
+ * the "pending" payload — replacing any earlier pending payload that has not
+ * yet been shown — and take over only after the current pass completes
+ * off-screen. If nothing is pending when a pass ends, the same items re-loop.
  */
 export class HorizontalNewsTicker {
   private readonly scene: Phaser.Scene;
@@ -32,6 +38,9 @@ export class HorizontalNewsTicker {
   private maskShape: Phaser.GameObjects.Graphics | null = null;
   private marqueeText: Phaser.GameObjects.Text | null = null;
   private scrollTween: Phaser.Tweens.Tween | null = null;
+  private currentItems: TickerItem[] = [];
+  private pendingItems: TickerItem[] | null = null;
+  private destroyed = false;
 
   constructor(
     scene: Phaser.Scene,
@@ -57,10 +66,19 @@ export class HorizontalNewsTicker {
   }
 
   updateItems(items: TickerItem[]): void {
-    this.scrollTween?.stop();
-    this.scrollTween = null;
-    this.marqueeText?.destroy();
-    this.marqueeText = null;
+    if (this.scrollTween) {
+      // Currently scrolling — queue this payload, replacing any earlier
+      // pending payload that has not yet been displayed.
+      this.pendingItems = items;
+      return;
+    }
+    this.currentItems = items;
+    this.pendingItems = null;
+    this.startScrollPass(items);
+  }
+
+  private startScrollPass(items: TickerItem[]): void {
+    if (this.destroyed) return;
 
     const theme = getTheme();
     const text = buildMarqueeString(items);
@@ -83,36 +101,44 @@ export class HorizontalNewsTicker {
 
     // Apply mask so text doesn't bleed outside the strip.
     if (this.maskShape) {
-      const geomMask = this.maskShape.createGeometryMask();
-      this.marqueeText.setMask(geomMask);
+      applyClippingMask(this.marqueeText, this.maskShape);
     }
 
     const textWidth = this.marqueeText.width;
     const totalTravel = this.width + textWidth;
     const duration = (totalTravel / SCROLL_SPEED) * 1000;
 
-    // Scroll from right edge to fully off-screen left, then repeat.
+    // Single-pass tween from right edge to fully off-screen left. When the
+    // pass finishes, drain the pending queue (or re-loop the same items).
     this.scrollTween = this.scene.tweens.add({
       targets: this.marqueeText,
       x: this.x - textWidth,
       duration,
       ease: "Linear",
-      repeat: -1,
-      onRepeat: () => {
-        // Reset to right edge for next cycle.
-        if (this.marqueeText) {
-          this.marqueeText.setX(this.x + this.width);
-        }
-      },
+      onComplete: () => this.onPassComplete(),
     });
   }
 
+  private onPassComplete(): void {
+    this.marqueeText?.destroy();
+    this.marqueeText = null;
+    this.scrollTween = null;
+    if (this.destroyed) return;
+
+    const next = this.pendingItems ?? this.currentItems;
+    this.pendingItems = null;
+    this.currentItems = next;
+    this.startScrollPass(next);
+  }
+
   destroy(): void {
+    this.destroyed = true;
     this.scrollTween?.stop();
     this.scrollTween = null;
     this.marqueeText?.destroy();
     this.marqueeText = null;
     this.maskShape?.destroy();
     this.maskShape = null;
+    this.pendingItems = null;
   }
 }


### PR DESCRIPTION
## Summary

- `GalacticNewsPanel` and `HorizontalNewsTicker` were the last two UI components still using the Phaser 3 `maskShape.createGeometryMask()` + `setMask()` pair. Under Phaser 4 WebGL (the project's only renderer) those calls are no-ops and emit a deprecation warning. The ticker re-masked on every `updateItems`, producing 330+ warnings per game session. CLAUDE.md mandates the Phaser 4 filter API; PR #213 was supposed to be the final pass on this.
- Both call sites now go through the existing `applyClippingMask` helper from `@spacebiz/ui`, which uses `filters.internal.addMask(maskShape, false, undefined, "world")`.
- Also addresses a UX issue in the ticker: `updateItems` used to destroy the in-flight marquee and reset to the right edge whenever fresh items arrived, cutting off mid-message. The ticker now keeps the current pass running to completion; new payloads land in a single `pendingItems` slot (replacing any earlier-but-not-yet-shown payload) and only take over once the current scroll exits off-screen left. If nothing is pending at swap time, the same items re-loop.

## Why

CLAUDE.md is explicit: *"use the v4 filter API — `gameObject.filters?.internal.addMask(maskShape)` — not `setMask()`/`createGeometryMask()`"*. The remaining call sites were both no-ops under WebGL and a major source of console noise. Letting `updateItems` interrupt the in-flight scroll also meant turn-driven news updates clobbered messages players were mid-read.

## Verification

- `npm run check` — typecheck clean, 896/896 tests pass, build succeeds.
- Dev build, `GameHUDScene` + `GalaxyMapScene` (where the ticker is mounted), instrumented console hook on `console.{log,info,warn,error,debug}` matching `/setMask|createGeometryMask/i`: **0** warnings across 25 s of continuous scrolling, vs. ~330+/session before.
- Ticker visual behavior unchanged: same right-to-left marquee at the same speed.

## Reviewer notes — out-of-scope finding

While stress-testing across `Fleet`/`Routes`/`Finance` scenes I observed 22 residual `setMask` warnings. Stack traces show **all** of them originate inside `applyClippingMask`'s legacy fallback in `packages/spacebiz-ui/src/MaskUtils.ts`, called from `PortraitPanel` and `ScrollFrame` — `target.filters?.internal?.addMask` evaluates falsy for those targets, so the helper falls through to the Phaser 3 path. None are from the news ticker or panel. This is a separate, pre-existing issue worth its own PR — likely needs the helper to enable/initialize the FilterList before checking for `addMask`.

## Test plan

- [ ] `npm run check` passes
- [ ] Boot a new game; confirm the bottom news ticker scrolls right-to-left at constant speed and looks visually identical to before
- [ ] Open the browser console; confirm zero `setMask: This method is not supported in WebGL` warnings while sitting on `GameHUDScene`
- [ ] End a turn so news updates fire; confirm the current marquee finishes its pass before the new payload swaps in (no mid-message reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)