### PR TITLE
test(ui): add unit tests for foundation modules (Theme, DepthLayers, TextMetrics, MaskUtils, UiSound, WidgetHooks, AmbientFX)

### DIFF
--- a/packages/spacebiz-ui/src/__tests__/foundation/AmbientFX.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/foundation/AmbientFX.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi } from "vitest";
+import type * as Phaser from "phaser";
+
+// Phaser's runtime touches `window` on import. Stub it; these tests only need
+// the type imports — the implementation reaches into scene.* off the argument.
+vi.mock("phaser", () => ({}));
+
+import {
+  addPulseTween,
+  addTwinkleTween,
+  addFloatTween,
+  addRotateTween,
+  flashScreen,
+  registerAmbientCleanup,
+} from "../../AmbientFX.ts";
+
+interface CapturedTween {
+  config: Record<string, unknown>;
+  isPlayingValue: boolean;
+  stop: ReturnType<typeof vi.fn>;
+  isPlaying: () => boolean;
+}
+
+interface MockScene {
+  scene: Phaser.Scene;
+  tweenCalls: CapturedTween[];
+  shutdownHandlers: Array<() => void>;
+  cameraWidth: number;
+  cameraHeight: number;
+  cameraZoom: number;
+  rectangles: Array<{
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    color: number;
+    alpha: number;
+    destroy: ReturnType<typeof vi.fn>;
+  }>;
+}
+
+function makeMockScene(): MockScene {
+  const tweenCalls: CapturedTween[] = [];
+  const shutdownHandlers: Array<() => void> = [];
+  const rectangles: MockScene["rectangles"] = [];
+
+  const scene = {
+    tweens: {
+      add: (config: Record<string, unknown>) => {
+        const captured: CapturedTween = {
+          config,
+          isPlayingValue: true,
+          stop: vi.fn(),
+          isPlaying: () => captured.isPlayingValue,
+        };
+        tweenCalls.push(captured);
+        return captured as unknown as Phaser.Tweens.Tween;
+      },
+    },
+    events: {
+      once: (event: string, handler: () => void) => {
+        if (event === "shutdown") {
+          shutdownHandlers.push(handler);
+        }
+      },
+    },
+    cameras: {
+      main: { width: 800, height: 600, zoom: 1 },
+    },
+    add: {
+      rectangle: (
+        x: number,
+        y: number,
+        w: number,
+        h: number,
+        color: number,
+        alpha: number,
+      ) => {
+        const rect: {
+          x: number;
+          y: number;
+          w: number;
+          h: number;
+          color: number;
+          alpha: number;
+          destroy: ReturnType<typeof vi.fn>;
+          setOrigin: () => typeof rect;
+          setDepth: () => typeof rect;
+          setScrollFactor: () => typeof rect;
+        } = {
+          x,
+          y,
+          w,
+          h,
+          color,
+          alpha,
+          destroy: vi.fn(),
+          setOrigin: () => rect,
+          setDepth: () => rect,
+          setScrollFactor: () => rect,
+        };
+        rectangles.push(rect);
+        return rect;
+      },
+    },
+  } as unknown as Phaser.Scene;
+
+  return {
+    scene,
+    tweenCalls,
+    shutdownHandlers,
+    cameraWidth: 800,
+    cameraHeight: 600,
+    cameraZoom: 1,
+    rectangles,
+  };
+}
+
+describe("AmbientFX", () => {
+  describe("addPulseTween", () => {
+    it("creates an infinite yoyo tween between minAlpha and maxAlpha", () => {
+      const m = makeMockScene();
+      const target = {} as unknown as Phaser.GameObjects.GameObject;
+
+      addPulseTween(m.scene, target, {
+        minAlpha: 0.2,
+        maxAlpha: 0.8,
+        duration: 1000,
+      });
+
+      expect(m.tweenCalls).toHaveLength(1);
+      const cfg = m.tweenCalls[0].config;
+      expect(cfg.targets).toBe(target);
+      expect(cfg.alpha).toEqual({ from: 0.2, to: 0.8 });
+      expect(cfg.duration).toBe(1000);
+      expect(cfg.yoyo).toBe(true);
+      expect(cfg.repeat).toBe(-1);
+      expect(cfg.ease).toBe("Sine.easeInOut");
+      expect(cfg.delay).toBe(0);
+    });
+
+    it("respects custom ease and delay", () => {
+      const m = makeMockScene();
+      addPulseTween(m.scene, {} as Phaser.GameObjects.GameObject, {
+        minAlpha: 0,
+        maxAlpha: 1,
+        duration: 500,
+        ease: "Linear",
+        delay: 250,
+      });
+
+      const cfg = m.tweenCalls[0].config;
+      expect(cfg.ease).toBe("Linear");
+      expect(cfg.delay).toBe(250);
+    });
+  });
+
+  describe("addTwinkleTween", () => {
+    it("creates a yoyo tween with a duration in [min, max]", () => {
+      const m = makeMockScene();
+      addTwinkleTween(m.scene, {} as Phaser.GameObjects.GameObject, {
+        minAlpha: 0.1,
+        maxAlpha: 0.9,
+        minDuration: 1000,
+        maxDuration: 2000,
+      });
+
+      const cfg = m.tweenCalls[0].config as {
+        duration: number;
+        delay: number;
+        yoyo: boolean;
+        repeat: number;
+        alpha: { from: number; to: number };
+      };
+      expect(cfg.alpha).toEqual({ from: 0.1, to: 0.9 });
+      expect(cfg.yoyo).toBe(true);
+      expect(cfg.repeat).toBe(-1);
+      expect(cfg.duration).toBeGreaterThanOrEqual(1000);
+      expect(cfg.duration).toBeLessThanOrEqual(2000);
+      expect(cfg.delay).toBeGreaterThanOrEqual(0);
+      expect(cfg.delay).toBeLessThanOrEqual(cfg.duration);
+    });
+
+    it("uses the supplied delay verbatim when provided", () => {
+      const m = makeMockScene();
+      addTwinkleTween(m.scene, {} as Phaser.GameObjects.GameObject, {
+        minAlpha: 0,
+        maxAlpha: 1,
+        minDuration: 100,
+        maxDuration: 100,
+        delay: 42,
+      });
+      expect(m.tweenCalls[0].config.delay).toBe(42);
+    });
+  });
+
+  describe("addFloatTween", () => {
+    it("animates relative x/y offsets and yoyos forever", () => {
+      const m = makeMockScene();
+      addFloatTween(m.scene, {} as Phaser.GameObjects.GameObject, {
+        dx: 5,
+        dy: -3,
+        duration: 1200,
+      });
+
+      const cfg = m.tweenCalls[0].config;
+      expect(cfg.x).toBe("+=5");
+      expect(cfg.y).toBe("+=-3");
+      expect(cfg.duration).toBe(1200);
+      expect(cfg.yoyo).toBe(true);
+      expect(cfg.repeat).toBe(-1);
+      expect(cfg.ease).toBe("Sine.easeInOut");
+      expect(cfg.delay).toBe(0);
+    });
+  });
+
+  describe("addRotateTween", () => {
+    it("rotates a full clockwise revolution by default", () => {
+      const m = makeMockScene();
+      addRotateTween(m.scene, {} as Phaser.GameObjects.GameObject, 5000);
+
+      const cfg = m.tweenCalls[0].config;
+      expect(cfg.rotation).toBeCloseTo(Math.PI * 2);
+      expect(cfg.duration).toBe(5000);
+      expect(cfg.repeat).toBe(-1);
+      expect(cfg.ease).toBe("Linear");
+    });
+
+    it("rotates counter-clockwise when clockwise=false", () => {
+      const m = makeMockScene();
+      addRotateTween(m.scene, {} as Phaser.GameObjects.GameObject, 2000, false);
+      expect(m.tweenCalls[0].config.rotation).toBeCloseTo(-Math.PI * 2);
+    });
+  });
+
+  describe("registerAmbientCleanup", () => {
+    it("registers a single shutdown listener", () => {
+      const m = makeMockScene();
+      registerAmbientCleanup(m.scene, []);
+      expect(m.shutdownHandlers).toHaveLength(1);
+    });
+
+    it("stops every still-playing tween on scene shutdown", () => {
+      const m = makeMockScene();
+      const t1 = m.scene.tweens.add({} as never) as unknown as CapturedTween;
+      const t2 = m.scene.tweens.add({} as never) as unknown as CapturedTween;
+      registerAmbientCleanup(m.scene, [
+        t1 as unknown as Phaser.Tweens.Tween,
+        t2 as unknown as Phaser.Tweens.Tween,
+      ]);
+
+      m.shutdownHandlers[0]();
+
+      expect(t1.stop).toHaveBeenCalledTimes(1);
+      expect(t2.stop).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips tweens that are no longer playing", () => {
+      const m = makeMockScene();
+      const live = m.scene.tweens.add({} as never) as unknown as CapturedTween;
+      const dead = m.scene.tweens.add({} as never) as unknown as CapturedTween;
+      dead.isPlayingValue = false;
+
+      registerAmbientCleanup(m.scene, [
+        live as unknown as Phaser.Tweens.Tween,
+        dead as unknown as Phaser.Tweens.Tween,
+      ]);
+      m.shutdownHandlers[0]();
+
+      expect(live.stop).toHaveBeenCalledTimes(1);
+      expect(dead.stop).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("flashScreen", () => {
+    it("creates a fullscreen overlay rectangle and a fade tween", () => {
+      const m = makeMockScene();
+      flashScreen(m.scene, 0x00ff88);
+
+      expect(m.rectangles).toHaveLength(1);
+      const rect = m.rectangles[0];
+      expect(rect.w).toBe(m.cameraWidth);
+      expect(rect.h).toBe(m.cameraHeight);
+      expect(rect.color).toBe(0x00ff88);
+      expect(rect.alpha).toBe(0);
+
+      expect(m.tweenCalls).toHaveLength(1);
+      const cfg = m.tweenCalls[0].config as {
+        alpha: number;
+        duration: number;
+        yoyo: boolean;
+        onComplete: () => void;
+      };
+      expect(cfg.alpha).toBe(0.35);
+      // Default 600ms × 0.25 (rise + yoyo fall = full cycle).
+      expect(cfg.duration).toBe(150);
+      expect(cfg.yoyo).toBe(true);
+      cfg.onComplete();
+      expect(rect.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("scales the overlay by inverse camera zoom", () => {
+      const m = makeMockScene();
+      (m.scene.cameras.main as unknown as { zoom: number }).zoom = 2;
+      flashScreen(m.scene, 0xff0000);
+
+      const rect = m.rectangles[0];
+      expect(rect.w).toBe(m.cameraWidth / 2);
+      expect(rect.h).toBe(m.cameraHeight / 2);
+    });
+
+    it("respects custom peakAlpha and duration", () => {
+      const m = makeMockScene();
+      flashScreen(m.scene, 0xffffff, 0.7, 1200);
+      const cfg = m.tweenCalls[0].config as {
+        alpha: number;
+        duration: number;
+      };
+      expect(cfg.alpha).toBe(0.7);
+      expect(cfg.duration).toBe(300);
+    });
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/foundation/DepthLayers.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/foundation/DepthLayers.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEPTH_STARFIELD,
+  DEPTH_AMBIENT_MID,
+  DEPTH_CONTENT,
+  DEPTH_UI,
+  DEPTH_MODAL,
+  DEPTH_HUD,
+} from "../../DepthLayers.ts";
+
+describe("DepthLayers", () => {
+  it("exports numeric constants", () => {
+    for (const value of [
+      DEPTH_STARFIELD,
+      DEPTH_AMBIENT_MID,
+      DEPTH_CONTENT,
+      DEPTH_UI,
+      DEPTH_MODAL,
+      DEPTH_HUD,
+    ]) {
+      expect(typeof value).toBe("number");
+      expect(Number.isFinite(value)).toBe(true);
+    }
+  });
+
+  it("orders layers from background to foreground", () => {
+    expect(DEPTH_STARFIELD).toBeLessThan(DEPTH_AMBIENT_MID);
+    expect(DEPTH_AMBIENT_MID).toBeLessThan(DEPTH_CONTENT);
+    expect(DEPTH_CONTENT).toBeLessThan(DEPTH_UI);
+    expect(DEPTH_UI).toBeLessThan(DEPTH_MODAL);
+    expect(DEPTH_MODAL).toBeLessThan(DEPTH_HUD);
+  });
+
+  it("contains no duplicate depth values", () => {
+    const values = [
+      DEPTH_STARFIELD,
+      DEPTH_AMBIENT_MID,
+      DEPTH_CONTENT,
+      DEPTH_UI,
+      DEPTH_MODAL,
+      DEPTH_HUD,
+    ];
+    const unique = new Set(values);
+    expect(unique.size).toBe(values.length);
+  });
+
+  it("places content layer at the natural zero baseline", () => {
+    expect(DEPTH_CONTENT).toBe(0);
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/foundation/MaskUtils.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/foundation/MaskUtils.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import type * as Phaser from "phaser";
+
+// Phaser's runtime touches `window` on import. Stub it; these tests only need
+// the type imports — the implementation doesn't reference the namespace.
+vi.mock("phaser", () => ({}));
+
+import { applyClippingMask } from "../../MaskUtils.ts";
+
+/** Build a fake target with the Phaser 4 `filters.internal.addMask` API. */
+function makeFilterTarget(): {
+  target: Phaser.GameObjects.GameObject;
+  addMask: ReturnType<typeof vi.fn>;
+  setMask: ReturnType<typeof vi.fn>;
+} {
+  const addMask = vi.fn();
+  const setMask = vi.fn();
+  const target = {
+    filters: { internal: { addMask } },
+    setMask,
+  } as unknown as Phaser.GameObjects.GameObject;
+  return { target, addMask, setMask };
+}
+
+/** Build a fake target with only the deprecated Phaser 3 `setMask` API. */
+function makeLegacyTarget(): {
+  target: Phaser.GameObjects.GameObject;
+  setMask: ReturnType<typeof vi.fn>;
+} {
+  const setMask = vi.fn();
+  const target = { setMask } as unknown as Phaser.GameObjects.GameObject;
+  return { target, setMask };
+}
+
+function makeMaskShape(): Phaser.GameObjects.Graphics {
+  return {
+    createGeometryMask: vi.fn(() => ({ kind: "geometry-mask" })),
+  } as unknown as Phaser.GameObjects.Graphics;
+}
+
+describe("MaskUtils.applyClippingMask", () => {
+  it("invokes the Phaser 4 filter API when available", () => {
+    const { target, addMask, setMask } = makeFilterTarget();
+    const mask = makeMaskShape();
+
+    applyClippingMask(target, mask);
+
+    expect(addMask).toHaveBeenCalledTimes(1);
+    expect(setMask).not.toHaveBeenCalled();
+  });
+
+  it("passes the mask shape, invert=false, and viewTransform='world'", () => {
+    const { target, addMask } = makeFilterTarget();
+    const mask = makeMaskShape();
+
+    applyClippingMask(target, mask);
+
+    expect(addMask).toHaveBeenCalledWith(mask, false, undefined, "world");
+  });
+
+  it("does not call createGeometryMask on the v4 path", () => {
+    const { target } = makeFilterTarget();
+    const mask = makeMaskShape();
+    const createGeo = mask.createGeometryMask as unknown as ReturnType<
+      typeof vi.fn
+    >;
+
+    applyClippingMask(target, mask);
+
+    expect(createGeo).not.toHaveBeenCalled();
+  });
+
+  it("falls back to legacy setMask when filters API is missing", () => {
+    const { target, setMask } = makeLegacyTarget();
+    const mask = makeMaskShape();
+    const createGeo = mask.createGeometryMask as unknown as ReturnType<
+      typeof vi.fn
+    >;
+
+    applyClippingMask(target, mask);
+
+    expect(createGeo).toHaveBeenCalledTimes(1);
+    expect(setMask).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op when neither API is present", () => {
+    const target = {} as unknown as Phaser.GameObjects.GameObject;
+    const mask = makeMaskShape();
+
+    expect(() => applyClippingMask(target, mask)).not.toThrow();
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/foundation/TextMetrics.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/foundation/TextMetrics.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from "vitest";
+import type * as Phaser from "phaser";
+
+// Phaser's runtime touches `window` on import. Stub it out — these tests only
+// need the Phaser TYPES; the source files do `import * as Phaser from "phaser"`
+// for nothing more than scene typing in the public API.
+vi.mock("phaser", () => ({}));
+
+import {
+  measureText,
+  fitTextWithEllipsis,
+  fitFontSize,
+  autoButtonWidth,
+} from "../../TextMetrics.ts";
+
+/**
+ * `scene.add.text()` returns a Text-shaped probe whose `.width` is computed
+ * from a heuristic (chars × fontSize × 0.6) so tests can reason about layout
+ * without a real renderer. `.destroy()` increments `destroyCount`.
+ */
+function makeMockScene(): {
+  scene: Phaser.Scene;
+  destroyCount: { value: number };
+} {
+  const destroyCount = { value: 0 };
+
+  const scene = {
+    add: {
+      text: (
+        _x: number,
+        _y: number,
+        text: string,
+        style: { fontFamily: string; fontSize: string },
+      ) => {
+        const sizePx = Number.parseInt(style.fontSize, 10);
+        return {
+          width: text.length * sizePx * 0.6,
+          height: sizePx * 1.2,
+          destroy: () => {
+            destroyCount.value += 1;
+          },
+        };
+      },
+    },
+  } as unknown as Phaser.Scene;
+
+  return { scene, destroyCount };
+}
+
+describe("TextMetrics", () => {
+  describe("measureText", () => {
+    it("returns the heuristic width and height", () => {
+      const { scene } = makeMockScene();
+      const size = measureText(scene, "ABCD", "monospace", 16);
+      // 4 chars × 16 × 0.6 = 38.4
+      expect(size.width).toBeCloseTo(4 * 16 * 0.6);
+      expect(size.height).toBeCloseTo(16 * 1.2);
+    });
+
+    it("destroys the probe Text after measuring", () => {
+      const { scene, destroyCount } = makeMockScene();
+      measureText(scene, "hi", "monospace", 16);
+      expect(destroyCount.value).toBe(1);
+    });
+  });
+
+  describe("fitTextWithEllipsis", () => {
+    it("returns the original string when it already fits", () => {
+      const { scene } = makeMockScene();
+      // "ABC" at fontSize=10 = 18px; maxWidth=200 fits easily.
+      const result = fitTextWithEllipsis(scene, "ABC", 200, "monospace", 10);
+      expect(result).toBe("ABC");
+    });
+
+    it("truncates with ellipsis when text overflows", () => {
+      const { scene } = makeMockScene();
+      // Long string at fontSize=10 forced into a tiny maxWidth.
+      const result = fitTextWithEllipsis(
+        scene,
+        "ABCDEFGHIJKLMNOP",
+        30,
+        "monospace",
+        10,
+      );
+      expect(result.endsWith("…")).toBe(true);
+      expect(result.length).toBeLessThan("ABCDEFGHIJKLMNOP".length + 1);
+    });
+
+    it("collapses to just the ellipsis when nothing fits", () => {
+      const { scene } = makeMockScene();
+      const result = fitTextWithEllipsis(scene, "XXXX", 1, "monospace", 100);
+      expect(result).toBe("…");
+    });
+  });
+
+  describe("autoButtonWidth", () => {
+    it("returns minWidth when label is short", () => {
+      const { scene } = makeMockScene();
+      // "OK" at 16px = ~19.2 px, +40 padding = ~59. minWidth=200 wins.
+      expect(autoButtonWidth(scene, "OK", "monospace", 16, 200)).toBe(200);
+    });
+
+    it("expands beyond minWidth for long labels", () => {
+      const { scene } = makeMockScene();
+      const longLabel = "A very long button label";
+      const result = autoButtonWidth(scene, longLabel, "monospace", 16, 80);
+      // 24 chars × 16 × 0.6 = 230.4 + 40 padding = 270.4 > 80.
+      expect(result).toBeGreaterThan(80);
+      expect(result).toBeCloseTo(longLabel.length * 16 * 0.6 + 40);
+    });
+
+    it("respects custom paddingX", () => {
+      const { scene } = makeMockScene();
+      const r1 = autoButtonWidth(scene, "AAAA", "monospace", 10, 0, 0);
+      const r2 = autoButtonWidth(scene, "AAAA", "monospace", 10, 0, 50);
+      expect(r2 - r1).toBe(100);
+    });
+  });
+
+  describe("fitFontSize", () => {
+    it("picks the largest candidate that fits", () => {
+      const { scene } = makeMockScene();
+      // "ABC" widths: 18@10, 27@15, 36@20, 54@30
+      // maxWidth=30 should select 15.
+      const size = fitFontSize(scene, "ABC", "monospace", 30, [30, 20, 15, 10]);
+      expect(size).toBe(15);
+    });
+
+    it("falls back to the smallest candidate when none fit", () => {
+      const { scene } = makeMockScene();
+      const size = fitFontSize(
+        scene,
+        "VERY LONG LABEL",
+        "monospace",
+        5,
+        [40, 30, 20],
+      );
+      expect(size).toBe(20);
+    });
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/foundation/Theme.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/foundation/Theme.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  DEFAULT_THEME,
+  getTheme,
+  setTheme,
+  colorToString,
+  colorWithAlpha,
+  lerpColor,
+} from "../../Theme.ts";
+import type { ThemeConfig } from "../../Theme.ts";
+
+describe("Theme", () => {
+  beforeEach(() => {
+    // Always reset to default to avoid test pollution.
+    setTheme(DEFAULT_THEME);
+  });
+
+  describe("DEFAULT_THEME", () => {
+    it("exposes the expected top-level shape", () => {
+      expect(DEFAULT_THEME).toHaveProperty("colors");
+      expect(DEFAULT_THEME).toHaveProperty("fonts");
+      expect(DEFAULT_THEME).toHaveProperty("spacing");
+      expect(DEFAULT_THEME).toHaveProperty("panel");
+      expect(DEFAULT_THEME).toHaveProperty("button");
+      expect(DEFAULT_THEME).toHaveProperty("glow");
+      expect(DEFAULT_THEME).toHaveProperty("glass");
+      expect(DEFAULT_THEME).toHaveProperty("chamfer");
+      expect(DEFAULT_THEME).toHaveProperty("ambient");
+    });
+
+    it("uses numeric hex color codes", () => {
+      for (const value of Object.values(DEFAULT_THEME.colors)) {
+        expect(typeof value).toBe("number");
+        expect(value).toBeGreaterThanOrEqual(0);
+        expect(value).toBeLessThanOrEqual(0xffffff);
+      }
+    });
+
+    it("defines spacing scale in ascending order", () => {
+      const { xs, sm, md, lg, xl } = DEFAULT_THEME.spacing;
+      expect(xs).toBeLessThan(sm);
+      expect(sm).toBeLessThan(md);
+      expect(md).toBeLessThan(lg);
+      expect(lg).toBeLessThan(xl);
+    });
+
+    it("defines all four font roles with size and family", () => {
+      for (const role of ["heading", "body", "caption", "value"] as const) {
+        expect(DEFAULT_THEME.fonts[role].size).toBeGreaterThan(0);
+        expect(typeof DEFAULT_THEME.fonts[role].family).toBe("string");
+      }
+    });
+  });
+
+  describe("getTheme / setTheme", () => {
+    it("returns the default theme initially", () => {
+      expect(getTheme()).toBe(DEFAULT_THEME);
+    });
+
+    it("replaces the active theme via setTheme", () => {
+      const custom: ThemeConfig = {
+        ...DEFAULT_THEME,
+        colors: { ...DEFAULT_THEME.colors, accent: 0xff00ff },
+      };
+      setTheme(custom);
+      expect(getTheme()).toBe(custom);
+      expect(getTheme().colors.accent).toBe(0xff00ff);
+    });
+
+    it("can be reset back to DEFAULT_THEME", () => {
+      const custom: ThemeConfig = {
+        ...DEFAULT_THEME,
+        colors: { ...DEFAULT_THEME.colors, accent: 0x123456 },
+      };
+      setTheme(custom);
+      expect(getTheme().colors.accent).toBe(0x123456);
+      setTheme(DEFAULT_THEME);
+      expect(getTheme()).toBe(DEFAULT_THEME);
+    });
+  });
+
+  describe("colorToString", () => {
+    it("formats a hex number with leading hash and zero padding", () => {
+      expect(colorToString(0xff00ff)).toBe("#ff00ff");
+      expect(colorToString(0x000001)).toBe("#000001");
+      expect(colorToString(0)).toBe("#000000");
+    });
+
+    it("matches Phaser-style 6-digit hex strings", () => {
+      expect(colorToString(0xabcdef)).toMatch(/^#[0-9a-f]{6}$/);
+    });
+  });
+
+  describe("colorWithAlpha", () => {
+    it("returns the supplied color and alpha as a struct", () => {
+      const result = colorWithAlpha(0x112233, 0.5);
+      expect(result).toEqual({ color: 0x112233, alpha: 0.5 });
+    });
+  });
+
+  describe("lerpColor", () => {
+    it("returns c1 at t=0", () => {
+      expect(lerpColor(0xff0000, 0x00ff00, 0)).toBe(0xff0000);
+    });
+
+    it("returns c2 at t=1", () => {
+      expect(lerpColor(0xff0000, 0x00ff00, 1)).toBe(0x00ff00);
+    });
+
+    it("returns the midpoint at t=0.5", () => {
+      // Halfway between 0xff0000 (255,0,0) and 0x00ff00 (0,255,0)
+      // = (128, 128, 0) = 0x808000
+      expect(lerpColor(0xff0000, 0x00ff00, 0.5)).toBe(0x808000);
+    });
+
+    it("interpolates per-channel across all RGB", () => {
+      // 0x000000 to 0xffffff midpoint = 0x808080
+      expect(lerpColor(0x000000, 0xffffff, 0.5)).toBe(0x808080);
+    });
+
+    it("rounds intermediate values predictably", () => {
+      const result = lerpColor(0x000000, 0x010101, 0.5);
+      // Each channel: round(0 + 1*0.5) = round(0.5) = 1 (Math.round half-up)
+      expect(result).toBe(0x010101);
+    });
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/foundation/UiSound.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/foundation/UiSound.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { registerUiSoundHandler, playUiSfx } from "../../UiSound.ts";
+
+describe("UiSound", () => {
+  beforeEach(() => {
+    // Reset the module-level handler between tests by registering a fresh stub.
+    registerUiSoundHandler({ sfx: () => {} });
+  });
+
+  it("is a no-op before any handler is registered", async () => {
+    // Re-import the module in isolation so the module-level handler is null.
+    vi.resetModules();
+    const fresh = await import("../../UiSound.ts");
+    expect(() => fresh.playUiSfx("ui.click")).not.toThrow();
+  });
+
+  it("invokes the registered handler with the supplied key", () => {
+    const sfx = vi.fn();
+    registerUiSoundHandler({ sfx });
+
+    playUiSfx("ui.click");
+
+    expect(sfx).toHaveBeenCalledTimes(1);
+    expect(sfx).toHaveBeenCalledWith("ui.click");
+  });
+
+  it("supports replacing the handler at runtime", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    registerUiSoundHandler({ sfx: first });
+    registerUiSoundHandler({ sfx: second });
+
+    playUiSfx("ui.hover");
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith("ui.hover");
+  });
+
+  it("forwards every call without dedup or buffering", () => {
+    const sfx = vi.fn();
+    registerUiSoundHandler({ sfx });
+
+    playUiSfx("a");
+    playUiSfx("b");
+    playUiSfx("a");
+
+    expect(sfx).toHaveBeenCalledTimes(3);
+    expect(sfx.mock.calls.map((c) => c[0])).toEqual(["a", "b", "a"]);
+  });
+
+  it("does not throw when the handler itself errors are not swallowed", () => {
+    // Sanity: handler errors propagate so callers see real bugs.
+    registerUiSoundHandler({
+      sfx: () => {
+        throw new Error("boom");
+      },
+    });
+    expect(() => playUiSfx("x")).toThrow("boom");
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/foundation/WidgetHooks.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/foundation/WidgetHooks.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as Phaser from "phaser";
+import {
+  setWidgetHook,
+  registerWidget,
+  slugifyLabel,
+} from "../../WidgetHooks.ts";
+import type { WidgetRegistration } from "../../WidgetHooks.ts";
+
+function makeRegistration(
+  overrides: Partial<WidgetRegistration> = {},
+): WidgetRegistration {
+  return {
+    testId: "btn-default",
+    kind: "button",
+    label: "Default",
+    scene: {} as unknown as Phaser.Scene,
+    invoke: () => {},
+    isEnabled: () => true,
+    isVisible: () => true,
+    ...overrides,
+  };
+}
+
+describe("WidgetHooks", () => {
+  beforeEach(() => {
+    setWidgetHook(null);
+  });
+
+  describe("slugifyLabel", () => {
+    it("prefixes button kinds with 'btn-'", () => {
+      expect(slugifyLabel("Save Game")).toBe("btn-save-game");
+      expect(slugifyLabel("Save Game", "button")).toBe("btn-save-game");
+    });
+
+    it("uses the kind itself as the prefix for non-button kinds", () => {
+      expect(slugifyLabel("Confirm", "modal-ok")).toBe("modal-ok-confirm");
+      expect(slugifyLabel("Cancel", "modal-cancel")).toBe(
+        "modal-cancel-cancel",
+      );
+      expect(slugifyLabel("Close", "modal-close")).toBe("modal-close-close");
+      expect(slugifyLabel("Routes", "tab")).toBe("tab-routes");
+    });
+
+    it("lowercases and replaces non-alphanumerics with single dashes", () => {
+      expect(slugifyLabel("HELLO World!!")).toBe("btn-hello-world");
+      expect(slugifyLabel("Buy / Sell")).toBe("btn-buy-sell");
+      expect(slugifyLabel("100% Profit")).toBe("btn-100-profit");
+    });
+
+    it("strips leading and trailing dashes", () => {
+      expect(slugifyLabel("--Hello--")).toBe("btn-hello");
+      expect(slugifyLabel("***boom***")).toBe("btn-boom");
+    });
+
+    it("returns just the prefix when the label has no usable characters", () => {
+      expect(slugifyLabel("***")).toBe("btn");
+      expect(slugifyLabel("", "tab")).toBe("tab");
+    });
+
+    it("collapses runs of separators into single dashes", () => {
+      expect(slugifyLabel("foo   bar___baz")).toBe("btn-foo-bar-baz");
+    });
+  });
+
+  describe("registerWidget", () => {
+    it("returns null when no hook is registered", () => {
+      const result = registerWidget(makeRegistration());
+      expect(result).toBeNull();
+    });
+
+    it("invokes the registered hook with the registration", () => {
+      const hook = vi.fn(() => () => {});
+      setWidgetHook(hook);
+      const reg = makeRegistration({ testId: "btn-confirm", label: "Confirm" });
+
+      registerWidget(reg);
+
+      expect(hook).toHaveBeenCalledTimes(1);
+      expect(hook).toHaveBeenCalledWith(reg);
+    });
+
+    it("returns the unregister function produced by the hook", () => {
+      const unregister = vi.fn();
+      setWidgetHook(() => unregister);
+
+      const result = registerWidget(makeRegistration());
+
+      expect(result).toBe(unregister);
+      result?.();
+      expect(unregister).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns null again after the hook is cleared", () => {
+      setWidgetHook(() => () => {});
+      expect(registerWidget(makeRegistration())).not.toBeNull();
+      setWidgetHook(null);
+      expect(registerWidget(makeRegistration())).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Unit 7 of 21 from the 3-tier UI library plan. Adds 62 unit tests across 7 foundation modules in `@spacebiz/ui`:

- **Theme**: `getTheme`/`setTheme` replacement and reset, `colorToString` formatting, `lerpColor` midpoint and per-channel interpolation, `DEFAULT_THEME` shape and spacing-scale ordering.
- **DepthLayers**: layer ordering (starfield < ambient < content < ui < modal < hud), uniqueness, numeric type checks.
- **TextMetrics**: `measureText`, `fitTextWithEllipsis`, `fitFontSize`, `autoButtonWidth` against an inline mock scene that uses a `chars * fontSize * 0.6` width heuristic.
- **MaskUtils**: verifies `applyClippingMask` invokes the Phaser 4 `filters.internal.addMask(maskShape, false, undefined, "world")` path and falls back to legacy `setMask` only when filters are absent.
- **UiSound**: handler invocation, replacement, no-op before registration (via `vi.resetModules`), error propagation.
- **WidgetHooks**: `slugifyLabel` prefixing per kind plus edge cases (separators, empty input), `registerWidget` null-when-no-hook, unregister-fn passthrough.
- **AmbientFX**: `addPulseTween`/`addTwinkleTween`/`addFloatTween`/`addRotateTween` tween config assertions, `flashScreen` overlay sizing under camera zoom, `registerAmbientCleanup` shutdown listener and `isPlaying` guard.

Each file uses `vi.mock("phaser", () => ({}))` because Phaser's runtime touches `window` on import; the foundation API only needs Phaser type imports.

## Test plan

- [x] `npm run check` passes (typecheck + lint + format:check + test + build)
- [x] All 62 new tests green; 958 total tests passing
- [x] Pre-existing lint warnings unchanged (no new warnings introduced)

E2E skipped per the plan (test additions only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)