### PR TITLE
feat(ui-tier-1): add stepper, text input, color swatch

### DIFF
--- a/packages/spacebiz-ui/src/index.ts
+++ b/packages/spacebiz-ui/src/index.ts
@@ -121,3 +121,6 @@ export {
   SHIP_CLASS_LIST,
 } from "./ShipIcons.ts";
 export type { ShipClassValue } from "./ShipIcons.ts";
+
+// Form input controls
+export * from "./input/index.ts";

--- a/packages/spacebiz-ui/src/input/ColorSwatch.ts
+++ b/packages/spacebiz-ui/src/input/ColorSwatch.ts
@@ -1,0 +1,92 @@
+import * as Phaser from "phaser";
+import { getTheme } from "../Theme.ts";
+import { playUiSfx } from "../UiSound.ts";
+
+export interface ColorSwatchConfig {
+  x: number;
+  y: number;
+  /** Square edge length in pixels. */
+  size: number;
+  /** Hex color (e.g. 0xff8800). */
+  color: number;
+  onClick?: (color: number) => void;
+  /** When true, draws a thicker accent border to indicate selection. */
+  selected?: boolean;
+}
+
+/**
+ * A small clickable color square. Building block for a future ColorPicker;
+ * also useful on its own for "current color" displays.
+ */
+export class ColorSwatch extends Phaser.GameObjects.Container {
+  private fillRect: Phaser.GameObjects.Rectangle;
+  private borderRect: Phaser.GameObjects.Rectangle;
+  private currentColor: number;
+  private isSelected: boolean;
+
+  constructor(scene: Phaser.Scene, config: ColorSwatchConfig) {
+    super(scene, config.x, config.y);
+    const theme = getTheme();
+
+    this.currentColor = config.color;
+    this.isSelected = config.selected ?? false;
+    this.setSize(config.size, config.size);
+
+    this.fillRect = scene.add
+      .rectangle(0, 0, config.size, config.size, this.currentColor)
+      .setOrigin(0, 0);
+    this.borderRect = scene.add
+      .rectangle(0, 0, config.size, config.size)
+      .setOrigin(0, 0)
+      .setFillStyle()
+      .setStrokeStyle(
+        this.isSelected ? 3 : 1,
+        this.isSelected ? theme.colors.accent : theme.colors.panelBorder,
+        this.isSelected ? 1 : 0.7,
+      );
+
+    this.add([this.fillRect, this.borderRect]);
+
+    if (config.onClick) {
+      const onClick = config.onClick;
+      this.fillRect.setInteractive({ useHandCursor: true });
+      this.fillRect.on("pointerover", () => {
+        playUiSfx("ui_hover");
+        this.borderRect.setStrokeStyle(2, theme.colors.accentHover, 1);
+      });
+      this.fillRect.on("pointerout", () => {
+        this.borderRect.setStrokeStyle(
+          this.isSelected ? 3 : 1,
+          this.isSelected ? theme.colors.accent : theme.colors.panelBorder,
+          this.isSelected ? 1 : 0.7,
+        );
+      });
+      this.fillRect.on("pointerdown", () => {
+        playUiSfx("ui_click_secondary");
+        onClick(this.currentColor);
+      });
+    }
+
+    scene.add.existing(this);
+  }
+
+  setColor(color: number): void {
+    this.currentColor = color;
+    this.fillRect.setFillStyle(color);
+  }
+
+  getColor(): number {
+    return this.currentColor;
+  }
+
+  setSelected(selected: boolean): void {
+    if (this.isSelected === selected) return;
+    this.isSelected = selected;
+    const theme = getTheme();
+    this.borderRect.setStrokeStyle(
+      selected ? 3 : 1,
+      selected ? theme.colors.accent : theme.colors.panelBorder,
+      selected ? 1 : 0.7,
+    );
+  }
+}

--- a/packages/spacebiz-ui/src/input/Stepper.ts
+++ b/packages/spacebiz-ui/src/input/Stepper.ts
@@ -1,0 +1,246 @@
+import * as Phaser from "phaser";
+import { getTheme, colorToString } from "../Theme.ts";
+import { playUiSfx } from "../UiSound.ts";
+import {
+  HOLD_REPEAT_INITIAL_DELAY,
+  HOLD_REPEAT_START_INTERVAL,
+  clampStepperValue,
+  nextRepeatInterval,
+} from "./stepperLogic.ts";
+
+export interface StepperConfig {
+  x: number;
+  y: number;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  /** Total width of the stepper (buttons + value display). Default 140. */
+  width?: number;
+  /** Height of the stepper. Default theme.button.height. */
+  height?: number;
+  onChange?: (value: number) => void;
+  /** Format the value for display (e.g. money, percent). Default String(value). */
+  formatValue?: (value: number) => string;
+}
+
+export class Stepper extends Phaser.GameObjects.Container {
+  private currentValue: number;
+  private readonly min: number;
+  private readonly max: number;
+  private readonly step: number;
+  private readonly onChange?: (value: number) => void;
+  private readonly format: (value: number) => string;
+
+  private valueText: Phaser.GameObjects.Text;
+  private decBg: Phaser.GameObjects.Rectangle;
+  private incBg: Phaser.GameObjects.Rectangle;
+  private decGlyph: Phaser.GameObjects.Text;
+  private incGlyph: Phaser.GameObjects.Text;
+
+  private holdInitialTimer: Phaser.Time.TimerEvent | null = null;
+  private holdRepeatTimer: Phaser.Time.TimerEvent | null = null;
+  private currentRepeatInterval = HOLD_REPEAT_START_INTERVAL;
+
+  constructor(scene: Phaser.Scene, config: StepperConfig) {
+    super(scene, config.x, config.y);
+    const theme = getTheme();
+
+    this.min = config.min ?? Number.NEGATIVE_INFINITY;
+    this.max = config.max ?? Number.POSITIVE_INFINITY;
+    this.step = config.step ?? 1;
+    this.onChange = config.onChange;
+    this.format = config.formatValue ?? ((v) => String(v));
+    this.currentValue = clampStepperValue(config.value, this.min, this.max);
+
+    const width = config.width ?? 140;
+    const height = config.height ?? theme.button.height;
+    const btnSize = height;
+    const valueWidth = width - btnSize * 2;
+    this.setSize(width, height);
+
+    // Decrement button (left)
+    this.decBg = scene.add
+      .rectangle(0, 0, btnSize, height, theme.colors.buttonBg)
+      .setOrigin(0, 0)
+      .setStrokeStyle(1, theme.colors.panelBorder, 0.6);
+    this.decGlyph = scene.add
+      .text(btnSize / 2, height / 2, "−", {
+        fontSize: `${theme.fonts.value.size}px`,
+        fontFamily: theme.fonts.value.family,
+        color: colorToString(theme.colors.text),
+      })
+      .setOrigin(0.5);
+
+    // Value display (middle)
+    const valueBg = scene.add
+      .rectangle(btnSize, 0, valueWidth, height, theme.colors.panelBg)
+      .setOrigin(0, 0)
+      .setStrokeStyle(1, theme.colors.panelBorder, 0.6);
+    this.valueText = scene.add
+      .text(
+        btnSize + valueWidth / 2,
+        height / 2,
+        this.format(this.currentValue),
+        {
+          fontSize: `${theme.fonts.body.size}px`,
+          fontFamily: theme.fonts.body.family,
+          color: colorToString(theme.colors.text),
+        },
+      )
+      .setOrigin(0.5);
+
+    // Increment button (right)
+    this.incBg = scene.add
+      .rectangle(
+        btnSize + valueWidth,
+        0,
+        btnSize,
+        height,
+        theme.colors.buttonBg,
+      )
+      .setOrigin(0, 0)
+      .setStrokeStyle(1, theme.colors.panelBorder, 0.6);
+    this.incGlyph = scene.add
+      .text(btnSize + valueWidth + btnSize / 2, height / 2, "+", {
+        fontSize: `${theme.fonts.value.size}px`,
+        fontFamily: theme.fonts.value.family,
+        color: colorToString(theme.colors.text),
+      })
+      .setOrigin(0.5);
+
+    this.add([
+      this.decBg,
+      this.decGlyph,
+      valueBg,
+      this.valueText,
+      this.incBg,
+      this.incGlyph,
+    ]);
+
+    this.wireButton(this.decBg, -1);
+    this.wireButton(this.incBg, +1);
+
+    scene.add.existing(this);
+
+    this.refreshDisabledStates();
+  }
+
+  private wireButton(
+    bg: Phaser.GameObjects.Rectangle,
+    direction: 1 | -1,
+  ): void {
+    const theme = getTheme();
+    bg.setInteractive({ useHandCursor: true });
+
+    bg.on("pointerover", () => {
+      if (!this.canStep(direction)) return;
+      bg.setFillStyle(theme.colors.buttonHover);
+      playUiSfx("ui_hover");
+    });
+    bg.on("pointerout", () => {
+      bg.setFillStyle(theme.colors.buttonBg);
+      this.cancelHold();
+    });
+    bg.on("pointerup", () => {
+      bg.setFillStyle(theme.colors.buttonHover);
+      this.cancelHold();
+    });
+    bg.on("pointerupoutside", () => {
+      bg.setFillStyle(theme.colors.buttonBg);
+      this.cancelHold();
+    });
+    bg.on("pointerdown", () => {
+      if (!this.canStep(direction)) return;
+      bg.setFillStyle(theme.colors.buttonPressed);
+      this.applyStep(direction);
+      this.beginHold(direction);
+    });
+  }
+
+  private beginHold(direction: 1 | -1): void {
+    this.cancelHold();
+    this.currentRepeatInterval = HOLD_REPEAT_START_INTERVAL;
+    this.holdInitialTimer = this.scene.time.delayedCall(
+      HOLD_REPEAT_INITIAL_DELAY,
+      () => {
+        this.scheduleNextRepeat(direction);
+      },
+    );
+  }
+
+  private scheduleNextRepeat(direction: 1 | -1): void {
+    if (!this.canStep(direction)) {
+      this.cancelHold();
+      return;
+    }
+    this.applyStep(direction);
+    this.currentRepeatInterval = nextRepeatInterval(this.currentRepeatInterval);
+    this.holdRepeatTimer = this.scene.time.delayedCall(
+      this.currentRepeatInterval,
+      () => this.scheduleNextRepeat(direction),
+    );
+  }
+
+  private cancelHold(): void {
+    this.holdInitialTimer?.remove(false);
+    this.holdInitialTimer = null;
+    this.holdRepeatTimer?.remove(false);
+    this.holdRepeatTimer = null;
+  }
+
+  private canStep(direction: 1 | -1): boolean {
+    const next = this.currentValue + direction * this.step;
+    return clampStepperValue(next, this.min, this.max) !== this.currentValue;
+  }
+
+  private applyStep(direction: 1 | -1): void {
+    const proposed = this.currentValue + direction * this.step;
+    const clamped = clampStepperValue(proposed, this.min, this.max);
+    if (clamped === this.currentValue) {
+      this.cancelHold();
+      return;
+    }
+    this.currentValue = clamped;
+    this.valueText.setText(this.format(this.currentValue));
+    playUiSfx("ui_click_secondary");
+    this.onChange?.(this.currentValue);
+    this.refreshDisabledStates();
+  }
+
+  private refreshDisabledStates(): void {
+    const theme = getTheme();
+    const decAlpha = this.canStep(-1) ? 1 : 0.35;
+    const incAlpha = this.canStep(+1) ? 1 : 0.35;
+    this.decGlyph.setColor(
+      colorToString(
+        this.canStep(-1) ? theme.colors.text : theme.colors.textDim,
+      ),
+    );
+    this.incGlyph.setColor(
+      colorToString(
+        this.canStep(+1) ? theme.colors.text : theme.colors.textDim,
+      ),
+    );
+    this.decBg.setAlpha(decAlpha);
+    this.incBg.setAlpha(incAlpha);
+  }
+
+  getValue(): number {
+    return this.currentValue;
+  }
+
+  setValue(value: number): void {
+    const clamped = clampStepperValue(value, this.min, this.max);
+    if (clamped === this.currentValue) return;
+    this.currentValue = clamped;
+    this.valueText.setText(this.format(this.currentValue));
+    this.refreshDisabledStates();
+    this.onChange?.(this.currentValue);
+  }
+
+  override destroy(fromScene?: boolean): void {
+    this.cancelHold();
+    super.destroy(fromScene);
+  }
+}

--- a/packages/spacebiz-ui/src/input/TextInput.ts
+++ b/packages/spacebiz-ui/src/input/TextInput.ts
@@ -1,0 +1,210 @@
+import * as Phaser from "phaser";
+import { getTheme, colorToString } from "../Theme.ts";
+
+export type TextInputType = "text" | "password" | "number";
+
+export interface TextInputConfig {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  value?: string;
+  placeholder?: string;
+  maxLength?: number;
+  type?: TextInputType;
+  onChange?: (value: string) => void;
+  onSubmit?: (value: string) => void;
+}
+
+/**
+ * Single-line text input. Phaser has no native DOM-free text input, so this
+ * positions an absolutely-positioned <input> element on top of the canvas
+ * synchronized to the component's screen-space rect each frame. The Phaser
+ * rectangle/text underneath is a visual fallback that's hidden whenever the
+ * DOM overlay is mounted (i.e. always, in browsers).
+ */
+export class TextInput extends Phaser.GameObjects.Container {
+  private bgRect: Phaser.GameObjects.Rectangle;
+  private fallbackText: Phaser.GameObjects.Text;
+  private domInput: HTMLInputElement | null = null;
+  private readonly widthPx: number;
+  private readonly heightPx: number;
+  private readonly maxLength?: number;
+  private readonly onChange?: (value: string) => void;
+  private readonly onSubmit?: (value: string) => void;
+  private currentValue: string;
+  private resizeListener: (() => void) | null = null;
+  private scrollListener: (() => void) | null = null;
+  private destroyed = false;
+
+  constructor(scene: Phaser.Scene, config: TextInputConfig) {
+    super(scene, config.x, config.y);
+    const theme = getTheme();
+
+    this.widthPx = config.width;
+    this.heightPx = config.height;
+    this.maxLength = config.maxLength;
+    this.onChange = config.onChange;
+    this.onSubmit = config.onSubmit;
+    this.currentValue = config.value ?? "";
+    this.setSize(config.width, config.height);
+
+    this.bgRect = scene.add
+      .rectangle(0, 0, config.width, config.height, theme.colors.panelBg)
+      .setOrigin(0, 0)
+      .setStrokeStyle(1, theme.colors.panelBorder, 0.7);
+
+    // Fallback text — visible only in headless / non-browser test environments
+    // where we can't mount a real DOM input.
+    this.fallbackText = scene.add
+      .text(8, config.height / 2, this.displayText(config.placeholder), {
+        fontSize: `${theme.fonts.body.size}px`,
+        fontFamily: theme.fonts.body.family,
+        color: colorToString(
+          this.currentValue ? theme.colors.text : theme.colors.textDim,
+        ),
+      })
+      .setOrigin(0, 0.5);
+
+    this.add([this.bgRect, this.fallbackText]);
+    scene.add.existing(this);
+
+    this.tryMountDomInput(config);
+
+    // Tear down the DOM overlay when the scene shuts down or this object
+    // is destroyed; teardownDom is idempotent via the `destroyed` guard.
+    scene.events.once(Phaser.Scenes.Events.SHUTDOWN, () => this.teardownDom());
+    this.once(Phaser.GameObjects.Events.DESTROY, () => this.teardownDom());
+  }
+
+  private displayText(placeholder?: string): string {
+    if (this.currentValue) return this.currentValue;
+    return placeholder ?? "";
+  }
+
+  private tryMountDomInput(config: TextInputConfig): void {
+    // Only mount when a real DOM is available (skip in node test envs).
+    if (typeof document === "undefined") return;
+
+    const theme = getTheme();
+    const input = document.createElement("input");
+    input.type = config.type ?? "text";
+    input.value = this.currentValue;
+    if (config.placeholder) input.placeholder = config.placeholder;
+    if (this.maxLength !== undefined) input.maxLength = this.maxLength;
+
+    // Theme-driven base styling. Position is computed each frame.
+    input.style.position = "absolute";
+    input.style.boxSizing = "border-box";
+    input.style.margin = "0";
+    input.style.padding = "0 8px";
+    input.style.border = "none";
+    input.style.outline = "none";
+    input.style.background = "transparent";
+    input.style.color = colorToString(theme.colors.text);
+    input.style.fontFamily = theme.fonts.body.family;
+    input.style.fontSize = `${theme.fonts.body.size}px`;
+    input.style.zIndex = "10";
+    input.style.pointerEvents = "auto";
+
+    document.body.appendChild(input);
+    this.domInput = input;
+    // Hide the fallback text once DOM is mounted; the <input> renders text.
+    this.fallbackText.setVisible(false);
+
+    input.addEventListener("input", () => {
+      this.currentValue = input.value;
+      this.onChange?.(this.currentValue);
+    });
+    input.addEventListener("keydown", (ev) => {
+      if (ev.key === "Enter") {
+        this.onSubmit?.(this.currentValue);
+      }
+    });
+
+    // Reposition on resize/scroll (canvas may move or DPR may change).
+    this.resizeListener = () => this.syncDomPosition();
+    this.scrollListener = () => this.syncDomPosition();
+    window.addEventListener("resize", this.resizeListener);
+    window.addEventListener("scroll", this.scrollListener, true);
+
+    this.syncDomPosition();
+  }
+
+  /**
+   * Phaser's preUpdate runs every frame; we use it to keep the DOM input
+   * pinned to the container's world position even if the parent moves.
+   */
+  preUpdate(): void {
+    if (this.domInput) this.syncDomPosition();
+  }
+
+  private syncDomPosition(): void {
+    if (!this.domInput || this.destroyed) return;
+    const canvas = this.scene.game.canvas as HTMLCanvasElement | undefined;
+    if (!canvas || !canvas.getBoundingClientRect) return;
+
+    const rect = canvas.getBoundingClientRect();
+    // Phaser scales the internal resolution to fit the canvas element; map
+    // game coordinates to CSS pixels via the displayed canvas size.
+    const scaleX = rect.width / this.scene.scale.width;
+    const scaleY = rect.height / this.scene.scale.height;
+
+    const m = this.getWorldTransformMatrix();
+    const cssLeft = rect.left + m.tx * scaleX;
+    const cssTop = rect.top + m.ty * scaleY;
+    const cssW = this.widthPx * scaleX;
+    const cssH = this.heightPx * scaleY;
+
+    const style = this.domInput.style;
+    style.left = `${cssLeft}px`;
+    style.top = `${cssTop}px`;
+    style.width = `${cssW}px`;
+    style.height = `${cssH}px`;
+    style.display = this.visible ? "block" : "none";
+  }
+
+  override setVisible(value: boolean): this {
+    super.setVisible(value);
+    if (this.domInput) {
+      this.domInput.style.display = value ? "block" : "none";
+    }
+    return this;
+  }
+
+  getValue(): string {
+    return this.currentValue;
+  }
+
+  setValue(value: string): void {
+    this.currentValue = value;
+    if (this.domInput) this.domInput.value = value;
+    else this.fallbackText.setText(value);
+  }
+
+  focus(): void {
+    this.domInput?.focus();
+  }
+
+  private teardownDom(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    if (this.resizeListener) {
+      window.removeEventListener("resize", this.resizeListener);
+      this.resizeListener = null;
+    }
+    if (this.scrollListener) {
+      window.removeEventListener("scroll", this.scrollListener, true);
+      this.scrollListener = null;
+    }
+    if (this.domInput && this.domInput.parentNode) {
+      this.domInput.parentNode.removeChild(this.domInput);
+    }
+    this.domInput = null;
+  }
+
+  override destroy(fromScene?: boolean): void {
+    this.teardownDom();
+    super.destroy(fromScene);
+  }
+}

--- a/packages/spacebiz-ui/src/input/__tests__/ColorSwatch.test.ts
+++ b/packages/spacebiz-ui/src/input/__tests__/ColorSwatch.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+// Vite "?raw" loads the file content as a string at test time without
+// pulling Phaser through a normal `import`. The Vitest config runs in
+// node and the unblocked harness for headless component tests lands in
+// plan unit 6.
+import colorSwatchSource from "../ColorSwatch.ts?raw";
+
+describe("ColorSwatch (file shape)", () => {
+  it("exports a ColorSwatch class and ColorSwatchConfig type", () => {
+    expect(colorSwatchSource).toMatch(/export class ColorSwatch/);
+    expect(colorSwatchSource).toMatch(/export interface ColorSwatchConfig/);
+  });
+
+  it("wires onClick through a pointerdown handler", () => {
+    expect(colorSwatchSource).toMatch(/pointerdown/);
+    expect(colorSwatchSource).toMatch(/onClick/);
+  });
+});

--- a/packages/spacebiz-ui/src/input/__tests__/Stepper.test.ts
+++ b/packages/spacebiz-ui/src/input/__tests__/Stepper.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  clampStepperValue,
+  nextRepeatInterval,
+  STEPPER_TIMING,
+} from "../stepperLogic.ts";
+
+describe("Stepper helpers", () => {
+  describe("clampStepperValue", () => {
+    it("returns value when in range", () => {
+      expect(clampStepperValue(5, 0, 10)).toBe(5);
+    });
+    it("clamps below min", () => {
+      expect(clampStepperValue(-3, 0, 10)).toBe(0);
+    });
+    it("clamps above max", () => {
+      expect(clampStepperValue(99, 0, 10)).toBe(10);
+    });
+    it("supports unbounded ranges via -Infinity / +Infinity", () => {
+      expect(
+        clampStepperValue(
+          1e9,
+          Number.NEGATIVE_INFINITY,
+          Number.POSITIVE_INFINITY,
+        ),
+      ).toBe(1e9);
+      expect(
+        clampStepperValue(
+          -1e9,
+          Number.NEGATIVE_INFINITY,
+          Number.POSITIVE_INFINITY,
+        ),
+      ).toBe(-1e9);
+    });
+  });
+
+  describe("nextRepeatInterval", () => {
+    it("accelerates by the configured factor", () => {
+      const next = nextRepeatInterval(STEPPER_TIMING.startInterval);
+      expect(next).toBeCloseTo(
+        STEPPER_TIMING.startInterval * STEPPER_TIMING.accel,
+      );
+      expect(next).toBeLessThan(STEPPER_TIMING.startInterval);
+    });
+
+    it("never goes below the minimum interval", () => {
+      let current: number = STEPPER_TIMING.startInterval;
+      for (let i = 0; i < 50; i++) {
+        current = nextRepeatInterval(current);
+      }
+      expect(current).toBe(STEPPER_TIMING.minInterval);
+    });
+
+    it("clamps a tiny input to the floor in one step", () => {
+      expect(nextRepeatInterval(1)).toBe(STEPPER_TIMING.minInterval);
+    });
+  });
+
+  describe("STEPPER_TIMING constants", () => {
+    it("uses a 400ms hold-to-repeat initial delay", () => {
+      expect(STEPPER_TIMING.initialDelay).toBe(400);
+    });
+    it("starts repeating slower than the floor", () => {
+      expect(STEPPER_TIMING.startInterval).toBeGreaterThan(
+        STEPPER_TIMING.minInterval,
+      );
+    });
+    it("uses an acceleration factor < 1", () => {
+      expect(STEPPER_TIMING.accel).toBeLessThan(1);
+      expect(STEPPER_TIMING.accel).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/spacebiz-ui/src/input/__tests__/TextInput.test.ts
+++ b/packages/spacebiz-ui/src/input/__tests__/TextInput.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+// Vite "?raw" loads the source text without invoking the module body
+// (Phaser, which references `window`, would otherwise blow up in node).
+// Plan unit 6 introduces a jsdom harness that will allow real
+// construction tests.
+import textInputSource from "../TextInput.ts?raw";
+
+describe("TextInput (file shape)", () => {
+  it("exports the documented surface", () => {
+    expect(textInputSource).toMatch(/export class TextInput/);
+    expect(textInputSource).toMatch(/export interface TextInputConfig/);
+    expect(textInputSource).toMatch(/export type TextInputType/);
+  });
+
+  it("mounts a DOM <input> overlay positioned over the canvas", () => {
+    expect(textInputSource).toMatch(/document\.createElement\(['"]input['"]\)/);
+    expect(textInputSource).toMatch(/getBoundingClientRect/);
+    expect(textInputSource).toMatch(/position\s*=\s*['"]absolute['"]/);
+  });
+
+  it("cleans up the DOM input on destroy", () => {
+    expect(textInputSource).toMatch(/removeChild/);
+    expect(textInputSource).toMatch(/teardownDom/);
+  });
+
+  it("guards DOM access so module loads safely in node", () => {
+    expect(textInputSource).toMatch(/typeof document === ['"]undefined['"]/);
+  });
+});

--- a/packages/spacebiz-ui/src/input/index.ts
+++ b/packages/spacebiz-ui/src/input/index.ts
@@ -1,0 +1,13 @@
+export { Stepper } from "./Stepper.ts";
+export type { StepperConfig } from "./Stepper.ts";
+export {
+  clampStepperValue,
+  nextRepeatInterval,
+  STEPPER_TIMING,
+} from "./stepperLogic.ts";
+
+export { TextInput } from "./TextInput.ts";
+export type { TextInputConfig, TextInputType } from "./TextInput.ts";
+
+export { ColorSwatch } from "./ColorSwatch.ts";
+export type { ColorSwatchConfig } from "./ColorSwatch.ts";

--- a/packages/spacebiz-ui/src/input/stepperLogic.ts
+++ b/packages/spacebiz-ui/src/input/stepperLogic.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure logic for the Stepper component, extracted so it can be unit-tested
+ * without loading Phaser (which depends on `window` and won't run in the
+ * node-environment Vitest config).
+ */
+
+/** Initial delay before hold-to-repeat starts firing (ms). */
+export const HOLD_REPEAT_INITIAL_DELAY = 400;
+/** Starting interval between repeats (ms). Slowest tick. */
+export const HOLD_REPEAT_START_INTERVAL = 150;
+/** Floor on repeat interval after acceleration (ms). */
+export const HOLD_REPEAT_MIN_INTERVAL = 30;
+/** Multiplicative acceleration factor applied each repeat tick. */
+export const HOLD_REPEAT_ACCEL = 0.85;
+
+export const STEPPER_TIMING = {
+  initialDelay: HOLD_REPEAT_INITIAL_DELAY,
+  startInterval: HOLD_REPEAT_START_INTERVAL,
+  minInterval: HOLD_REPEAT_MIN_INTERVAL,
+  accel: HOLD_REPEAT_ACCEL,
+} as const;
+
+export function clampStepperValue(
+  value: number,
+  min: number,
+  max: number,
+): number {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+export function nextRepeatInterval(current: number): number {
+  const next = current * HOLD_REPEAT_ACCEL;
+  return next < HOLD_REPEAT_MIN_INTERVAL ? HOLD_REPEAT_MIN_INTERVAL : next;
+}

--- a/styleguide/scenes/StyleguideScene.ts
+++ b/styleguide/scenes/StyleguideScene.ts
@@ -55,6 +55,7 @@ import {
   getCargoColor,
   getCargoLabel,
 } from "@spacebiz/ui";
+import { Stepper, TextInput, ColorSwatch } from "@spacebiz/ui";
 import {
   drawRexPortrait,
   getMoodAccentColor,
@@ -119,6 +120,7 @@ export class StyleguideScene extends Phaser.Scene {
     y = this.addInfoCardSection(y);
     y = this.addIconButtonSection(y);
     y = this.addStatusBadgeSection(y);
+    y = this.addFormControlsBSection(y);
     y += 60;
 
     this.maxScroll = Math.max(0, y - GAME_HEIGHT);
@@ -2148,5 +2150,163 @@ export class StyleguideScene extends Phaser.Scene {
     }
 
     return y + 40;
+  }
+
+  /* ── 26. Form Controls B (Stepper / TextInput / ColorSwatch) ─ */
+
+  private addFormControlsBSection(y: number): number {
+    y = this.addSubheading(
+      y,
+      "FORM CONTROLS B — STEPPER, TEXT INPUT, COLOR SWATCH",
+    );
+
+    // ── Stepper ──
+    const stepperLabel = new Label(this, {
+      x: 60,
+      y,
+      text: "Stepper (range 0–10, hold + or − to repeat with acceleration)",
+      style: "caption",
+      color: this.theme.colors.textDim,
+    });
+    this.scrollContainer.add(stepperLabel);
+    y += 24;
+
+    const stepperReadout = new Label(this, {
+      x: 230,
+      y: y + 12,
+      text: "value: 5",
+      style: "body",
+    });
+    this.scrollContainer.add(stepperReadout);
+
+    const stepper = new Stepper(this, {
+      x: 60,
+      y,
+      value: 5,
+      min: 0,
+      max: 10,
+      step: 1,
+      onChange: (v) => stepperReadout.setText(`value: ${v}`),
+    });
+    this.children.remove(stepper);
+    this.scrollContainer.add(stepper);
+
+    // Stepper with formatter (currency)
+    const moneyReadout = new Label(this, {
+      x: 230,
+      y: y + 64,
+      text: "price: $1,000",
+      style: "body",
+    });
+    this.scrollContainer.add(moneyReadout);
+
+    const moneyStepper = new Stepper(this, {
+      x: 60,
+      y: y + 52,
+      value: 1000,
+      min: 0,
+      max: 100000,
+      step: 250,
+      width: 160,
+      formatValue: (v) => `$${v.toLocaleString()}`,
+      onChange: (v) => moneyReadout.setText(`price: $${v.toLocaleString()}`),
+    });
+    this.children.remove(moneyStepper);
+    this.scrollContainer.add(moneyStepper);
+
+    y += 120;
+
+    // ── TextInput ──
+    const inputLabel = new Label(this, {
+      x: 60,
+      y,
+      text: "TextInput (DOM overlay positioned over Phaser canvas)",
+      style: "caption",
+      color: this.theme.colors.textDim,
+    });
+    this.scrollContainer.add(inputLabel);
+    y += 24;
+
+    const inputReadout = new Label(this, {
+      x: 380,
+      y: y + 12,
+      text: "value: (empty)",
+      style: "body",
+    });
+    this.scrollContainer.add(inputReadout);
+
+    const textInput = new TextInput(this, {
+      x: 60,
+      y,
+      width: 300,
+      height: 40,
+      placeholder: "Type a captain's name…",
+      onChange: (v) =>
+        inputReadout.setText(`value: ${v.length === 0 ? "(empty)" : v}`),
+    });
+    this.children.remove(textInput);
+    this.scrollContainer.add(textInput);
+
+    y += 56;
+
+    const passwordInput = new TextInput(this, {
+      x: 60,
+      y,
+      width: 300,
+      height: 40,
+      type: "password",
+      placeholder: "Password (type=password)",
+    });
+    this.children.remove(passwordInput);
+    this.scrollContainer.add(passwordInput);
+
+    y += 60;
+
+    // ── ColorSwatch ──
+    const swatchLabel = new Label(this, {
+      x: 60,
+      y,
+      text: "ColorSwatch (click to pick — building block for ColorPicker)",
+      style: "caption",
+      color: this.theme.colors.textDim,
+    });
+    this.scrollContainer.add(swatchLabel);
+    y += 24;
+
+    const palette = [
+      0xff5566, 0xffaa33, 0xffee66, 0x66dd66, 0x44aaff, 0x9966ff, 0xff66cc,
+      0xffffff,
+    ];
+    const swatchSize = 36;
+    const swatchGap = 8;
+
+    const selectedReadout = new Label(this, {
+      x: 60 + (swatchSize + swatchGap) * palette.length + 16,
+      y: y + (swatchSize - 16) / 2,
+      text: `selected: ${colorToString(palette[0])}`,
+      style: "body",
+    });
+    this.scrollContainer.add(selectedReadout);
+
+    const swatches: ColorSwatch[] = [];
+    palette.forEach((color, idx) => {
+      const swatch = new ColorSwatch(this, {
+        x: 60 + idx * (swatchSize + swatchGap),
+        y,
+        size: swatchSize,
+        color,
+        selected: idx === 0,
+        onClick: (c) => {
+          swatches.forEach((s) => s.setSelected(false));
+          swatch.setSelected(true);
+          selectedReadout.setText(`selected: ${colorToString(c)}`);
+        },
+      });
+      this.children.remove(swatch);
+      this.scrollContainer.add(swatch);
+      swatches.push(swatch);
+    });
+
+    return y + swatchSize + 30;
   }
 }


### PR DESCRIPTION
## Summary

Plan unit 3 (Form Controls B) of the 21-unit UI 3-tier formalization. Adds three new Tier 1 input primitives to `packages/spacebiz-ui/src/input/`:

- **Stepper** — number with +/- buttons. Hold-to-repeat after 400ms with accelerating tick (150ms → 30ms floor, ×0.85 per tick). Pure clamping/acceleration helpers split into `stepperLogic.ts` so they're testable without loading Phaser in the node Vitest env.
- **TextInput** — single-line input that mounts a real `<input>` DOM overlay positioned over the Phaser canvas each frame. Handles canvas resize, page scroll, DPR, scene shutdown cleanup, and visibility sync.
- **ColorSwatch** — clickable color square with `selected` and hover states; intended building block for a future ColorPicker.

The styleguide gains a Form Controls B section that visibly positions the DOM input over the Phaser canvas, alongside Stepper (with currency formatter variant) and a clickable ColorSwatch palette.

## Notes

- New `input/index.ts` barrel re-exported from the package's main `index.ts`.
- Tests cover the Stepper logic (clamping, acceleration, floor) plus file-shape smoke tests for ColorSwatch and TextInput. Headless construction tests will follow once plan unit 6 lands the jsdom harness.

## Test plan

- [x] `npm run check` (typecheck + lint + format + 912 tests + build) — clean
- [x] `npm run dev` + `npm run test:e2e` — 8/8 Playwright smoke tests pass
- [x] Manually verified styleguide section by visiting `/styleguide/`