### PR TITLE
test(ui): add unit tests for primitives (Button, Panel, Label, IconButton, Dropdown, ProgressBar)

### DIFF
--- a/packages/spacebiz-ui/src/__tests__/_harness/phaserMock.ts
+++ b/packages/spacebiz-ui/src/__tests__/_harness/phaserMock.ts
@@ -1,0 +1,505 @@
+/**
+ * Minimal `phaser` module mock for headless component tests.
+ *
+ * The real Phaser package can't be imported in Vitest's `node` environment
+ * because its bootstrap touches `window` at import time. This mock reproduces
+ * just enough of the API surface that the Tier 1 primitive components
+ * (`Button`, `Panel`, `Label`, `IconButton`, `Dropdown`, `ProgressBar`) need
+ * to construct, react to events, and tear down cleanly.
+ *
+ * Usage in a test file:
+ *
+ *   import { vi } from "vitest";
+ *   vi.mock("phaser", async () => {
+ *     const harness = await import("../_harness/phaserMock.ts");
+ *     return harness.makePhaserMock();
+ *   });
+ *
+ * Then `import { Button } from "../../Button.ts"` works as normal.
+ */
+
+/* eslint-disable */
+
+class EventEmitterStub {
+  private listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+
+  on(event: string, fn: (...args: unknown[]) => void): this {
+    const list = this.listeners.get(event) ?? [];
+    list.push(fn);
+    this.listeners.set(event, list);
+    return this;
+  }
+
+  once(event: string, fn: (...args: unknown[]) => void): this {
+    const wrap = (...args: unknown[]): void => {
+      this.off(event, wrap);
+      fn(...args);
+    };
+    return this.on(event, wrap);
+  }
+
+  off(event: string, fn?: (...args: unknown[]) => void): this {
+    if (!fn) {
+      this.listeners.delete(event);
+      return this;
+    }
+    const list = this.listeners.get(event);
+    if (!list) return this;
+    const idx = list.indexOf(fn);
+    if (idx >= 0) list.splice(idx, 1);
+    return this;
+  }
+
+  emit(event: string, ...args: unknown[]): boolean {
+    const list = this.listeners.get(event);
+    if (!list) return false;
+    for (const fn of [...list]) fn(...args);
+    return true;
+  }
+
+  listenerCount(event: string): number {
+    return this.listeners.get(event)?.length ?? 0;
+  }
+
+  removeAllListeners(): this {
+    this.listeners.clear();
+    return this;
+  }
+}
+
+class GameObjectStub extends EventEmitterStub {
+  scene: any;
+  x = 0;
+  y = 0;
+  width = 0;
+  height = 0;
+  displayWidth = 0;
+  displayHeight = 0;
+  alpha = 1;
+  visible = true;
+  active = true;
+  depth = 0;
+  originX = 0;
+  originY = 0;
+  input: { cursor?: string } | null = null;
+  parentContainer: ContainerStub | null = null;
+  destroyed = false;
+
+  constructor(scene: any) {
+    super();
+    this.scene = scene;
+  }
+
+  setOrigin(x: number, y?: number): this {
+    this.originX = x;
+    this.originY = y ?? x;
+    return this;
+  }
+
+  setPosition(x?: number, y?: number): this {
+    if (x !== undefined) this.x = x;
+    if (y !== undefined) this.y = y;
+    return this;
+  }
+
+  setX(x: number): this {
+    this.x = x;
+    return this;
+  }
+
+  setY(y: number): this {
+    this.y = y;
+    return this;
+  }
+
+  setSize(w: number, h: number): this {
+    this.width = w;
+    this.height = h;
+    this.displayWidth = w;
+    this.displayHeight = h;
+    return this;
+  }
+
+  setAlpha(a: number): this {
+    this.alpha = a;
+    return this;
+  }
+
+  setVisible(v: boolean): this {
+    this.visible = v;
+    return this;
+  }
+
+  setActive(v: boolean): this {
+    this.active = v;
+    return this;
+  }
+
+  setDepth(d: number): this {
+    this.depth = d;
+    return this;
+  }
+
+  setInteractive(_a?: unknown, _b?: unknown): this {
+    this.input = { cursor: "default" };
+    return this;
+  }
+
+  disableInteractive(): this {
+    this.input = null;
+    return this;
+  }
+
+  setFillStyle(_color?: number, _alpha?: number): this {
+    return this;
+  }
+
+  setStrokeStyle(_lw?: number, _color?: number): this {
+    return this;
+  }
+
+  setTint(_t: number): this {
+    return this;
+  }
+
+  setTexture(_k: string): this {
+    return this;
+  }
+
+  setColor(_c: string): this {
+    return this;
+  }
+
+  setText(t: string): this {
+    (this as any).text = t;
+    return this;
+  }
+
+  setShadow(): this {
+    return this;
+  }
+
+  getWorldTransformMatrix(): { tx: number; ty: number } {
+    return { tx: this.x, ty: this.y };
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.removeAllListeners();
+  }
+}
+
+class ContainerStub extends GameObjectStub {
+  list: GameObjectStub[] = [];
+
+  constructor(scene: any, x = 0, y = 0) {
+    super(scene);
+    this.x = x;
+    this.y = y;
+  }
+
+  add(child: GameObjectStub | GameObjectStub[]): this {
+    const arr = Array.isArray(child) ? child : [child];
+    for (const c of arr) {
+      this.list.push(c);
+      c.parentContainer = this;
+    }
+    return this;
+  }
+
+  preUpdate(): void {
+    // intentionally empty; subclasses may override
+  }
+}
+
+class TextStub extends GameObjectStub {
+  text: string;
+  style: Record<string, unknown>;
+
+  constructor(scene: any, x: number, y: number, text: string, style: any) {
+    super(scene);
+    this.x = x;
+    this.y = y;
+    this.text = text;
+    this.style = style ?? {};
+    // crude width approximation: 8px per char × text length
+    this.width = Math.max(1, text.length * 8);
+    this.height = 16;
+  }
+
+  setText(t: string): this {
+    this.text = t;
+    this.width = Math.max(1, t.length * 8);
+    return this;
+  }
+}
+
+class GameObjectFactoryStub {
+  scene: any;
+  constructor(scene: any) {
+    this.scene = scene;
+  }
+
+  zone(x: number, y: number, w: number, h: number): GameObjectStub {
+    const g = new GameObjectStub(this.scene);
+    g.x = x;
+    g.y = y;
+    g.width = w;
+    g.height = h;
+    return g;
+  }
+
+  rectangle(
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    _color?: number,
+    _alpha?: number,
+  ): GameObjectStub {
+    const g = new GameObjectStub(this.scene);
+    g.x = x;
+    g.y = y;
+    g.width = w;
+    g.height = h;
+    return g;
+  }
+
+  nineslice(
+    x: number,
+    y: number,
+    _key: string,
+    _frame?: unknown,
+    w?: number,
+    h?: number,
+  ): GameObjectStub {
+    const g = new GameObjectStub(this.scene);
+    g.x = x;
+    g.y = y;
+    g.width = w ?? 0;
+    g.height = h ?? 0;
+    return g;
+  }
+
+  image(x: number, y: number, _key: string): GameObjectStub {
+    const g = new GameObjectStub(this.scene);
+    g.x = x;
+    g.y = y;
+    g.width = 32;
+    g.height = 32;
+    return g;
+  }
+
+  circle(
+    x: number,
+    y: number,
+    radius: number,
+    _color?: number,
+    _alpha?: number,
+  ): GameObjectStub {
+    const g = new GameObjectStub(this.scene);
+    g.x = x;
+    g.y = y;
+    g.width = radius * 2;
+    g.height = radius * 2;
+    return g;
+  }
+
+  text(x: number, y: number, text: string, style?: any): TextStub {
+    return new TextStub(this.scene, x, y, text, style);
+  }
+
+  container(x: number, y: number, children?: GameObjectStub[]): ContainerStub {
+    const c = new ContainerStub(this.scene, x, y);
+    if (children) c.add(children);
+    return c;
+  }
+
+  existing<T>(go: T): T {
+    return go;
+  }
+}
+
+class TweensStub {
+  add(config: any): { stop: () => void; isPlaying: () => boolean } {
+    if (config && typeof config.onComplete === "function") {
+      // Run synchronously so component "complete" callbacks fire in tests.
+      try {
+        config.onComplete();
+      } catch {
+        // ignore — a faulty tween callback shouldn't crash the harness
+      }
+    }
+    return {
+      stop() {},
+      isPlaying() {
+        return false;
+      },
+    };
+  }
+}
+
+class TimeStub {
+  delayedCall(_delay: number, fn: () => void): { remove: () => void } {
+    // Defer one microtask so the call lands after the synchronous setup,
+    // matching real Phaser behaviour for the dropdown's outside-click setup.
+    queueMicrotask(() => {
+      try {
+        fn();
+      } catch {
+        /* ignore */
+      }
+    });
+    return { remove() {} };
+  }
+}
+
+interface SceneStub {
+  add: GameObjectFactoryStub;
+  tweens: TweensStub;
+  time: TimeStub;
+  events: EventEmitterStub;
+  input: EventEmitterStub & {
+    setDraggable: (..._args: unknown[]) => void;
+  };
+  scale: EventEmitterStub & { width: number; height: number };
+  game: {
+    canvas: {
+      width: number;
+      height: number;
+      getBoundingClientRect: () => {
+        left: number;
+        top: number;
+        width: number;
+        height: number;
+      };
+      addEventListener: (e: string, fn: any) => void;
+      removeEventListener: (e: string, fn: any) => void;
+    };
+  };
+  sys: { isActive: () => boolean; isVisible: () => boolean };
+  scene: { key: string };
+}
+
+export function createMockScene(key = "TestScene"): SceneStub {
+  const scene = {} as SceneStub;
+  scene.add = new GameObjectFactoryStub(scene);
+  scene.tweens = new TweensStub();
+  scene.time = new TimeStub();
+  scene.events = new EventEmitterStub();
+  const inputEmitter = new EventEmitterStub() as EventEmitterStub & {
+    setDraggable: (..._args: unknown[]) => void;
+  };
+  inputEmitter.setDraggable = () => {};
+  scene.input = inputEmitter;
+  const scaleEmitter = new EventEmitterStub() as EventEmitterStub & {
+    width: number;
+    height: number;
+  };
+  scaleEmitter.width = 1280;
+  scaleEmitter.height = 720;
+  scene.scale = scaleEmitter;
+  const canvasListeners: Record<string, Array<(...a: unknown[]) => void>> = {};
+  scene.game = {
+    canvas: {
+      width: 1280,
+      height: 720,
+      getBoundingClientRect: () => ({
+        left: 0,
+        top: 0,
+        width: 1280,
+        height: 720,
+      }),
+      addEventListener: (e: string, fn: any) => {
+        (canvasListeners[e] ??= []).push(fn);
+      },
+      removeEventListener: (e: string, fn: any) => {
+        const list = canvasListeners[e] ?? [];
+        const idx = list.indexOf(fn);
+        if (idx >= 0) list.splice(idx, 1);
+      },
+    },
+  };
+  scene.sys = { isActive: () => true, isVisible: () => true };
+  scene.scene = { key };
+  return scene;
+}
+
+export type MockScene = ReturnType<typeof createMockScene>;
+
+/**
+ * Returns the value to be used as the `phaser` module replacement.
+ * Must be called from the `vi.mock("phaser", ...)` factory.
+ */
+export function makePhaserMock(): Record<string, unknown> {
+  const Math_ = {
+    Clamp(v: number, lo: number, hi: number): number {
+      return v < lo ? lo : v > hi ? hi : v;
+    },
+  };
+  class GeomRectangle {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    constructor(x: number, y: number, width: number, height: number) {
+      this.x = x;
+      this.y = y;
+      this.width = width;
+      this.height = height;
+    }
+    static Contains(_r: unknown, _x: number, _y: number): boolean {
+      return true;
+    }
+  }
+  const Geom = { Rectangle: GeomRectangle };
+  const GameObjects = {
+    Container: ContainerStub,
+    Text: TextStub,
+  };
+  const Scene = class {};
+  const Input = {
+    Pointer: class {},
+  };
+  const Tweens = {
+    Tween: class {},
+  };
+  return {
+    default: {
+      Scene,
+      GameObjects,
+      Math: Math_,
+      Geom,
+      Input,
+      Tweens,
+    },
+    Scene,
+    GameObjects,
+    Math: Math_,
+    Geom,
+    Input,
+    Tweens,
+  };
+}
+
+/**
+ * Helper: synthesize a pointer event on a stub-mounted GameObject.
+ * Resets idle-shimmer tween side effects across hover/out cycles.
+ */
+export function fireEvent(
+  target: any,
+  event: string,
+  ...args: unknown[]
+): void {
+  if (typeof target?.emit === "function") {
+    target.emit(event, ...args);
+  }
+}
+
+/** Internal helpers exposed for unit-test introspection. */
+export const _internals = {
+  ContainerStub,
+  TextStub,
+  GameObjectStub,
+  EventEmitterStub,
+};

--- a/packages/spacebiz-ui/src/__tests__/primitives/Button.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/primitives/Button.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("phaser", async () => {
+  const harness = await import("../_harness/phaserMock.ts");
+  return harness.makePhaserMock();
+});
+
+import { Button, type ButtonConfig } from "../../Button.ts";
+import {
+  createMockScene,
+  fireEvent,
+  type MockScene,
+} from "../_harness/phaserMock.ts";
+
+let scene: MockScene;
+
+beforeEach(() => {
+  scene = createMockScene("ButtonScene");
+});
+
+function makeButton(overrides: Partial<ButtonConfig> = {}) {
+  const onClick = vi.fn();
+  const btn = new Button(scene as unknown as Phaser.Scene, {
+    x: 10,
+    y: 20,
+    label: "Save",
+    onClick,
+    ...overrides,
+  });
+  return { btn, onClick };
+}
+
+describe("Button construction", () => {
+  it("creates a container with theme-driven default size", () => {
+    const { btn } = makeButton();
+    expect(btn).toBeDefined();
+    expect(btn.x).toBe(10);
+    expect(btn.y).toBe(20);
+    expect(btn.width).toBeGreaterThan(0);
+    expect(btn.height).toBeGreaterThan(0);
+  });
+
+  it("respects an explicit width/height override", () => {
+    const { btn } = makeButton({ width: 200, height: 60 });
+    expect(btn.width).toBe(200);
+    expect(btn.height).toBe(60);
+  });
+
+  it("defaults to enabled (interactive) state", () => {
+    const { btn } = makeButton();
+    expect(
+      (btn as unknown as { isDisabled: boolean }).isDisabled ?? false,
+    ).toBe(false);
+  });
+});
+
+describe("Button.setLabel", () => {
+  it("updates the underlying text", () => {
+    const { btn } = makeButton({ label: "Old" });
+    btn.setLabel("New");
+    const inner = (btn as unknown as { label: { text: string } }).label;
+    expect(inner.text).toBe("New");
+  });
+});
+
+describe("Button.setDisabled", () => {
+  it("toggles the disabled flag", () => {
+    const { btn } = makeButton();
+    btn.setDisabled(true);
+    expect((btn as unknown as { isDisabled: boolean }).isDisabled).toBe(true);
+    btn.setDisabled(false);
+    expect((btn as unknown as { isDisabled: boolean }).isDisabled).toBe(false);
+  });
+
+  it("disables interactivity on the hit zone when disabled", () => {
+    const { btn } = makeButton();
+    const hitZone = (btn as unknown as { hitZone: { input: unknown } }).hitZone;
+    btn.setDisabled(true);
+    expect(hitZone.input).toBeNull();
+  });
+});
+
+describe("Button click and hover", () => {
+  it("invokes onClick on hit-zone pointerup", () => {
+    const { btn, onClick } = makeButton({ label: "Go" });
+    const hitZone = (btn as unknown as { hitZone: any }).hitZone;
+    fireEvent(hitZone, "pointerup");
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("hover and out events do not throw and toggle texture state", () => {
+    const { btn } = makeButton();
+    const hitZone = (btn as unknown as { hitZone: any }).hitZone;
+    expect(() => {
+      fireEvent(hitZone, "pointerover");
+      fireEvent(hitZone, "pointerout");
+      fireEvent(hitZone, "pointerdown");
+      fireEvent(hitZone, "pointerupoutside");
+    }).not.toThrow();
+  });
+});
+
+describe("Button.setActive (visual selection state)", () => {
+  it("returns the button instance for chaining", () => {
+    const { btn } = makeButton();
+    expect(btn.setActive(true)).toBe(btn);
+    expect(btn.setActive(false)).toBe(btn);
+  });
+
+  it("is a no-op when disabled", () => {
+    const { btn } = makeButton();
+    btn.setDisabled(true);
+    expect(() => btn.setActive(true)).not.toThrow();
+  });
+});
+
+describe("Button.destroy", () => {
+  it("tears down hit zone without throwing", () => {
+    const { btn } = makeButton();
+    const hitZone = (btn as unknown as { hitZone: any }).hitZone;
+    btn.destroy();
+    expect(hitZone.destroyed).toBe(true);
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/primitives/Dropdown.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/primitives/Dropdown.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("phaser", async () => {
+  const harness = await import("../_harness/phaserMock.ts");
+  return harness.makePhaserMock();
+});
+
+import { Dropdown, type DropdownOption } from "../../Dropdown.ts";
+import { createMockScene, type MockScene } from "../_harness/phaserMock.ts";
+
+let scene: MockScene;
+
+const opts: DropdownOption[] = [
+  { label: "Alpha", value: "a" },
+  { label: "Beta", value: "b" },
+  { label: "Gamma", value: "g" },
+];
+
+beforeEach(() => {
+  scene = createMockScene("DropdownScene");
+});
+
+function makeDropdown(
+  overrides: {
+    defaultIndex?: number;
+    onChange?: (v: string, i: number) => void;
+  } = {},
+) {
+  return new Dropdown(scene as unknown as Phaser.Scene, {
+    x: 0,
+    y: 0,
+    width: 200,
+    options: opts,
+    ...overrides,
+  });
+}
+
+describe("Dropdown construction", () => {
+  it("displays the default option label at index 0", () => {
+    const dd = makeDropdown();
+    expect(dd.getSelectedIndex()).toBe(0);
+    expect(dd.getSelectedValue()).toBe("a");
+  });
+
+  it("respects defaultIndex", () => {
+    const dd = makeDropdown({ defaultIndex: 2 });
+    expect(dd.getSelectedIndex()).toBe(2);
+    expect(dd.getSelectedValue()).toBe("g");
+  });
+
+  it("starts in the closed state with no overlay objects", () => {
+    const dd = makeDropdown();
+    const overlays = (dd as unknown as { overlayObjects: unknown[] })
+      .overlayObjects;
+    expect(overlays).toHaveLength(0);
+  });
+});
+
+describe("Dropdown.setSelectedIndex", () => {
+  it("updates selection within bounds", () => {
+    const dd = makeDropdown();
+    dd.setSelectedIndex(1);
+    expect(dd.getSelectedIndex()).toBe(1);
+    expect(dd.getSelectedValue()).toBe("b");
+  });
+
+  it("ignores out-of-range indices", () => {
+    const dd = makeDropdown({ defaultIndex: 1 });
+    dd.setSelectedIndex(-1);
+    dd.setSelectedIndex(99);
+    expect(dd.getSelectedIndex()).toBe(1);
+  });
+});
+
+describe("Dropdown opening and closing", () => {
+  it("opens on pointerdown of the trigger and creates per-option overlay objects", () => {
+    const dd = makeDropdown();
+    const bg = (dd as unknown as { bg: { emit: (e: string) => void } }).bg;
+    bg.emit("pointerdown");
+    const overlays = (dd as unknown as { overlayObjects: unknown[] })
+      .overlayObjects;
+    // Each option contributes 3 overlay objects (bg, border, label).
+    expect(overlays.length).toBe(opts.length * 3);
+  });
+
+  it("closes on a second pointerdown of the trigger", () => {
+    const dd = makeDropdown();
+    const bg = (dd as unknown as { bg: { emit: (e: string) => void } }).bg;
+    bg.emit("pointerdown");
+    bg.emit("pointerdown");
+    const overlays = (dd as unknown as { overlayObjects: unknown[] })
+      .overlayObjects;
+    expect(overlays).toHaveLength(0);
+  });
+});
+
+describe("Dropdown selection callback", () => {
+  it("calls onChange with the picked value and its index", () => {
+    const onChange = vi.fn();
+    const dd = makeDropdown({ onChange });
+    const bg = (dd as unknown as { bg: { emit: (e: string) => void } }).bg;
+    bg.emit("pointerdown");
+    const overlays = (
+      dd as unknown as {
+        overlayObjects: Array<{ emit?: (e: string) => void }>;
+      }
+    ).overlayObjects;
+    // The first overlay group is for index 0 (bg); pick index 1 -> overlay at offset 3
+    overlays[3]?.emit?.("pointerdown");
+    expect(onChange).toHaveBeenCalledWith("b", 1);
+    expect(dd.getSelectedIndex()).toBe(1);
+  });
+
+  it("is a no-op when no onChange handler is provided", () => {
+    const dd = makeDropdown();
+    const bg = (dd as unknown as { bg: { emit: (e: string) => void } }).bg;
+    bg.emit("pointerdown");
+    const overlays = (
+      dd as unknown as {
+        overlayObjects: Array<{ emit?: (e: string) => void }>;
+      }
+    ).overlayObjects;
+    expect(() => overlays[0]?.emit?.("pointerdown")).not.toThrow();
+    expect(dd.getSelectedIndex()).toBe(0);
+  });
+});
+
+describe("Dropdown.destroy", () => {
+  it("closes any open overlay before destroy and does not throw", () => {
+    const dd = makeDropdown();
+    const bg = (dd as unknown as { bg: { emit: (e: string) => void } }).bg;
+    bg.emit("pointerdown");
+    expect(() => dd.destroy()).not.toThrow();
+    expect(
+      (dd as unknown as { overlayObjects: unknown[] }).overlayObjects,
+    ).toHaveLength(0);
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/primitives/IconButton.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/primitives/IconButton.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("phaser", async () => {
+  const harness = await import("../_harness/phaserMock.ts");
+  return harness.makePhaserMock();
+});
+
+import { IconButton } from "../../IconButton.ts";
+import { createMockScene, type MockScene } from "../_harness/phaserMock.ts";
+
+let scene: MockScene;
+
+beforeEach(() => {
+  scene = createMockScene("IconButtonScene");
+});
+
+function makeIconButton(
+  overrides: Partial<{
+    size: number;
+    label: string;
+    active: boolean;
+    disabled: boolean;
+    icon: string;
+  }> = {},
+) {
+  const onClick = vi.fn();
+  const btn = new IconButton(scene as unknown as Phaser.Scene, {
+    x: 5,
+    y: 6,
+    icon: overrides.icon ?? "icon-fleet",
+    onClick,
+    ...overrides,
+  });
+  return { btn, onClick };
+}
+
+describe("IconButton construction", () => {
+  it("creates a container at the configured position", () => {
+    const { btn } = makeIconButton();
+    expect(btn.x).toBe(5);
+    expect(btn.y).toBe(6);
+  });
+
+  it("uses default 40px square size when none specified", () => {
+    const { btn } = makeIconButton();
+    const icon = (btn as unknown as { iconImage: { x: number; y: number } })
+      .iconImage;
+    expect(icon.x).toBe(20);
+    expect(icon.y).toBe(20);
+  });
+
+  it("respects an explicit size override", () => {
+    const { btn } = makeIconButton({ size: 64 });
+    const icon = (btn as unknown as { iconImage: { x: number; y: number } })
+      .iconImage;
+    expect(icon.x).toBe(32);
+    expect(icon.y).toBe(32);
+  });
+
+  it("renders a label text node when label is provided", () => {
+    const { btn } = makeIconButton({ label: "Fleet" });
+    const lbl = (btn as unknown as { labelText: { text: string } | null })
+      .labelText;
+    expect(lbl).not.toBeNull();
+    expect(lbl?.text).toBe("Fleet");
+  });
+
+  it("omits the label text node when no label is provided", () => {
+    const { btn } = makeIconButton();
+    expect((btn as unknown as { labelText: unknown }).labelText).toBeNull();
+  });
+});
+
+describe("IconButton click handler", () => {
+  it("invokes onClick on hit-zone pointerdown when enabled", () => {
+    const { btn, onClick } = makeIconButton();
+    const hitZone = (
+      btn as unknown as { list: Array<{ emit?: (e: string) => void }> }
+    ).list.at(-1);
+    hitZone?.emit?.("pointerdown");
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not register pointer listeners when disabled", () => {
+    const { btn, onClick } = makeIconButton({ disabled: true });
+    const hitZone = (
+      btn as unknown as {
+        list: Array<{
+          emit?: (e: string) => void;
+          listenerCount?: (e: string) => number;
+        }>;
+      }
+    ).list.at(-1);
+    expect(hitZone?.listenerCount?.("pointerdown") ?? 0).toBe(0);
+    hitZone?.emit?.("pointerdown");
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});
+
+describe("IconButton.setActiveState", () => {
+  it("returns the instance for chaining", () => {
+    const { btn } = makeIconButton();
+    expect(btn.setActiveState(true)).toBe(btn);
+    expect(btn.setActiveState(false)).toBe(btn);
+  });
+
+  it("toggles the active indicator alpha", () => {
+    const { btn } = makeIconButton();
+    const indicator = (btn as unknown as { activeIndicator: { alpha: number } })
+      .activeIndicator;
+    btn.setActiveState(true);
+    expect(indicator.alpha).toBeGreaterThan(0);
+    btn.setActiveState(false);
+    expect(indicator.alpha).toBe(0);
+  });
+});
+
+describe("IconButton hover state (icon swap path)", () => {
+  it("emits hover/out without throwing and the icon stays valid", () => {
+    const { btn } = makeIconButton({ label: "Map" });
+    const hitZone = (
+      btn as unknown as { list: Array<{ emit?: (e: string) => void }> }
+    ).list.at(-1);
+    expect(() => {
+      hitZone?.emit?.("pointerover");
+      hitZone?.emit?.("pointerout");
+    }).not.toThrow();
+    expect((btn as unknown as { iconImage: unknown }).iconImage).toBeDefined();
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/primitives/Label.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/primitives/Label.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("phaser", async () => {
+  const harness = await import("../_harness/phaserMock.ts");
+  return harness.makePhaserMock();
+});
+
+import { Label } from "../../Label.ts";
+import { getTheme, colorToString } from "../../Theme.ts";
+import { createMockScene, type MockScene } from "../_harness/phaserMock.ts";
+
+let scene: MockScene;
+
+beforeEach(() => {
+  scene = createMockScene("LabelScene");
+});
+
+describe("Label construction", () => {
+  it("renders text at the configured position", () => {
+    const lbl = new Label(scene as unknown as Phaser.Scene, {
+      x: 5,
+      y: 7,
+      text: "Hello",
+    });
+    expect(lbl.x).toBe(5);
+    expect(lbl.y).toBe(7);
+    expect((lbl as unknown as { text: string }).text).toBe("Hello");
+  });
+
+  it("applies the body font style by default", () => {
+    const lbl = new Label(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      text: "Body",
+    });
+    const theme = getTheme();
+    const style = (
+      lbl as unknown as { style: { fontSize?: string; fontFamily?: string } }
+    ).style;
+    expect(style.fontSize).toBe(`${theme.fonts.body.size}px`);
+    expect(style.fontFamily).toBe(theme.fonts.body.family);
+  });
+
+  it("uses the heading style when style='heading' is requested", () => {
+    const lbl = new Label(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      text: "Title",
+      style: "heading",
+    });
+    const theme = getTheme();
+    const style = (lbl as unknown as { style: { fontSize?: string } }).style;
+    expect(style.fontSize).toBe(`${theme.fonts.heading.size}px`);
+  });
+
+  it("uses the caption style when style='caption' is requested", () => {
+    const lbl = new Label(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      text: "Tiny",
+      style: "caption",
+    });
+    const theme = getTheme();
+    const style = (lbl as unknown as { style: { fontSize?: string } }).style;
+    expect(style.fontSize).toBe(`${theme.fonts.caption.size}px`);
+  });
+
+  it("applies a custom color when provided", () => {
+    const lbl = new Label(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      text: "Tinted",
+      color: 0xff00aa,
+    });
+    const style = (lbl as unknown as { style: { color?: string } }).style;
+    expect(style.color).toBe(colorToString(0xff00aa));
+  });
+
+  it("includes wordWrap when maxWidth is set", () => {
+    const lbl = new Label(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      text: "Long text",
+      maxWidth: 120,
+    });
+    const style = (
+      lbl as unknown as { style: { wordWrap?: { width: number } } }
+    ).style;
+    expect(style.wordWrap?.width).toBe(120);
+  });
+});
+
+describe("Label.setLabelColor", () => {
+  it("returns the label instance for chaining", () => {
+    const lbl = new Label(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      text: "X",
+    });
+    expect(lbl.setLabelColor(0x123456)).toBe(lbl);
+  });
+});
+
+describe("Label.setGlow", () => {
+  it("returns the label instance for chaining (enable + disable)", () => {
+    const lbl = new Label(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      text: "Glowy",
+    });
+    expect(lbl.setGlow(true)).toBe(lbl);
+    expect(lbl.setGlow(false)).toBe(lbl);
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/primitives/Panel.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/primitives/Panel.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("phaser", async () => {
+  const harness = await import("../_harness/phaserMock.ts");
+  return harness.makePhaserMock();
+});
+
+import { Panel } from "../../Panel.ts";
+import { getTheme } from "../../Theme.ts";
+import { createMockScene, type MockScene } from "../_harness/phaserMock.ts";
+
+let scene: MockScene;
+
+beforeEach(() => {
+  scene = createMockScene("PanelScene");
+});
+
+describe("Panel construction", () => {
+  it("creates a container at the configured position with the configured size", () => {
+    const panel = new Panel(scene as unknown as Phaser.Scene, {
+      x: 30,
+      y: 40,
+      width: 400,
+      height: 300,
+    });
+    expect(panel.x).toBe(30);
+    expect(panel.y).toBe(40);
+    const internal = panel as unknown as {
+      panelWidth: number;
+      panelHeight: number;
+    };
+    expect(internal.panelWidth).toBe(400);
+    expect(internal.panelHeight).toBe(300);
+  });
+
+  it("includes a glow layer by default and skips it when showGlow=false", () => {
+    const withGlow = new Panel(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+    });
+    const withoutGlow = new Panel(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+      showGlow: false,
+    });
+    expect(
+      (withGlow as unknown as { glowLayer: unknown }).glowLayer,
+    ).not.toBeNull();
+    expect(
+      (withoutGlow as unknown as { glowLayer: unknown }).glowLayer,
+    ).toBeNull();
+  });
+});
+
+describe("Panel title bar", () => {
+  it("omits the title bar when no title is provided", () => {
+    const panel = new Panel(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+    });
+    expect((panel as unknown as { titleBar: unknown }).titleBar).toBeNull();
+  });
+
+  it("creates a title bar when a title is provided and bumps contentY", () => {
+    const panel = new Panel(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 200,
+      title: "Inventory",
+    });
+    const theme = getTheme();
+    expect((panel as unknown as { titleBar: unknown }).titleBar).not.toBeNull();
+    expect(panel.getContentY()).toBe(
+      theme.panel.titleHeight + theme.spacing.sm,
+    );
+  });
+});
+
+describe("Panel.getContentArea", () => {
+  it("returns positive dimensions inside the panel padding", () => {
+    const panel = new Panel(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 300,
+    });
+    const area = panel.getContentArea();
+    expect(area.x).toBeGreaterThan(0);
+    expect(area.y).toBeGreaterThan(0);
+    expect(area.width).toBeGreaterThan(0);
+    expect(area.width).toBeLessThan(400);
+    expect(area.height).toBeGreaterThan(0);
+    expect(area.height).toBeLessThan(300);
+  });
+
+  it("subtracts the title bar from the content area when titled", () => {
+    const untitled = new Panel(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 300,
+    }).getContentArea();
+    const titled = new Panel(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 300,
+      title: "Inventory",
+    }).getContentArea();
+    expect(titled.height).toBeLessThan(untitled.height);
+  });
+});
+
+describe("Panel.setActive", () => {
+  it("returns the panel instance for chaining", () => {
+    const panel = new Panel(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+    });
+    expect(panel.setActive(true)).toBe(panel);
+    expect(panel.setActive(false)).toBe(panel);
+  });
+
+  it("is a no-op when there is no glow layer", () => {
+    const panel = new Panel(scene as unknown as Phaser.Scene, {
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+      showGlow: false,
+    });
+    expect(() => panel.setActive(true)).not.toThrow();
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/primitives/ProgressBar.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/primitives/ProgressBar.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("phaser", async () => {
+  const harness = await import("../_harness/phaserMock.ts");
+  return harness.makePhaserMock();
+});
+
+import { ProgressBar } from "../../ProgressBar.ts";
+import { createMockScene, type MockScene } from "../_harness/phaserMock.ts";
+
+let scene: MockScene;
+
+beforeEach(() => {
+  scene = createMockScene("ProgressBarScene");
+});
+
+function makeBar(
+  overrides: {
+    value?: number;
+    maxValue?: number;
+    showLabel?: boolean;
+    labelFormat?: (v: number, m: number) => string;
+  } = {},
+) {
+  return new ProgressBar(scene as unknown as Phaser.Scene, {
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 20,
+    ...overrides,
+  });
+}
+
+describe("ProgressBar construction", () => {
+  it("defaults to value=0 / maxValue=100", () => {
+    const bar = makeBar();
+    expect(bar.getValue()).toBe(0);
+  });
+
+  it("respects an initial value", () => {
+    const bar = makeBar({ value: 25 });
+    expect(bar.getValue()).toBe(25);
+  });
+
+  it("renders a label by default and omits it when showLabel=false", () => {
+    const withLabel = makeBar();
+    const withoutLabel = makeBar({ showLabel: false });
+    expect((withLabel as unknown as { label: unknown }).label).not.toBeNull();
+    expect((withoutLabel as unknown as { label: unknown }).label).toBeNull();
+  });
+});
+
+describe("ProgressBar.setValue (clamping)", () => {
+  it("clamps values above maxValue", () => {
+    const bar = makeBar({ maxValue: 50 });
+    bar.setValue(200);
+    expect(bar.getValue()).toBe(50);
+  });
+
+  it("clamps negative values to 0", () => {
+    const bar = makeBar({ value: 30 });
+    bar.setValue(-10);
+    expect(bar.getValue()).toBe(0);
+  });
+
+  it("accepts in-range values directly", () => {
+    const bar = makeBar({ maxValue: 200 });
+    bar.setValue(75);
+    expect(bar.getValue()).toBe(75);
+  });
+});
+
+describe("ProgressBar fill width", () => {
+  it("non-animated update writes displayWidth synchronously", () => {
+    const bar = makeBar({ maxValue: 100 });
+    const fill = (bar as unknown as { fill: { displayWidth: number } }).fill;
+    bar.setValue(50, false);
+    expect(fill.displayWidth).toBeGreaterThan(0);
+  });
+
+  it("zero value yields zero fill width (non-animated)", () => {
+    const bar = makeBar({ value: 50 });
+    const fill = (bar as unknown as { fill: { displayWidth: number } }).fill;
+    bar.setValue(0, false);
+    expect(fill.displayWidth).toBe(0);
+  });
+});
+
+describe("ProgressBar label formatting", () => {
+  it("uses default percent format when no formatter is supplied", () => {
+    const bar = makeBar({ value: 25, maxValue: 100 });
+    const lbl = (bar as unknown as { label: { text: string } | null }).label;
+    expect(lbl?.text).toBe("25%");
+  });
+
+  it("uses a custom labelFormat callback", () => {
+    const bar = makeBar({
+      value: 30,
+      maxValue: 60,
+      labelFormat: (v, m) => `${v}/${m}`,
+    });
+    const lbl = (bar as unknown as { label: { text: string } | null }).label;
+    expect(lbl?.text).toBe("30/60");
+  });
+
+  it("re-formats the label after setValue", () => {
+    const fmt = vi.fn((v: number, m: number) => `${v}/${m}`);
+    const bar = makeBar({ value: 0, maxValue: 100, labelFormat: fmt });
+    bar.setValue(40);
+    const lbl = (bar as unknown as { label: { text: string } | null }).label;
+    expect(lbl?.text).toBe("40/100");
+  });
+});
+
+describe("ProgressBar.setMaxValue", () => {
+  it("clamps current value to the new max", () => {
+    const bar = makeBar({ value: 80, maxValue: 100 });
+    bar.setMaxValue(50);
+    expect(bar.getValue()).toBe(50);
+  });
+
+  it("guards against zero/negative max", () => {
+    const bar = makeBar({ value: 5, maxValue: 10 });
+    bar.setMaxValue(0);
+    expect(bar.getValue()).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("ProgressBar.setFillColor", () => {
+  it("updates the stored fill color and applies it without throwing", () => {
+    const bar = makeBar();
+    expect(() => bar.setFillColor(0xff00aa)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a minimal `phaser` module mock harness (`packages/spacebiz-ui/src/__tests__/_harness/phaserMock.ts`) so Tier 1 UI primitives can be exercised under Vitest's `node` environment without instantiating the real Phaser runtime (which touches `window` at import time). The harness is opted into per test file via `vi.mock("phaser", ...)`.
- 61 new tests across 6 files cover construction, label/value mutation, disabled state, click and hover handlers, opening/closing/selection, value clamping, and label formatting for `Button`, `Panel`, `Label`, `IconButton`, `Dropdown`, and `ProgressBar`.
- Bumps `packages/spacebiz-ui` test coverage from 1 file to 7. Implements unit 8 of the 3-tier UI plan.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors; 43 pre-existing warnings unrelated to this change)
- [x] `npm run format:check` passes
- [x] `npm run test` passes — 957 tests across 70 files (61 new)
- [x] `npm run build` produces both main + styleguide bundles
- [x] E2E intentionally skipped per the unit's recipe (test additions only)

Note: the harness is intentionally minimal. When unit 6 lands its full headless harness, primitives tests can either keep using this mock or migrate; both approaches coexist cleanly because the mock is opted into per file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)