### PR TITLE
fix(masks): call enableFilters() before reading filters in applyClippingMask

### DIFF
--- a/packages/spacebiz-ui/src/MaskUtils.ts
+++ b/packages/spacebiz-ui/src/MaskUtils.ts
@@ -5,11 +5,19 @@ import * as Phaser from "phaser";
  *
  * Phaser 4 + WebGL: the only supported geometry mask path is the filter-based
  * mask via `gameObject.filters.internal.addMask(maskShape)`. The legacy
- * `setMask(maskShape.createGeometryMask())` API only works on the Canvas
- * Renderer in Phaser 4 (it silently no-ops under WebGL). Phaser's own type
- * docs warn:
+ * `setMask(maskShape.createGeometryMask())` API logs a deprecation warning
+ * and silently no-ops under WebGL. Phaser's own type docs warn:
  *   "GeometryMask is only supported in the Canvas Renderer. If you want to
  *    use geometry to mask objects in WebGL, see FilterList#addMask."
+ *
+ * Important Phaser 4 detail: `target.filters` is a *getter* that returns
+ * `null` until `target.enableFilters()` has been called. Without that call,
+ * `target.filters?.internal?.addMask` is always falsy and you fall through
+ * to the deprecated `setMask` path. `enableFilters()` lazily allocates a
+ * filter camera + `{ internal, external }` FilterList pair (see
+ * Phaser src/gameobjects/components/Filters.js). It's idempotent (early-
+ * returns if `filterCamera` is already set) and a no-op under non-WebGL
+ * renderers, so it's safe to call before every mask application.
  *
  * The filter mask renders the target (and, for Containers, the entire
  * container subtree) into a render texture, then composites only the masked
@@ -17,44 +25,47 @@ import * as Phaser from "phaser";
  * previous fix in this file mistakenly believed otherwise and routed
  * Containers to the no-op `setMask` path, which caused DataTable rows to
  * escape the table on scroll.
- *
- * Callers that need rock-solid clipping for scrolling content should also
- * implement viewport-based row visibility (see DataTable.clipRowsToViewport)
- * as belt-and-suspenders, since filter masks can be defeated by transform
- * staleness in nested containers.
  */
 export function applyClippingMask(
   target: Phaser.GameObjects.GameObject,
   maskShape: Phaser.GameObjects.Graphics,
 ): void {
-  // Phaser 4 WebGL filter mask path — works for Containers and renderables.
-  // Use viewTransform: 'world' so maskShape.setPosition(matrix.tx, matrix.ty)
+  // Phaser 4 WebGL filter mask path. Must call enableFilters() first to
+  // allocate the filter camera; otherwise `target.filters` is null.
+  // viewTransform: 'world' so maskShape.setPosition(matrix.tx, matrix.ty)
   // (called from preupdate sync) is interpreted in world coords.
-  const filters = (
-    target as unknown as {
-      filters?: {
-        internal?: {
-          addMask?: (
-            mask: Phaser.GameObjects.Graphics,
-            invert?: boolean,
-            viewCamera?: Phaser.Cameras.Scene2D.Camera,
-            viewTransform?: "local" | "world",
-            scaleFactor?: number,
-          ) => unknown;
-        };
+  const t = target as unknown as {
+    enableFilters?: () => unknown;
+    filters?: {
+      internal?: {
+        addMask?: (
+          mask: Phaser.GameObjects.Graphics,
+          invert?: boolean,
+          viewCamera?: Phaser.Cameras.Scene2D.Camera,
+          viewTransform?: "local" | "world",
+          scaleFactor?: number,
+        ) => unknown;
       };
-    }
-  ).filters;
-  if (filters?.internal?.addMask) {
-    filters.internal.addMask(maskShape, false, undefined, "world");
+    };
+  };
+
+  if (typeof t.enableFilters === "function") {
+    t.enableFilters();
+  }
+
+  if (t.filters?.internal?.addMask) {
+    t.filters.internal.addMask(maskShape, false, undefined, "world");
     return;
   }
 
-  // Phaser 3 fallback (only useful during dev when node_modules lags).
-  const t = target as unknown as {
+  // Last-resort fallback (only reachable on non-WebGL renderers, e.g. unit
+  // tests under the headless canvas mock). Under WebGL this path emits a
+  // deprecation warning and no-ops, so we deliberately don't take it when
+  // the filter API is reachable.
+  const legacy = target as unknown as {
     setMask?: (mask: Phaser.Display.Masks.GeometryMask) => unknown;
   };
-  if (typeof t.setMask === "function") {
-    t.setMask(maskShape.createGeometryMask());
+  if (typeof legacy.setMask === "function") {
+    legacy.setMask(maskShape.createGeometryMask());
   }
 }


### PR DESCRIPTION
## Summary

- `applyClippingMask` now calls `target.enableFilters()` before reading `target.filters`, so the WebGL filter mask path is reliably taken on `Container`, `Image`, and `Graphics` targets.
- Eliminates ~22 `setMask` / `createGeometryMask` deprecation warnings per navigation into `FleetScene`, `RoutesScene`, and `FinanceScene` (called from `PortraitPanel` × 3 sites and `ScrollFrame`).

## Root cause

In Phaser 4, `gameObject.filters` is a *getter* that returns `null` until `enableFilters()` is called — that's what lazily allocates the hidden filter camera and the `{ internal, external }` `FilterList` pair (see Phaser source: `src/gameobjects/components/Filters.js:86-95, 237-287`). Without the prior `enableFilters()` call, the optional chain `target.filters?.internal?.addMask` always evaluated falsy and the helper fell through to the legacy `setMask` path, which Phaser 4 + WebGL logs as deprecated and silently no-ops.

`enableFilters()` is idempotent (early-returns if `filterCamera` is already set) and a no-op under non-WebGL renderers, so it's safe to call defensively before every mask application. All `GameObject` subclasses inherit it from the base mixin chain (`GameObject.js:48-51`), so no per-type branching is needed.

## Test plan

- [x] `npm run check` — typecheck + 896 tests + production build all green.
- [x] Live nav through `MainMenuScene → FleetScene → RoutesScene → FinanceScene → FleetScene` (5 transitions) with a `console.log/info/warn/error/debug` hook on `/setMask|createGeometryMask/i` produced **0 deprecation warnings** (down from ~22).
- [x] Screenshot confirmed `FleetScene`'s `PortraitPanel` and `ScrollFrame` render with the clip mask intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)