### PR TITLE
feat(ui-tier-1): add Toast/ToastManager/ConfirmDialog

### DIFF
--- a/packages/spacebiz-ui/src/index.ts
+++ b/packages/spacebiz-ui/src/index.ts
@@ -109,6 +109,9 @@ export {
 } from "./CargoIcons.ts";
 export type { CargoTypeValue } from "./CargoIcons.ts";
 
+// Notifications
+export * from "./notifications/index.ts";
+
 // Ship icon utilities
 export {
   generateShipIcons,

--- a/packages/spacebiz-ui/src/notifications/ConfirmDialog.ts
+++ b/packages/spacebiz-ui/src/notifications/ConfirmDialog.ts
@@ -1,0 +1,73 @@
+import type * as Phaser from "phaser";
+import { Modal } from "../Modal.ts";
+
+export type ConfirmDialogKind = "default" | "danger";
+
+export interface ConfirmDialogConfig {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  kind?: ConfirmDialogKind;
+  width?: number;
+  height?: number;
+  testId?: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+}
+
+/**
+ * Standardized confirm/cancel dialog. Composes the existing `Modal` so
+ * styling stays in one place; adds a `Promise<boolean>` API for ergonomic
+ * async usage.
+ *
+ * The `kind: 'danger'` variant is reserved for destructive actions and is
+ * surfaced via the testId prefix (e.g. `confirm-danger-ok`). Theming for
+ * the danger variant currently relies on the wording / context — the
+ * underlying Modal API does not yet support per-button colour overrides.
+ */
+export class ConfirmDialog {
+  /**
+   * Show a confirm dialog and resolve a promise with the user's choice.
+   * `true` if confirmed, `false` if cancelled or dismissed.
+   */
+  static show(
+    scene: Phaser.Scene,
+    config: ConfirmDialogConfig,
+  ): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const settle = (value: boolean): void => {
+        if (settled) return;
+        settled = true;
+        resolve(value);
+      };
+
+      const prefix =
+        config.testId ??
+        (config.kind === "danger" ? "confirm-danger" : "confirm");
+
+      const modal = new Modal(scene, {
+        title: config.title,
+        body: config.message,
+        okText: config.confirmLabel ?? "Confirm",
+        cancelText: config.cancelLabel ?? "Cancel",
+        width: config.width,
+        height: config.height,
+        testId: prefix,
+        onOk: () => {
+          config.onConfirm?.();
+          settle(true);
+        },
+        onCancel: () => {
+          config.onCancel?.();
+          settle(false);
+        },
+      });
+      modal.show();
+      // If the modal is destroyed without either callback firing
+      // (e.g. scene shutdown), resolve as cancelled so awaiters don't hang.
+      modal.once("destroy", () => settle(false));
+    });
+  }
+}

--- a/packages/spacebiz-ui/src/notifications/Toast.ts
+++ b/packages/spacebiz-ui/src/notifications/Toast.ts
@@ -1,0 +1,143 @@
+import * as Phaser from "phaser";
+import { getTheme, colorToString } from "../Theme.ts";
+
+export type ToastKind = "info" | "success" | "warning" | "error";
+
+export interface ToastConfig {
+  message: string;
+  kind?: ToastKind;
+  /** Auto-dismiss after this many ms. Defaults to 3000. Use 0 for sticky. */
+  durationMs?: number;
+  /** Maximum width before the message wraps. Defaults to 320. */
+  width?: number;
+  onDismiss?: () => void;
+}
+
+const PADDING_X = 14;
+const PADDING_Y = 10;
+const SLIDE_DURATION = 220;
+
+/**
+ * Single transient corner notification. Slides in from the right edge,
+ * auto-dismisses after `durationMs`, and can be dismissed by clicking.
+ *
+ * Toasts are normally created and laid out by `ToastManager`; instantiate
+ * directly only for one-off cases.
+ */
+export class Toast extends Phaser.GameObjects.Container {
+  readonly toastWidth: number;
+  readonly toastHeight: number;
+  readonly kind: ToastKind;
+  private dismissed = false;
+  private autoTimer: Phaser.Time.TimerEvent | null = null;
+  private readonly onDismissFn?: () => void;
+
+  constructor(scene: Phaser.Scene, config: ToastConfig) {
+    super(scene, 0, 0);
+    const theme = getTheme();
+    const kind = config.kind ?? "info";
+    this.kind = kind;
+    this.onDismissFn = config.onDismiss;
+
+    const maxWidth = config.width ?? 320;
+    const innerWidth = maxWidth - PADDING_X * 2;
+
+    const fg = kindForeground(theme, kind);
+    // All kinds share the panel background; the accent strip + border signal kind.
+    const bg = theme.colors.panelBg;
+
+    const text = scene.add.text(PADDING_X, PADDING_Y, config.message, {
+      fontFamily: theme.fonts.body.family,
+      fontSize: `${theme.fonts.body.size}px`,
+      color: colorToString(theme.colors.text),
+      wordWrap: { width: innerWidth },
+    });
+
+    const measuredWidth = Math.min(maxWidth, text.width + PADDING_X * 2);
+    const measuredHeight = text.height + PADDING_Y * 2;
+
+    this.toastWidth = measuredWidth;
+    this.toastHeight = measuredHeight;
+
+    const background = scene.add
+      .rectangle(0, 0, measuredWidth, measuredHeight, bg, 0.96)
+      .setOrigin(0, 0)
+      .setStrokeStyle(1, fg, 0.85);
+
+    // Left accent strip — kind indicator.
+    const accent = scene.add
+      .rectangle(0, 0, 4, measuredHeight, fg, 1)
+      .setOrigin(0, 0);
+
+    background.setInteractive({ useHandCursor: true });
+    background.on("pointerup", () => this.dismiss());
+
+    this.add([background, accent, text]);
+    scene.add.existing(this);
+
+    const duration = config.durationMs ?? 3000;
+    if (duration > 0) {
+      this.autoTimer = scene.time.delayedCall(duration, () => this.dismiss());
+    }
+  }
+
+  /**
+   * Animate the toast to the given top-right anchor. Called by the manager.
+   * `targetX` is the right edge to align the toast's right side to.
+   */
+  slideTo(targetX: number, targetY: number, animate: boolean): void {
+    const finalX = targetX - this.toastWidth;
+    if (!animate || !this.scene) {
+      this.setPosition(finalX, targetY);
+      return;
+    }
+    this.scene.tweens.add({
+      targets: this,
+      x: finalX,
+      y: targetY,
+      duration: SLIDE_DURATION,
+      ease: "Cubic.easeOut",
+    });
+  }
+
+  /** Dismiss this toast. Idempotent. */
+  dismiss(): void {
+    if (this.dismissed) return;
+    this.dismissed = true;
+    this.autoTimer?.remove(false);
+    this.autoTimer = null;
+    this.onDismissFn?.();
+    if (!this.scene) {
+      this.destroy();
+      return;
+    }
+    this.scene.tweens.add({
+      targets: this,
+      alpha: 0,
+      duration: SLIDE_DURATION,
+      ease: "Cubic.easeIn",
+      onComplete: () => this.destroy(),
+    });
+  }
+
+  isDismissed(): boolean {
+    return this.dismissed;
+  }
+}
+
+function kindForeground(
+  theme: ReturnType<typeof getTheme>,
+  kind: ToastKind,
+): number {
+  switch (kind) {
+    case "success":
+      return theme.colors.profit;
+    case "warning":
+      return theme.colors.warning;
+    case "error":
+      return theme.colors.loss;
+    case "info":
+    default:
+      return theme.colors.accent;
+  }
+}

--- a/packages/spacebiz-ui/src/notifications/ToastManager.ts
+++ b/packages/spacebiz-ui/src/notifications/ToastManager.ts
@@ -1,0 +1,97 @@
+import type * as Phaser from "phaser";
+import { Toast } from "./Toast.ts";
+import type { ToastConfig } from "./Toast.ts";
+import { DEPTH_MODAL } from "../DepthLayers.ts";
+
+const STACK_GAP = 8;
+const TOP_INSET = 16;
+const RIGHT_INSET = 16;
+
+interface SceneRegistry {
+  toasts: Toast[];
+  shutdownBound: boolean;
+}
+
+const registries = new WeakMap<Phaser.Scene, SceneRegistry>();
+
+function getRegistry(scene: Phaser.Scene): SceneRegistry {
+  let reg = registries.get(scene);
+  if (!reg) {
+    reg = { toasts: [], shutdownBound: false };
+    registries.set(scene, reg);
+  }
+  if (!reg.shutdownBound) {
+    const cleanup = (): void => {
+      const r = registries.get(scene);
+      if (!r) return;
+      for (const t of r.toasts) {
+        t.destroy();
+      }
+      r.toasts = [];
+      registries.delete(scene);
+    };
+    scene.events.once("shutdown", cleanup);
+    scene.events.once("destroy", cleanup);
+    reg.shutdownBound = true;
+  }
+  return reg;
+}
+
+function reflow(scene: Phaser.Scene, animate: boolean): void {
+  const reg = registries.get(scene);
+  if (!reg) return;
+  const cam = scene.cameras.main;
+  const rightX = cam.width - RIGHT_INSET;
+  let y = TOP_INSET;
+  for (const toast of reg.toasts) {
+    toast.slideTo(rightX, y, animate);
+    y += toast.toastHeight + STACK_GAP;
+  }
+}
+
+/**
+ * Singleton-per-scene queue of stacked toasts. New toasts appear at the top
+ * of the stack (top-right corner). When a toast dismisses, the remaining
+ * toasts re-flow upward.
+ */
+export const ToastManager = {
+  /** Show a toast in the given scene. Returns the created Toast instance. */
+  show(scene: Phaser.Scene, config: ToastConfig): Toast {
+    const reg = getRegistry(scene);
+
+    const toast = new Toast(scene, {
+      ...config,
+      onDismiss: () => {
+        const r = registries.get(scene);
+        if (r) {
+          r.toasts = r.toasts.filter((t) => t !== toast);
+          reflow(scene, true);
+        }
+        config.onDismiss?.();
+      },
+    });
+    toast.setDepth(DEPTH_MODAL);
+    // Start off-screen to the right so the first reflow animates a slide-in.
+    toast.setPosition(scene.cameras.main.width, TOP_INSET);
+
+    reg.toasts.push(toast);
+    reflow(scene, true);
+    return toast;
+  },
+
+  /** Dismiss every active toast in the scene. */
+  dismissAll(scene: Phaser.Scene): void {
+    const reg = registries.get(scene);
+    if (!reg) return;
+    // Snapshot — `dismiss` mutates the array via the onDismiss callback.
+    const snapshot = [...reg.toasts];
+    for (const t of snapshot) {
+      t.dismiss();
+    }
+  },
+
+  /** Snapshot of currently-active toasts in the scene (test/debug helper). */
+  active(scene: Phaser.Scene): readonly Toast[] {
+    return registries.get(scene)?.toasts ?? [];
+  },
+};

--- a/packages/spacebiz-ui/src/notifications/__tests__/ConfirmDialog.test.ts
+++ b/packages/spacebiz-ui/src/notifications/__tests__/ConfirmDialog.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Modal is non-trivial to instantiate without a full Phaser scene, so we
+// mock it with a tiny spy that captures the config and exposes hooks for
+// firing onOk/onCancel/destroy.
+
+interface CapturedConfig {
+  onOk?: () => void;
+  onCancel?: () => void;
+  okText?: string;
+  cancelText?: string;
+  testId?: string;
+  title?: string;
+  body?: string;
+}
+
+interface FakeModal {
+  config: CapturedConfig;
+  show: () => void;
+  destroyHandlers: Array<() => void>;
+  once: (event: string, fn: () => void) => void;
+  triggerDestroy: () => void;
+}
+
+const created: FakeModal[] = [];
+
+vi.mock("../../Modal.ts", () => {
+  class Modal implements FakeModal {
+    config: CapturedConfig;
+    destroyHandlers: Array<() => void> = [];
+    constructor(_scene: unknown, config: CapturedConfig) {
+      this.config = config;
+      created.push(this);
+    }
+    show(): void {}
+    once(event: string, fn: () => void): void {
+      if (event === "destroy") this.destroyHandlers.push(fn);
+    }
+    triggerDestroy(): void {
+      for (const h of this.destroyHandlers) h();
+    }
+  }
+  return { Modal };
+});
+
+beforeEach(() => {
+  created.length = 0;
+});
+
+describe("ConfirmDialog", () => {
+  it("resolves true when the user confirms", async () => {
+    const { ConfirmDialog } = await import("../ConfirmDialog.ts");
+    const promise = ConfirmDialog.show({} as never, {
+      title: "Sell ship?",
+      message: "This cannot be undone.",
+    });
+    const modal = created[0];
+    modal.config.onOk?.();
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it("resolves false when the user cancels", async () => {
+    const { ConfirmDialog } = await import("../ConfirmDialog.ts");
+    const promise = ConfirmDialog.show({} as never, {
+      title: "Sell ship?",
+      message: "This cannot be undone.",
+    });
+    created[0].config.onCancel?.();
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it("resolves false on modal destroy if not already settled", async () => {
+    const { ConfirmDialog } = await import("../ConfirmDialog.ts");
+    const promise = ConfirmDialog.show({} as never, {
+      title: "?",
+      message: "?",
+    });
+    created[0].triggerDestroy();
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it("only resolves once even if both callbacks fire", async () => {
+    const { ConfirmDialog } = await import("../ConfirmDialog.ts");
+    const promise = ConfirmDialog.show({} as never, {
+      title: "?",
+      message: "?",
+    });
+    const modal = created[0];
+    modal.config.onOk?.();
+    modal.config.onCancel?.();
+    modal.triggerDestroy();
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it("invokes onConfirm / onCancel side-effect callbacks", async () => {
+    const { ConfirmDialog } = await import("../ConfirmDialog.ts");
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    ConfirmDialog.show({} as never, {
+      title: "?",
+      message: "?",
+      onConfirm,
+      onCancel,
+    });
+    created[0].config.onOk?.();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+
+    ConfirmDialog.show({} as never, {
+      title: "?",
+      message: "?",
+      onConfirm,
+      onCancel,
+    });
+    created[1].config.onCancel?.();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses default labels and forwards custom ones", async () => {
+    const { ConfirmDialog } = await import("../ConfirmDialog.ts");
+    ConfirmDialog.show({} as never, { title: "t", message: "m" });
+    expect(created[0].config.okText).toBe("Confirm");
+    expect(created[0].config.cancelText).toBe("Cancel");
+
+    ConfirmDialog.show({} as never, {
+      title: "t",
+      message: "m",
+      confirmLabel: "Sell",
+      cancelLabel: "Keep",
+    });
+    expect(created[1].config.okText).toBe("Sell");
+    expect(created[1].config.cancelText).toBe("Keep");
+  });
+
+  it("derives a danger-prefixed testId for the danger kind", async () => {
+    const { ConfirmDialog } = await import("../ConfirmDialog.ts");
+    ConfirmDialog.show({} as never, {
+      title: "t",
+      message: "m",
+      kind: "danger",
+    });
+    expect(created[0].config.testId).toBe("confirm-danger");
+
+    ConfirmDialog.show({} as never, { title: "t", message: "m" });
+    expect(created[1].config.testId).toBe("confirm");
+  });
+});

--- a/packages/spacebiz-ui/src/notifications/__tests__/ToastManager.test.ts
+++ b/packages/spacebiz-ui/src/notifications/__tests__/ToastManager.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Stub the Toast module before importing ToastManager so the manager picks
+// up the lightweight stand-in. Tests focus on queue ordering and reflow,
+// not on Phaser rendering.
+type StubScene = {
+  cameras: { main: { width: number; height: number } };
+  events: {
+    once: (key: string, fn: () => void) => void;
+  };
+  time: { delayedCall: (ms: number, fn: () => void) => unknown };
+  add: { existing: () => void };
+  tweens: { add: () => void };
+};
+
+interface StubToast {
+  toastWidth: number;
+  toastHeight: number;
+  x: number;
+  y: number;
+  setDepth: (d: number) => StubToast;
+  setPosition: (x: number, y: number) => StubToast;
+  slideTo: (x: number, y: number, animate: boolean) => void;
+  dismiss: () => void;
+  destroy: () => void;
+  __config: { onDismiss?: () => void };
+}
+
+const constructed: StubToast[] = [];
+
+vi.mock("../Toast.ts", () => {
+  class FakeToast implements StubToast {
+    toastWidth = 200;
+    toastHeight = 40;
+    x = 0;
+    y = 0;
+    __config: { onDismiss?: () => void };
+    constructor(_scene: unknown, config: { onDismiss?: () => void }) {
+      this.__config = config;
+      constructed.push(this);
+    }
+    setDepth(_d: number): this {
+      return this;
+    }
+    setPosition(x: number, y: number): this {
+      this.x = x;
+      this.y = y;
+      return this;
+    }
+    slideTo(x: number, y: number, _animate: boolean): void {
+      this.x = x - this.toastWidth;
+      this.y = y;
+    }
+    dismiss(): void {
+      this.__config.onDismiss?.();
+    }
+    destroy(): void {}
+  }
+  return { Toast: FakeToast };
+});
+
+function createScene(width = 800, height = 600): StubScene {
+  return {
+    cameras: { main: { width, height } },
+    events: { once: () => {} },
+    time: { delayedCall: () => ({}) },
+    add: { existing: () => {} },
+    tweens: { add: () => {} },
+  };
+}
+
+beforeEach(() => {
+  constructed.length = 0;
+});
+
+describe("ToastManager", () => {
+  it("stacks toasts top-down in the right corner", async () => {
+    const { ToastManager } = await import("../ToastManager.ts");
+    const scene = createScene(800, 600) as unknown as Parameters<
+      typeof ToastManager.show
+    >[0];
+
+    ToastManager.show(scene, { message: "first" });
+    ToastManager.show(scene, { message: "second" });
+    ToastManager.show(scene, { message: "third" });
+
+    expect(constructed).toHaveLength(3);
+    const [a, b, c] = constructed;
+    expect(a.y).toBe(16); // TOP_INSET
+    expect(b.y).toBe(16 + a.toastHeight + 8);
+    expect(c.y).toBe(16 + a.toastHeight + 8 + b.toastHeight + 8);
+    // Each toast right-aligned to (width - RIGHT_INSET).
+    const rightEdge = 800 - 16;
+    expect(a.x + a.toastWidth).toBe(rightEdge);
+    expect(b.x + b.toastWidth).toBe(rightEdge);
+    expect(c.x + c.toastWidth).toBe(rightEdge);
+  });
+
+  it("re-flows remaining toasts when one dismisses early", async () => {
+    const { ToastManager } = await import("../ToastManager.ts");
+    const scene = createScene() as unknown as Parameters<
+      typeof ToastManager.show
+    >[0];
+
+    ToastManager.show(scene, { message: "a" });
+    ToastManager.show(scene, { message: "b" });
+    ToastManager.show(scene, { message: "c" });
+
+    const [a, b, c] = constructed;
+    a.dismiss();
+
+    // After A dismisses, B should occupy the top slot.
+    expect(b.y).toBe(16);
+    expect(c.y).toBe(16 + b.toastHeight + 8);
+    expect(ToastManager.active(scene)).toHaveLength(2);
+  });
+
+  it("dismissAll clears every toast", async () => {
+    const { ToastManager } = await import("../ToastManager.ts");
+    const scene = createScene() as unknown as Parameters<
+      typeof ToastManager.show
+    >[0];
+
+    ToastManager.show(scene, { message: "a" });
+    ToastManager.show(scene, { message: "b" });
+    expect(ToastManager.active(scene)).toHaveLength(2);
+
+    ToastManager.dismissAll(scene);
+    expect(ToastManager.active(scene)).toHaveLength(0);
+  });
+
+  it("forwards user onDismiss callback", async () => {
+    const { ToastManager } = await import("../ToastManager.ts");
+    const scene = createScene() as unknown as Parameters<
+      typeof ToastManager.show
+    >[0];
+    const cb = vi.fn();
+    ToastManager.show(scene, { message: "x", onDismiss: cb });
+    constructed[0].dismiss();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates registries per scene", async () => {
+    const { ToastManager } = await import("../ToastManager.ts");
+    const sceneA = createScene() as unknown as Parameters<
+      typeof ToastManager.show
+    >[0];
+    const sceneB = createScene() as unknown as Parameters<
+      typeof ToastManager.show
+    >[0];
+    ToastManager.show(sceneA, { message: "a1" });
+    ToastManager.show(sceneB, { message: "b1" });
+    ToastManager.show(sceneB, { message: "b2" });
+    expect(ToastManager.active(sceneA)).toHaveLength(1);
+    expect(ToastManager.active(sceneB)).toHaveLength(2);
+  });
+});

--- a/packages/spacebiz-ui/src/notifications/index.ts
+++ b/packages/spacebiz-ui/src/notifications/index.ts
@@ -1,0 +1,10 @@
+export { Toast } from "./Toast.ts";
+export type { ToastConfig, ToastKind } from "./Toast.ts";
+
+export { ToastManager } from "./ToastManager.ts";
+
+export { ConfirmDialog } from "./ConfirmDialog.ts";
+export type {
+  ConfirmDialogConfig,
+  ConfirmDialogKind,
+} from "./ConfirmDialog.ts";

--- a/styleguide/scenes/StyleguideScene.ts
+++ b/styleguide/scenes/StyleguideScene.ts
@@ -25,6 +25,8 @@ import {
   InfoCard,
   IconButton,
   StatusBadge,
+  ToastManager,
+  ConfirmDialog,
   // Layout constants
   SIDEBAR_WIDTH,
   CONTENT_GAP,
@@ -119,6 +121,7 @@ export class StyleguideScene extends Phaser.Scene {
     y = this.addInfoCardSection(y);
     y = this.addIconButtonSection(y);
     y = this.addStatusBadgeSection(y);
+    y = this.addNotificationSection(y);
     y += 60;
 
     this.maxScroll = Math.max(0, y - GAME_HEIGHT);
@@ -2148,5 +2151,108 @@ export class StyleguideScene extends Phaser.Scene {
     }
 
     return y + 40;
+  }
+
+  /* ── 26. Notifications: Toasts + ConfirmDialog ────────────── */
+
+  private addNotificationSection(y: number): number {
+    y = this.addSubheading(y, "NOTIFICATIONS — TOASTS & CONFIRM DIALOG");
+
+    const kinds: Array<{
+      label: string;
+      kind: "info" | "success" | "warning" | "error";
+      message: string;
+    }> = [
+      {
+        label: "Info Toast",
+        kind: "info",
+        message: "Route plotted to Solara.",
+      },
+      {
+        label: "Success Toast",
+        kind: "success",
+        message: "Cargo delivered. +$12,400 profit.",
+      },
+      {
+        label: "Warning Toast",
+        kind: "warning",
+        message: "Fuel reserves below 25%.",
+      },
+      {
+        label: "Error Toast",
+        kind: "error",
+        message: "Ship lost in pirate ambush at Helix Ring.",
+      },
+    ];
+
+    let x = 60;
+    for (const { label, kind, message } of kinds) {
+      const btn = new Button(this, {
+        x,
+        y: y + 10,
+        autoWidth: true,
+        label,
+        onClick: () => {
+          ToastManager.show(this, { message, kind });
+        },
+      });
+      this.scrollContainer.add(btn);
+      x += btn.width + 12;
+    }
+
+    const dismissAllBtn = new Button(this, {
+      x,
+      y: y + 10,
+      autoWidth: true,
+      label: "Dismiss All",
+      onClick: () => ToastManager.dismissAll(this),
+    });
+    this.scrollContainer.add(dismissAllBtn);
+
+    y += 70;
+
+    // Confirm dialog buttons
+    const confirmBtn = new Button(this, {
+      x: 60,
+      y: y + 10,
+      autoWidth: true,
+      label: "Open Confirm Dialog",
+      onClick: () => {
+        void ConfirmDialog.show(this, {
+          title: "Plot Route",
+          message: "Commit this route plan and end the planning phase?",
+        }).then((ok) => {
+          ToastManager.show(this, {
+            message: ok ? "Route confirmed." : "Cancelled.",
+            kind: ok ? "success" : "info",
+          });
+        });
+      },
+    });
+    this.scrollContainer.add(confirmBtn);
+
+    const dangerBtn = new Button(this, {
+      x: 60 + confirmBtn.width + 16,
+      y: y + 10,
+      autoWidth: true,
+      label: "Open Danger Confirm",
+      onClick: () => {
+        void ConfirmDialog.show(this, {
+          title: "Sell Ship",
+          message: "Sell the Bulk Freighter Aurora?\nThis cannot be undone.",
+          confirmLabel: "Sell",
+          cancelLabel: "Keep",
+          kind: "danger",
+        }).then((ok) => {
+          ToastManager.show(this, {
+            message: ok ? "Ship sold." : "Sale cancelled.",
+            kind: ok ? "warning" : "info",
+          });
+        });
+      },
+    });
+    this.scrollContainer.add(dangerBtn);
+
+    return y + 80;
   }
 }


### PR DESCRIPTION
## Summary

- Adds a `notifications/` module to `@spacebiz/ui` (Tier 1 of the planned 3-tier UI library) containing `Toast`, `ToastManager`, and `ConfirmDialog`.
- `Toast` is a single transient corner notification themed per kind (`info` / `success` / `warning` / `error`); auto-dismisses after `durationMs` (default 3000) or on click.
- `ToastManager` is a singleton-per-scene queue stacked top-right that re-flows surviving toasts when one dismisses early. API: `ToastManager.show(scene, config)` / `ToastManager.dismissAll(scene)`.
- `ConfirmDialog` composes the existing `Modal` and exposes `ConfirmDialog.show(scene, config): Promise<boolean>` so callers can `await` the user's choice.
- Styleguide gains a Notifications section with one button per kind and default + danger Confirm Dialog demos.

## Test plan

- [x] `npm run check` passes (typecheck + lint + format + 908 tests + build).
- [x] 12 new unit tests cover queue ordering, early-dismiss reflow, scene isolation, and ConfirmDialog promise resolution (confirm/cancel/destroy paths).
- [x] `npm run dev` + `npm run test:e2e` — all 8 Playwright smoke tests pass.
- [ ] Manually click the new buttons in `/styleguide/` to confirm toasts stack and confirm dialogs resolve.

Implements unit 4 of `vivid-knitting-lagoon.md` (3-tier UI library).

🤖 Generated with [Claude Code](https://claude.com/claude-code)