### PR TITLE
docs(ui): add per-component documentation for @spacebiz/ui

### DIFF
--- a/packages/spacebiz-ui/docs/README.md
+++ b/packages/spacebiz-ui/docs/README.md
@@ -1,0 +1,75 @@
+# @spacebiz/ui
+
+Reusable Phaser 4 UI component library — theme-driven primitives, composites, and feedback widgets with no game-specific knowledge.
+
+## Getting started
+
+- [Getting started](./getting-started.md) — install, scaffold, first Button.
+- [Theming](./theming.md) — `getTheme` / `setTheme`, `ThemeConfig` reference.
+
+## Components by category
+
+### Foundation
+
+- [Theme](./components/Theme.md) — design tokens, color/font/spacing constants.
+- [Layout](./components/Layout.md) — responsive layout metrics for HUD scenes.
+- [DepthLayers](./components/DepthLayers.md) — render-order constants.
+- [TextMetrics](./components/TextMetrics.md) — text measurement and ellipsis helpers.
+- [MaskUtils](./components/MaskUtils.md) — Phaser 4 filter-mask helper.
+- [UiSound](./components/UiSound.md) — pluggable SFX handler hook.
+- [AmbientFX](./components/AmbientFX.md) — pulse, twinkle, float, rotate, screen flash.
+
+### Primitives
+
+- [Button](./components/Button.md) — primary clickable button with hover/disabled states.
+- [Panel](./components/Panel.md) — glass-styled framed container with optional title bar.
+- [Label](./components/Label.md) — themed text with optional glow.
+- [IconButton](./components/IconButton.md) — compact icon-only nav/toolbar button.
+- [Dropdown](./components/Dropdown.md) — single-select option picker.
+- [ProgressBar](./components/ProgressBar.md) — animated progress bar with optional label.
+
+### Composites
+
+- [DataTable](./components/DataTable.md) — sortable, scrollable tabular data view.
+- [ScrollFrame](./components/ScrollFrame.md) — single-purpose scrollable viewport.
+- [ScrollableList](./components/ScrollableList.md) — vertical list with selection and keyboard nav.
+- [TabGroup](./components/TabGroup.md) — tab bar with swap-on-click content panes.
+- [StatRow](./components/StatRow.md) — label / dotted leader / value row.
+- [InfoCard](./components/InfoCard.md) — title + stat rows + description card.
+
+### Feedback
+
+- [Modal](./components/Modal.md) — centered dialog with overlay and OK/Cancel buttons.
+- [Tooltip](./components/Tooltip.md) — delayed hover tooltip attachable to any GameObject.
+- [FloatingText](./components/FloatingText.md) — short-lived popup numbers and messages.
+- [StatusBadge](./components/StatusBadge.md) — pill-shaped variant-styled status indicator.
+
+### Layout (planned)
+
+- HSizer, VSizer, GridSizer, FixWidthSizer, Anchor, ResizeHost (planned).
+
+### Input (planned)
+
+- Slider, Checkbox, Toggle, RadioGroup, Stepper, TextInput, ColorSwatch (planned).
+
+### Notifications (planned)
+
+- Toast, ConfirmDialog (planned).
+
+### Misc (planned)
+
+- Spinner, Accordion, ContextMenu, Toolbar (planned).
+
+### Ambient
+
+- [Starfield](./components/Starfield.md) — multi-layer parallax starfield with twinkle and shimmer.
+
+### Utility
+
+- [SceneUiDirector](./components/SceneUiDirector.md) — scoped UI layer manager with overlay support.
+
+### Domain (will move to `@rogue-universe/shared`)
+
+- [MilestoneOverlay](./components/MilestoneOverlay.md) — full-screen milestone announcement.
+- [CargoIcons](./components/CargoIcons.md) — cargo-type icon textures and tints.
+- [ShipIcons](./components/ShipIcons.md) — ship-class icon textures and tints.

--- a/packages/spacebiz-ui/docs/components/AmbientFX.md
+++ b/packages/spacebiz-ui/docs/components/AmbientFX.md
@@ -1,0 +1,93 @@
+# AmbientFX
+
+Reusable ambient animation helpers — pulse, twinkle, float, rotate, plus a screen flash and tween-cleanup helper.
+
+## Import
+
+```ts
+import {
+  addPulseTween,
+  addTwinkleTween,
+  addFloatTween,
+  addRotateTween,
+  registerAmbientCleanup,
+  flashScreen,
+} from "@spacebiz/ui";
+import type { PulseConfig, TwinkleConfig, FloatConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+import {
+  addPulseTween,
+  registerAmbientCleanup,
+  flashScreen,
+} from "@spacebiz/ui";
+
+const tween = addPulseTween(this, glowSprite, {
+  minAlpha: 0.3,
+  maxAlpha: 0.8,
+  duration: 1500,
+});
+registerAmbientCleanup(this, [tween]);
+
+flashScreen(this, 0x00ff88, 0.4, 600);
+```
+
+## Methods
+
+| Method                   | Signature                                                               | Description                                                           |
+| ------------------------ | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `addPulseTween`          | `(scene, target, config: PulseConfig) => Tween`                         | Infinite alpha pulse (yoyo, repeat -1).                               |
+| `addTwinkleTween`        | `(scene, target, config: TwinkleConfig) => Tween`                       | Random-duration alpha twinkle, ideal for stars.                       |
+| `addFloatTween`          | `(scene, target, config: FloatConfig) => Tween`                         | Yoyo positional drift by `dx` / `dy`.                                 |
+| `addRotateTween`         | `(scene, target, durationMs: number, clockwise?: boolean) => Tween`     | Continuous 360° rotation.                                             |
+| `registerAmbientCleanup` | `(scene, tweens: Tween[]) => void`                                      | Stop tweens on scene shutdown. Safe to call multiple times.           |
+| `flashScreen`            | `(scene, color: number, peakAlpha?: number, duration?: number) => void` | Briefly tint the whole screen, then fade out. Defaults `0.35`, `600`. |
+
+### Config
+
+`PulseConfig`:
+
+| Field      | Type     | Default            | Description                 |
+| ---------- | -------- | ------------------ | --------------------------- |
+| `minAlpha` | `number` | —                  | Minimum alpha during pulse. |
+| `maxAlpha` | `number` | —                  | Maximum alpha during pulse. |
+| `duration` | `number` | —                  | Half-cycle duration in ms.  |
+| `ease`     | `string` | `"Sine.easeInOut"` | Tween ease.                 |
+| `delay`    | `number` | `0`                | Start delay in ms.          |
+
+`TwinkleConfig`:
+
+| Field         | Type     | Default                | Description                          |
+| ------------- | -------- | ---------------------- | ------------------------------------ |
+| `minAlpha`    | `number` | —                      | Minimum alpha.                       |
+| `maxAlpha`    | `number` | —                      | Maximum alpha.                       |
+| `minDuration` | `number` | —                      | Min duration of one half-cycle (ms). |
+| `maxDuration` | `number` | —                      | Max duration of one half-cycle (ms). |
+| `delay`       | `number` | `random ≤ maxDuration` | Start delay.                         |
+
+`FloatConfig`:
+
+| Field      | Type     | Default            | Description                           |
+| ---------- | -------- | ------------------ | ------------------------------------- |
+| `dx`       | `number` | —                  | Horizontal drift in px.               |
+| `dy`       | `number` | —                  | Vertical drift in px (negative = up). |
+| `duration` | `number` | —                  | Half-cycle duration in ms.            |
+| `ease`     | `string` | `"Sine.easeInOut"` | Tween ease.                           |
+| `delay`    | `number` | `0`                | Start delay.                          |
+
+## Events
+
+None.
+
+## Theming
+
+Standalone helpers; callers pass durations explicitly. The `theme.ambient.*` constants are convenient defaults to feed in.
+
+## See also
+
+- [Starfield](./Starfield.md)
+- [StatusBadge](./StatusBadge.md)
+- [Theme](./Theme.md)

--- a/packages/spacebiz-ui/docs/components/Button.md
+++ b/packages/spacebiz-ui/docs/components/Button.md
@@ -1,0 +1,63 @@
+# Button
+
+Primary clickable button with hover/pressed/disabled states, optional auto-width sizing, ellipsis truncation, and an idle accent shimmer.
+
+## Import
+
+```ts
+import { Button } from "@spacebiz/ui";
+import type { ButtonConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+new Button(this, {
+  x: 100,
+  y: 100,
+  label: "Launch",
+  autoWidth: true,
+  onClick: () => this.scene.start("GameScene"),
+});
+```
+
+## Config
+
+| Field       | Type         | Default                 | Description                                                          |
+| ----------- | ------------ | ----------------------- | -------------------------------------------------------------------- |
+| `x`         | `number`     | —                       | X position (top-left).                                               |
+| `y`         | `number`     | —                       | Y position (top-left).                                               |
+| `width`     | `number`     | `theme.button.minWidth` | Explicit width. Wins over `autoWidth`.                               |
+| `height`    | `number`     | `theme.button.height`   | Button height.                                                       |
+| `label`     | `string`     | —                       | Button label.                                                        |
+| `onClick`   | `() => void` | —                       | Click handler.                                                       |
+| `disabled`  | `boolean`    | `false`                 | Render as disabled and skip pointer events.                          |
+| `testId`    | `string`     | derived from label      | Stable id for QA automation. Defaults to `btn-<slugified-label>`.    |
+| `autoWidth` | `boolean`    | `false`                 | When `true` and no `width`, sizes to fit the label.                  |
+| `paddingX`  | `number`     | `20`                    | Horizontal padding per side for `autoWidth` and `ellipsis`.          |
+| `ellipsis`  | `boolean`    | `false`                 | When `true`, truncate the label with `…` if it overflows the button. |
+| `fontSize`  | `number`     | `theme.fonts.body.size` | Override the label font size.                                        |
+
+## Methods
+
+| Method        | Signature                     | Description                                            |
+| ------------- | ----------------------------- | ------------------------------------------------------ |
+| `setDisabled` | `(disabled: boolean) => void` | Toggle disabled state.                                 |
+| `setLabel`    | `(text: string) => void`      | Change the label text.                                 |
+| `setActive`   | `(value: boolean) => this`    | Toggle visual selected state for use in button groups. |
+
+`Button` also overrides `setDepth`, `setPosition`, `setVisible`, and `destroy` to keep its scene-level hit zone in sync.
+
+## Events
+
+None emitted on the Container itself; clicks are dispatched via `onClick`.
+
+## Theming
+
+Reads `theme.button.{height,minWidth}`, `theme.fonts.body`, `theme.colors.{text,textDim,accent}`, `theme.ambient.buttonIdleShimmerDuration`. Requires `btn-normal`, `btn-hover`, `btn-pressed`, `btn-disabled` nine-slice textures.
+
+## See also
+
+- [IconButton](./IconButton.md)
+- [Modal](./Modal.md)
+- [TextMetrics](./TextMetrics.md)

--- a/packages/spacebiz-ui/docs/components/CargoIcons.md
+++ b/packages/spacebiz-ui/docs/components/CargoIcons.md
@@ -1,0 +1,68 @@
+# CargoIcons
+
+> Domain helpers — slated to move to `@rogue-universe/shared`. Documented here while they live in `@spacebiz/ui`.
+
+Cargo type icon mappings — texture keys, tint colors, and display labels for the seven commodity types in Star Freight Tycoon. Icons are 24×24 white-on-transparent CanvasTextures generated at boot time.
+
+## Import
+
+```ts
+import {
+  generateCargoIcons,
+  getCargoIconKey,
+  getCargoColor,
+  getCargoLabel,
+  getCargoShortLabel,
+  CARGO_COLORS,
+  CARGO_LABELS,
+  CARGO_SHORT_LABELS,
+  CARGO_ICON_PREFIX,
+  CARGO_TYPE_LIST,
+} from "@spacebiz/ui";
+import type { CargoTypeValue } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+// In BootScene.create():
+generateCargoIcons(this.textures);
+
+// Elsewhere:
+const sprite = this.add.image(x, y, getCargoIconKey("food"));
+sprite.setTint(getCargoColor("food"));
+```
+
+## Constants
+
+| Name                 | Type                             | Description                                   |
+| -------------------- | -------------------------------- | --------------------------------------------- |
+| `CARGO_TYPE_LIST`    | `readonly [...]`                 | Ordered list of seven cargo type values.      |
+| `CARGO_COLORS`       | `Record<CargoTypeValue, number>` | Per-type tint color.                          |
+| `CARGO_LABELS`       | `Record<CargoTypeValue, string>` | Full display label.                           |
+| `CARGO_SHORT_LABELS` | `Record<CargoTypeValue, string>` | Compact 3–4 letter label (PAX, RAW, FOOD, …). |
+| `CARGO_ICON_PREFIX`  | `"cargo-"`                       | Texture key prefix.                           |
+
+`CargoTypeValue` is the union `"passengers" | "rawMaterials" | "food" | "technology" | "luxury" | "hazmat" | "medical"`.
+
+## Methods
+
+| Method               | Signature                                            | Description                                          |
+| -------------------- | ---------------------------------------------------- | ---------------------------------------------------- |
+| `generateCargoIcons` | `(textures: Phaser.Textures.TextureManager) => void` | Generate all 7 CanvasTextures. Call once at boot.    |
+| `getCargoIconKey`    | `(cargoType: string) => string`                      | `cargo-<cargoType>`.                                 |
+| `getCargoColor`      | `(cargoType: string) => number`                      | Tint color (accent cyan for unknown).                |
+| `getCargoLabel`      | `(cargoType: string) => string`                      | Full label (capitalised fallback for unknown).       |
+| `getCargoShortLabel` | `(cargoType: string) => string`                      | Compact label (uppercase first 4 chars for unknown). |
+
+## Events
+
+None.
+
+## Theming
+
+Independent of theme; tint colors are baked per cargo type.
+
+## See also
+
+- [ShipIcons](./ShipIcons.md)

--- a/packages/spacebiz-ui/docs/components/DataTable.md
+++ b/packages/spacebiz-ui/docs/components/DataTable.md
@@ -1,0 +1,98 @@
+# DataTable
+
+Sortable, scrollable tabular data view with column-driven formatting, optional cell/header icons, keyboard navigation, row tooltips, and a `contentSized` mode for nesting inside [ScrollFrame](./ScrollFrame.md).
+
+## Import
+
+```ts
+import { DataTable } from "@spacebiz/ui";
+import type { DataTableConfig, ColumnDef } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+const table = new DataTable(this, {
+  x: 40,
+  y: 80,
+  width: 720,
+  height: 360,
+  columns: [
+    { key: "name", label: "Ship", width: 200, sortable: true },
+    { key: "fuel", label: "Fuel", width: 80, align: "right" },
+    { key: "status", label: "Status", width: 120 },
+  ],
+  onRowSelect: (i, row) => console.log("selected", row),
+});
+table.setRows([
+  { name: "Aurora", fuel: 92, status: "Idle" },
+  { name: "Caliban", fuel: 18, status: "Refueling" },
+]);
+```
+
+## Config
+
+| Field                | Type                          | Default                  | Description                                                                |
+| -------------------- | ----------------------------- | ------------------------ | -------------------------------------------------------------------------- |
+| `x`                  | `number`                      | —                        | X position.                                                                |
+| `y`                  | `number`                      | —                        | Y position.                                                                |
+| `width`              | `number`                      | —                        | Total table width.                                                         |
+| `height`             | `number`                      | —                        | Table height (max in `contentSized` mode).                                 |
+| `columns`            | `ColumnDef[]`                 | —                        | Column definitions; widths scale to fill `width`.                          |
+| `onRowSelect`        | `(rowIndex, rowData) => void` | —                        | Fires on click and keyboard arrow.                                         |
+| `onRowActivate`      | `(rowIndex, rowData) => void` | —                        | Fires on Enter/Space when keyboard nav is enabled.                         |
+| `onCancel`           | `() => void`                  | —                        | Fires on Escape when keyboard nav is enabled.                              |
+| `keyboardNavigation` | `boolean`                     | `false`                  | Enable arrow/Enter/Escape/PageUp/PageDown navigation.                      |
+| `autoFocus`          | `boolean`                     | `false`                  | Auto-focus the table on creation; selects row 0.                           |
+| `emptyStateText`     | `string`                      | `"No entries available"` | Empty-state title.                                                         |
+| `emptyStateHint`     | `string`                      | —                        | Empty-state hint line.                                                     |
+| `rowAlphaFn`         | `(row) => number`             | `() => 0.95`             | Per-row alpha; return < 1 to dim unavailable rows.                         |
+| `rowTooltipFn`       | `(row) => string \| null`     | —                        | Return a tooltip string or null per row.                                   |
+| `contentSized`       | `boolean`                     | `false`                  | Render at natural height (for nesting in [ScrollFrame](./ScrollFrame.md)). |
+
+`ColumnDef`:
+
+| Field            | Type                             | Default      | Description                                    |
+| ---------------- | -------------------------------- | ------------ | ---------------------------------------------- |
+| `key`            | `string`                         | —            | Row property key for the cell value.           |
+| `label`          | `string`                         | —            | Header text.                                   |
+| `width`          | `number`                         | —            | Relative width (rescaled to fill table width). |
+| `align`          | `"left" \| "center" \| "right"`  | `"left"`     | Cell alignment.                                |
+| `sortable`       | `boolean`                        | `false`      | Click header to toggle sort.                   |
+| `format`         | `(value) => string`              | `String(v)`  | Format raw value for display.                  |
+| `colorFn`        | `(value) => number \| null`      | —            | Per-cell text color.                           |
+| `headerIcon`     | `string`                         | —            | Texture key shown left of header label.        |
+| `headerIconTint` | `number`                         | accent       | Tint for header icon.                          |
+| `iconFn`         | `(value, row) => string \| null` | —            | Texture key for an inline cell icon.           |
+| `iconTintFn`     | `(value, row) => number \| null` | text/colorFn | Tint for cell icon.                            |
+
+## Methods
+
+| Method                | Signature                                   | Description                                           |
+| --------------------- | ------------------------------------------- | ----------------------------------------------------- |
+| `setRows`             | `(rows: Record<string, unknown>[]) => void` | Replace all rows; resets scroll, preserves selection. |
+| `setEmptyState`       | `(text?: string, hint?: string) => void`    | Override the empty-state copy at runtime.             |
+| `getSelectedRowIndex` | `() => number`                              | Currently selected index, or `-1`.                    |
+| `getSelectedRow`      | `() => Record<string, unknown> \| null`     | Currently selected row data.                          |
+| `contentHeight`       | getter `number`                             | Natural rendered height (used by ScrollFrame).        |
+
+## Events
+
+In `contentSized` mode, the table emits on itself:
+
+| Event            | Payload                           | Description                                      |
+| ---------------- | --------------------------------- | ------------------------------------------------ |
+| `contentResize`  | `{ height: number }`              | After `setRows` recalculates content height.     |
+| `scrollIntoView` | `{ top: number; height: number }` | Asks parent to scroll a content range into view. |
+
+[ScrollFrame.setContent](./ScrollFrame.md) auto-wires both. Plays `ui_row_select` and `ui_tab_switch` via [UiSound](./UiSound.md).
+
+## Theming
+
+Reads `theme.colors.{headerBg,accent,rowEven,rowOdd,rowHover,text,textDim,panelBorder,panelBg}`, `theme.fonts.{body,caption}`, `theme.spacing.{xs,sm}`.
+
+## See also
+
+- [ScrollFrame](./ScrollFrame.md)
+- [ScrollableList](./ScrollableList.md)
+- [TabGroup](./TabGroup.md)

--- a/packages/spacebiz-ui/docs/components/DepthLayers.md
+++ b/packages/spacebiz-ui/docs/components/DepthLayers.md
@@ -1,0 +1,53 @@
+# DepthLayers
+
+Render-depth constants. Use these instead of magic numbers to keep z-order consistent across scenes.
+
+## Import
+
+```ts
+import {
+  DEPTH_STARFIELD,
+  DEPTH_AMBIENT_MID,
+  DEPTH_CONTENT,
+  DEPTH_UI,
+  DEPTH_MODAL,
+  DEPTH_HUD,
+} from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+import { DEPTH_UI, DEPTH_MODAL } from "@spacebiz/ui";
+
+panel.setDepth(DEPTH_UI);
+modal.setDepth(DEPTH_MODAL);
+```
+
+## Config
+
+| Constant            | Value   | Description                                       |
+| ------------------- | ------- | ------------------------------------------------- |
+| `DEPTH_STARFIELD`   | `-100`  | Parallax starfield, behind everything.            |
+| `DEPTH_AMBIENT_MID` | `-50`   | Nebulae, sector halos, decorative orbital rings.  |
+| `DEPTH_CONTENT`     | `0`     | In-world game objects (systems, planets, routes). |
+| `DEPTH_UI`          | `100`   | Buttons, panels, regular UI.                      |
+| `DEPTH_MODAL`       | `1000`  | Modals and dialogs.                               |
+| `DEPTH_HUD`         | `10000` | HUD bars, always on top within a scene.           |
+
+## Methods
+
+None.
+
+## Events
+
+None.
+
+## Theming
+
+Independent of theme.
+
+## See also
+
+- [SceneUiDirector](./SceneUiDirector.md)
+- [Modal](./Modal.md)

--- a/packages/spacebiz-ui/docs/components/Dropdown.md
+++ b/packages/spacebiz-ui/docs/components/Dropdown.md
@@ -1,0 +1,63 @@
+# Dropdown
+
+Single-select option picker. Opens an overlay menu beneath the trigger and closes on outside click or selection.
+
+## Import
+
+```ts
+import { Dropdown } from "@spacebiz/ui";
+import type { DropdownConfig, DropdownOption } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+new Dropdown(this, {
+  x: 100,
+  y: 100,
+  width: 200,
+  options: [
+    { label: "Easy", value: "easy" },
+    { label: "Normal", value: "normal" },
+    { label: "Hard", value: "hard" },
+  ],
+  defaultIndex: 1,
+  onChange: (value) => console.log(value),
+});
+```
+
+## Config
+
+| Field          | Type                                     | Default                 | Description                       |
+| -------------- | ---------------------------------------- | ----------------------- | --------------------------------- |
+| `x`            | `number`                                 | —                       | X position.                       |
+| `y`            | `number`                                 | —                       | Y position.                       |
+| `width`        | `number`                                 | —                       | Trigger width.                    |
+| `height`       | `number`                                 | `36`                    | Trigger height.                   |
+| `options`      | `DropdownOption[]`                       | —                       | List of `{ label, value }` items. |
+| `defaultIndex` | `number`                                 | `0`                     | Initially selected index.         |
+| `onChange`     | `(value: string, index: number) => void` | —                       | Fired after selection.            |
+| `fontSize`     | `number`                                 | `theme.fonts.body.size` | Label font size override.         |
+
+`DropdownOption` is `{ label: string; value: string }`.
+
+## Methods
+
+| Method             | Signature                 | Description                       |
+| ------------------ | ------------------------- | --------------------------------- |
+| `getSelectedIndex` | `() => number`            | Currently selected index.         |
+| `getSelectedValue` | `() => string`            | Value of the selected option.     |
+| `setSelectedIndex` | `(index: number) => void` | Programmatically select an index. |
+
+## Events
+
+None on the Container — selection is delivered through `onChange`. Plays `ui_click` via [UiSound](./UiSound.md).
+
+## Theming
+
+Reads `theme.colors.{buttonBg,buttonHover,headerBg,rowHover,panelBorder,accent,text,textDim}`, `theme.fonts.body`, `theme.spacing.sm`.
+
+## See also
+
+- [Button](./Button.md)
+- [TabGroup](./TabGroup.md)

--- a/packages/spacebiz-ui/docs/components/FloatingText.md
+++ b/packages/spacebiz-ui/docs/components/FloatingText.md
@@ -1,0 +1,57 @@
+# FloatingText
+
+Short-lived popup numbers and messages — pops in, drifts upward, fades out, then self-destructs. Common pattern for damage/profit numbers.
+
+## Import
+
+```ts
+import { FloatingText } from "@spacebiz/ui";
+import type { FloatingTextConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+new FloatingText(this, x, y, "+§1,500", 0x00ff88);
+new FloatingText(this, x, y, "-§240", 0xff4444, { size: "large", driftX: 8 });
+```
+
+## Constructor
+
+```ts
+new FloatingText(
+  scene: Phaser.Scene,
+  x: number,
+  y: number,
+  text: string,
+  color: number,
+  config?: FloatingTextConfig,
+)
+```
+
+## Config
+
+| Field          | Type                                       | Default    | Description                                     |
+| -------------- | ------------------------------------------ | ---------- | ----------------------------------------------- |
+| `size`         | `"small" \| "medium" \| "large" \| "huge"` | `"medium"` | Font size preset (14 / 20 / 28 / 42 px).        |
+| `bounce`       | `boolean`                                  | `true`     | Pop-in scales to 1.35× before settling to 1.0×. |
+| `riseDistance` | `number`                                   | `60`       | Pixels to drift upward.                         |
+| `duration`     | `number`                                   | `1200`     | Total animation duration in ms.                 |
+| `driftX`       | `number`                                   | `0`        | Signed horizontal drift in pixels.              |
+
+## Methods
+
+None — the instance manages its own lifecycle and destroys itself when the animation completes.
+
+## Events
+
+None.
+
+## Theming
+
+Reads `theme.fonts.value.family`. Color and size are passed in directly.
+
+## See also
+
+- [AmbientFX](./AmbientFX.md) (`flashScreen` pairs well for emphasis)
+- [MilestoneOverlay](./MilestoneOverlay.md)

--- a/packages/spacebiz-ui/docs/components/IconButton.md
+++ b/packages/spacebiz-ui/docs/components/IconButton.md
@@ -1,0 +1,57 @@
+# IconButton
+
+Compact icon-only (or icon + label) button used for nav sidebars, toolbars, and quick-access controls.
+
+## Import
+
+```ts
+import { IconButton } from "@spacebiz/ui";
+import type { IconButtonConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+new IconButton(this, {
+  x: 16,
+  y: 80,
+  icon: "icon-fleet",
+  label: "Fleet",
+  active: true,
+  onClick: () => this.scene.start("FleetScene"),
+});
+```
+
+## Config
+
+| Field       | Type         | Default                | Description                                       |
+| ----------- | ------------ | ---------------------- | ------------------------------------------------- |
+| `x`         | `number`     | —                      | X position.                                       |
+| `y`         | `number`     | —                      | Y position.                                       |
+| `icon`      | `string`     | —                      | Texture key for the icon image.                   |
+| `size`      | `number`     | `40`                   | Square button size in pixels.                     |
+| `label`     | `string`     | —                      | Optional label rendered to the right of the icon. |
+| `onClick`   | `() => void` | —                      | Click handler.                                    |
+| `tint`      | `number`     | `theme.colors.textDim` | Icon tint at rest.                                |
+| `hoverTint` | `number`     | `theme.colors.accent`  | Icon tint on hover.                               |
+| `active`    | `boolean`    | `false`                | Initial selected state.                           |
+| `disabled`  | `boolean`    | `false`                | Render as disabled (35% alpha) and skip pointers. |
+
+## Methods
+
+| Method           | Signature                   | Description                              |
+| ---------------- | --------------------------- | ---------------------------------------- |
+| `setActiveState` | `(active: boolean) => this` | Toggle the selected state and indicator. |
+
+## Events
+
+None.
+
+## Theming
+
+Reads `theme.colors.{panelBg,textDim,accent,rowHover}`, `theme.fonts.caption`. Plays `ui_hover` and `ui_click_primary` via [UiSound](./UiSound.md).
+
+## See also
+
+- [Button](./Button.md)
+- [UiSound](./UiSound.md)

--- a/packages/spacebiz-ui/docs/components/InfoCard.md
+++ b/packages/spacebiz-ui/docs/components/InfoCard.md
@@ -1,0 +1,59 @@
+# InfoCard
+
+Self-contained glass-styled card with a title, key-value [StatRow](./StatRow.md)s, and an optional description block. Useful for tooltips, sidebar summaries, and entity info popups.
+
+## Import
+
+```ts
+import { InfoCard } from "@spacebiz/ui";
+import type { InfoCardConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+const card = new InfoCard(this, {
+  x: 40,
+  y: 80,
+  width: 240,
+  title: "Aurora",
+  stats: [
+    { label: "Class", value: "Cargo Shuttle" },
+    { label: "Fuel", value: "92%", valueColor: 0x00ff88 },
+  ],
+  description: "Reliable short-haul freighter.",
+});
+card.updateStat(1, "78%", 0xffaa00);
+```
+
+## Config
+
+| Field         | Type                                                           | Default | Description                           |
+| ------------- | -------------------------------------------------------------- | ------- | ------------------------------------- |
+| `x`           | `number`                                                       | —       | X position.                           |
+| `y`           | `number`                                                       | —       | Y position.                           |
+| `width`       | `number`                                                       | —       | Card width.                           |
+| `title`       | `string`                                                       | —       | Title text in accent color.           |
+| `stats`       | `Array<{ label: string; value: string; valueColor?: number }>` | —       | Stat rows shown below the title.      |
+| `description` | `string`                                                       | —       | Optional description below the stats. |
+| `compact`     | `boolean`                                                      | `false` | Use caption fonts for a smaller card. |
+
+## Methods
+
+| Method       | Signature                                                | Description                           |
+| ------------ | -------------------------------------------------------- | ------------------------------------- |
+| `updateStat` | `(index: number, value: string, color?: number) => this` | Update a specific stat row.           |
+| `cardHeight` | getter `number`                                          | Total computed height (for stacking). |
+
+## Events
+
+None.
+
+## Theming
+
+Reads `theme.colors.{accent,text,textDim}`, `theme.fonts.{body,caption}`, `theme.spacing.sm`. Requires the `panel-bg` nine-slice texture.
+
+## See also
+
+- [StatRow](./StatRow.md)
+- [Panel](./Panel.md)

--- a/packages/spacebiz-ui/docs/components/Label.md
+++ b/packages/spacebiz-ui/docs/components/Label.md
@@ -1,0 +1,56 @@
+# Label
+
+Themed `Phaser.GameObjects.Text` with style presets (heading / body / caption / value), optional accent glow, and a built-in drop shadow.
+
+## Import
+
+```ts
+import { Label } from "@spacebiz/ui";
+import type { LabelConfig, LabelStyle } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+new Label(this, {
+  x: 24,
+  y: 24,
+  text: "Galactic Trade",
+  style: "heading",
+  glow: true,
+});
+```
+
+## Config
+
+| Field      | Type         | Default             | Description                                                          |
+| ---------- | ------------ | ------------------- | -------------------------------------------------------------------- |
+| `x`        | `number`     | —                   | X position.                                                          |
+| `y`        | `number`     | —                   | Y position.                                                          |
+| `text`     | `string`     | —                   | Label text.                                                          |
+| `style`    | `LabelStyle` | `"body"`            | `"heading"`, `"body"`, `"caption"`, or `"value"` — pulls from theme. |
+| `color`    | `number`     | `theme.colors.text` | Text color override (`0xRRGGBB`).                                    |
+| `maxWidth` | `number`     | —                   | When set, enables word-wrap at this width.                           |
+| `glow`     | `boolean`    | `false`             | Add an accent-colored glow shadow.                                   |
+
+## Methods
+
+| Method          | Signature                    | Description                    |
+| --------------- | ---------------------------- | ------------------------------ |
+| `setLabelColor` | `(color: number) => this`    | Change text color.             |
+| `setGlow`       | `(enabled: boolean) => this` | Toggle the accent glow shadow. |
+
+`Label` extends `Phaser.GameObjects.Text`, so all standard text methods (`setText`, `setOrigin`, etc.) are available.
+
+## Events
+
+None.
+
+## Theming
+
+Reads `theme.fonts[style]`, `theme.colors.text`, `theme.colors.accent`.
+
+## See also
+
+- [Theme](./Theme.md)
+- [StatRow](./StatRow.md)

--- a/packages/spacebiz-ui/docs/components/Layout.md
+++ b/packages/spacebiz-ui/docs/components/Layout.md
@@ -1,0 +1,78 @@
+# Layout
+
+Reactive layout metrics for HUD-driven scenes — single source of truth for content/sidebar positioning that adapts to game size.
+
+## Import
+
+```ts
+import {
+  getLayout,
+  updateLayout,
+  BASE_HEIGHT,
+  MIN_WIDTH,
+  MAX_WIDTH,
+} from "@spacebiz/ui";
+import type { LayoutMetrics } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+import { getLayout, updateLayout } from "@spacebiz/ui";
+
+this.scale.on("resize", (size: Phaser.Structs.Size) => {
+  updateLayout(size.width, size.height);
+  const m = getLayout();
+  this.panel.setPosition(m.mainContentLeft, m.contentTop);
+});
+```
+
+## Config
+
+This is a singleton; there is no constructor. `LayoutMetrics` returned by `getLayout()`:
+
+| Field                | Type      | Description                                        |
+| -------------------- | --------- | -------------------------------------------------- |
+| `gameWidth`          | `number`  | Current game width.                                |
+| `gameHeight`         | `number`  | Current game height.                               |
+| `maxContentWidth`    | `number`  | Max content area width (game width minus margins). |
+| `sidebarWidth`       | `number`  | Sidebar width (0 in compact mode).                 |
+| `contentGap`         | `number`  | Gap between sidebar and main content.              |
+| `hudTopBarHeight`    | `number`  | HUD top bar height.                                |
+| `hudBottomBarHeight` | `number`  | HUD bottom bar height.                             |
+| `hudTickerHeight`    | `number`  | HUD ticker bar height.                             |
+| `hudBottomBarTop`    | `number`  | Y of the bottom HUD bar.                           |
+| `navSidebarWidth`    | `number`  | Left nav sidebar width (0 in portrait).            |
+| `contentTop`         | `number`  | Y at which scene content starts.                   |
+| `contentHeight`      | `number`  | Available content vertical space.                  |
+| `contentLeft`        | `number`  | X of the leftmost content edge.                    |
+| `sidebarLeft`        | `number`  | X of the sidebar.                                  |
+| `mainContentLeft`    | `number`  | X of the main content area (right of sidebar).     |
+| `mainContentWidth`   | `number`  | Width of the main content area.                    |
+| `fullContentLeft`    | `number`  | X for full-bleed content.                          |
+| `fullContentWidth`   | `number`  | Width for full-bleed content.                      |
+| `isPortrait`         | `boolean` | True if `height > width`.                          |
+| `isCompact`          | `boolean` | True if `width < 1100`.                            |
+
+## Methods
+
+| Method         | Signature                                 | Description                                |
+| -------------- | ----------------------------------------- | ------------------------------------------ |
+| `getLayout`    | `() => LayoutMetrics`                     | Read the current metrics.                  |
+| `updateLayout` | `(width: number, height: number) => void` | Recompute metrics for a new viewport size. |
+
+## Constants
+
+`BASE_HEIGHT` (720), `MIN_WIDTH` (960), `MAX_WIDTH` (2400). Static fallbacks `GAME_WIDTH`, `GAME_HEIGHT`, `SIDEBAR_WIDTH`, etc. are exported for legacy code paths but new code should call `getLayout()`.
+
+## Events
+
+None.
+
+## Theming
+
+Independent of the active theme.
+
+## See also
+
+- [DepthLayers](./DepthLayers.md)

--- a/packages/spacebiz-ui/docs/components/MaskUtils.md
+++ b/packages/spacebiz-ui/docs/components/MaskUtils.md
@@ -1,0 +1,57 @@
+# MaskUtils
+
+Phaser 4 clipping-mask helper. Always use this rather than `setMask()` / `createGeometryMask()`, which Phaser 4 logs as deprecated under WebGL.
+
+## Import
+
+```ts
+import { applyClippingMask } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+import { applyClippingMask } from "@spacebiz/ui";
+
+const maskShape = this.make.graphics({});
+maskShape.fillStyle(0xffffff);
+maskShape.fillRect(0, 0, 200, 100);
+maskShape.setPosition(container.x, container.y);
+
+applyClippingMask(container, maskShape);
+```
+
+For nested containers, sync the mask shape's position to the target's world transform each `preupdate`:
+
+```ts
+this.events.on("preupdate", () => {
+  const m = container.getWorldTransformMatrix();
+  maskShape.setPosition(m.tx, m.ty);
+});
+```
+
+## Methods
+
+| Method              | Signature                                                                                 | Description                                                                                                 |
+| ------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `applyClippingMask` | `(target: Phaser.GameObjects.GameObject, maskShape: Phaser.GameObjects.Graphics) => void` | Enable filters on `target` (idempotent) and add `maskShape` as a clipping mask via the Phaser 4 filter API. |
+
+The function calls `target.enableFilters()` first to lazily allocate the filter camera, then `target.filters.internal.addMask(maskShape, false, undefined, "world")`. Falls back to legacy `setMask` only on non-WebGL renderers (e.g. headless tests).
+
+## Config
+
+None.
+
+## Events
+
+None.
+
+## Theming
+
+Independent of theme.
+
+## See also
+
+- [ScrollFrame](./ScrollFrame.md)
+- [DataTable](./DataTable.md)
+- [ScrollableList](./ScrollableList.md)

--- a/packages/spacebiz-ui/docs/components/MilestoneOverlay.md
+++ b/packages/spacebiz-ui/docs/components/MilestoneOverlay.md
@@ -1,0 +1,59 @@
+# MilestoneOverlay
+
+> Domain component — slated to move to `@rogue-universe/shared`. Documented here while it lives in `@spacebiz/ui`.
+
+Full-screen "dopamine burst" announcement with a typed colour palette (profit, streak, record, warning, etc.). Auto-dismisses after a hold duration.
+
+## Import
+
+```ts
+import { MilestoneOverlay } from "@spacebiz/ui";
+import type { MilestoneType } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+MilestoneOverlay.show(this, "profit_streak", "5-Turn Streak!", "Keep it up.");
+```
+
+## Static API
+
+```ts
+MilestoneOverlay.show(
+  scene: Phaser.Scene,
+  type: MilestoneType,
+  headline: string,
+  subtext?: string,
+  onComplete?: () => void,
+  options?: { holdDuration?: number },
+): void
+```
+
+| Argument               | Type            | Default | Description                                                |
+| ---------------------- | --------------- | ------- | ---------------------------------------------------------- |
+| `scene`                | `Phaser.Scene`  | —       | Scene to render into.                                      |
+| `type`                 | `MilestoneType` | —       | Drives the colour palette (see below).                     |
+| `headline`             | `string`        | —       | Large headline text; auto-fits.                            |
+| `subtext`              | `string`        | —       | Optional sub-text beneath the headline.                    |
+| `onComplete`           | `() => void`    | —       | Called after the overlay fades out.                        |
+| `options.holdDuration` | `number`        | `1400`  | Time (ms) the overlay stays at full opacity before fading. |
+
+## `MilestoneType`
+
+`"big_profit" | "profit_streak" | "record_profit" | "loss_warning" | "bankruptcy_warning" | "event_opportunity" | "event_hazard" | "sim_complete"`.
+
+Each type has its own background, text, and glow colors (see source).
+
+## Events
+
+None.
+
+## Theming
+
+Reads `theme.fonts.{heading,body}`, `theme.colors.text`. Colors are baked per-type; the rest of the theme does not influence rendering.
+
+## See also
+
+- [FloatingText](./FloatingText.md)
+- [AmbientFX](./AmbientFX.md) (`flashScreen` pairs well)

--- a/packages/spacebiz-ui/docs/components/Modal.md
+++ b/packages/spacebiz-ui/docs/components/Modal.md
@@ -1,0 +1,59 @@
+# Modal
+
+Centered dialog with full-screen overlay, title bar, body text, optional Cancel button, close (×) icon, and Enter/Escape keyboard shortcuts.
+
+## Import
+
+```ts
+import { Modal } from "@spacebiz/ui";
+import type { ModalConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+const modal = new Modal(this, {
+  title: "End turn?",
+  body: "Unconfirmed routes will be cancelled.",
+  okText: "End turn",
+  cancelText: "Keep planning",
+  onOk: () => store.endTurn(),
+  onCancel: () => undefined,
+});
+modal.show();
+```
+
+## Config
+
+| Field        | Type         | Default    | Description                                                              |
+| ------------ | ------------ | ---------- | ------------------------------------------------------------------------ |
+| `title`      | `string`     | —          | Title bar text.                                                          |
+| `body`       | `string`     | —          | Body text (word-wrapped to modal width).                                 |
+| `okText`     | `string`     | `"OK"`     | OK button label.                                                         |
+| `cancelText` | `string`     | `"Cancel"` | Cancel button label.                                                     |
+| `onOk`       | `() => void` | —          | Fires on OK click or Enter.                                              |
+| `onCancel`   | `() => void` | —          | When provided, renders the Cancel button. Fires on Cancel/×/overlay/Esc. |
+| `width`      | `number`     | `400`      | Modal width.                                                             |
+| `height`     | `number`     | `250`      | Modal height.                                                            |
+| `testId`     | `string`     | `"modal"`  | Test-id prefix; registers `${testId}-ok`, `-cancel`, `-close`.           |
+
+## Methods
+
+| Method | Signature    | Description        |
+| ------ | ------------ | ------------------ |
+| `show` | `() => void` | Display the modal. |
+| `hide` | `() => void` | Hide the modal.    |
+
+## Events
+
+None on the Container — handlers are invoked via the config callbacks. Auto-closes on overlay click, × click, Escape, OK, and Cancel.
+
+## Theming
+
+Reads `theme.colors.{modalOverlay,headerBg,accent,text,textDim}`, `theme.fonts.{heading,body}`, `theme.panel.titleHeight`, `theme.button.height`, `theme.spacing.{xs,sm,md}`. Requires `panel-bg`, `btn-normal`, `btn-hover`, `btn-pressed` nine-slice textures.
+
+## See also
+
+- [Panel](./Panel.md)
+- [Button](./Button.md)
+- [DepthLayers](./DepthLayers.md)

--- a/packages/spacebiz-ui/docs/components/Panel.md
+++ b/packages/spacebiz-ui/docs/components/Panel.md
@@ -1,0 +1,57 @@
+# Panel
+
+Glass-styled framed container with optional title bar, drag handle, and ambient idle glow.
+
+## Import
+
+```ts
+import { Panel } from "@spacebiz/ui";
+import type { PanelConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+const panel = new Panel(this, {
+  x: 200,
+  y: 80,
+  width: 400,
+  height: 240,
+  title: "Fleet Status",
+});
+const area = panel.getContentArea();
+```
+
+## Config
+
+| Field       | Type      | Default | Description                                                              |
+| ----------- | --------- | ------- | ------------------------------------------------------------------------ |
+| `x`         | `number`  | —       | X position (top-left).                                                   |
+| `y`         | `number`  | —       | Y position (top-left).                                                   |
+| `width`     | `number`  | —       | Panel width.                                                             |
+| `height`    | `number`  | —       | Panel height.                                                            |
+| `title`     | `string`  | —       | Optional title-bar text (in accent color).                               |
+| `draggable` | `boolean` | `false` | When `true`, drag the title bar (or whole panel if no title) to move it. |
+| `showGlow`  | `boolean` | `true`  | Show the breathing accent glow halo behind the panel.                    |
+
+## Methods
+
+| Method           | Signature                                                       | Description                                              |
+| ---------------- | --------------------------------------------------------------- | -------------------------------------------------------- |
+| `getContentY`    | `() => number`                                                  | Y offset of the content area (below the title bar).      |
+| `getContentArea` | `() => { x: number; y: number; width: number; height: number }` | Inner padded content rect for laying out children.       |
+| `setActive`      | `(active: boolean) => this`                                     | Brighten/dim the glow halo to flag the panel as focused. |
+
+## Events
+
+None.
+
+## Theming
+
+Reads `theme.glow.*`, `theme.glass.*`, `theme.panel.{borderWidth,cornerRadius,titleHeight}`, `theme.spacing`, `theme.fonts.heading`, `theme.colors.{accent,headerBg}`, `theme.ambient.panelIdlePulseDuration`. Requires `panel-bg` and `panel-glow` nine-slice textures.
+
+## See also
+
+- [Modal](./Modal.md)
+- [InfoCard](./InfoCard.md)
+- [SceneUiDirector](./SceneUiDirector.md)

--- a/packages/spacebiz-ui/docs/components/ProgressBar.md
+++ b/packages/spacebiz-ui/docs/components/ProgressBar.md
@@ -1,0 +1,63 @@
+# ProgressBar
+
+Animated horizontal progress bar with outer glow, optional centered label, and a customizable label formatter.
+
+## Import
+
+```ts
+import { ProgressBar } from "@spacebiz/ui";
+import type { ProgressBarConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+const bar = new ProgressBar(this, {
+  x: 40,
+  y: 40,
+  width: 200,
+  height: 18,
+  value: 30,
+  maxValue: 100,
+  labelFormat: (v, m) => `${v}/${m} fuel`,
+});
+bar.setValue(75);
+```
+
+## Config
+
+| Field         | Type                     | Default                    | Description                |
+| ------------- | ------------------------ | -------------------------- | -------------------------- |
+| `x`           | `number`                 | —                          | X position.                |
+| `y`           | `number`                 | —                          | Y position.                |
+| `width`       | `number`                 | —                          | Bar width.                 |
+| `height`      | `number`                 | —                          | Bar height.                |
+| `value`       | `number`                 | `0`                        | Current value.             |
+| `maxValue`    | `number`                 | `100`                      | Max value.                 |
+| `showLabel`   | `boolean`                | `true`                     | Render the centered label. |
+| `fillColor`   | `number`                 | `theme.colors.accent`      | Fill color.                |
+| `bgColor`     | `number`                 | `theme.colors.panelBg`     | Background color.          |
+| `borderColor` | `number`                 | `theme.colors.panelBorder` | Border color.              |
+| `labelFormat` | `(value, max) => string` | `"NN%"`                    | Label formatter.           |
+
+## Methods
+
+| Method         | Signature                                    | Description                                        |
+| -------------- | -------------------------------------------- | -------------------------------------------------- |
+| `setValue`     | `(value: number, animate?: boolean) => void` | Update value (clamped). `animate` defaults `true`. |
+| `getValue`     | `() => number`                               | Current value.                                     |
+| `setMaxValue`  | `(max: number, animate?: boolean) => void`   | Change the max; re-clamps current value.           |
+| `setFillColor` | `(color: number) => void`                    | Change fill color at runtime.                      |
+
+## Events
+
+None.
+
+## Theming
+
+Reads `theme.colors.{accent,panelBg,panelBorder,text}`, `theme.panel.borderWidth`, `theme.fonts.caption`.
+
+## See also
+
+- [StatusBadge](./StatusBadge.md)
+- [StatRow](./StatRow.md)

--- a/packages/spacebiz-ui/docs/components/SceneUiDirector.md
+++ b/packages/spacebiz-ui/docs/components/SceneUiDirector.md
@@ -1,0 +1,84 @@
+# SceneUiDirector
+
+Scoped UI layer manager. Each layer collects GameObjects and overlays so they can be torn down together (e.g. closing a popup).
+
+## Import
+
+```ts
+import { SceneUiDirector, SceneUiLayer } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+const director = new SceneUiDirector(this);
+
+const layer = director.openLayer({ key: "settings" });
+layer.createOverlay({ closeOnPointerUp: true });
+layer.track(
+  new Panel(this, {
+    x: 100,
+    y: 100,
+    width: 300,
+    height: 200,
+    title: "Settings",
+  }),
+);
+
+// Later, tear it all down:
+layer.destroy();
+```
+
+## SceneUiDirector
+
+### Constructor
+
+```ts
+new SceneUiDirector(scene: Phaser.Scene)
+```
+
+Auto-destroys all layers on scene shutdown.
+
+### Methods
+
+| Method       | Signature                                      | Description                                                      |
+| ------------ | ---------------------------------------------- | ---------------------------------------------------------------- |
+| `openLayer`  | `(options?: { key?: string }) => SceneUiLayer` | Create a new layer. Reusing a `key` destroys the previous layer. |
+| `closeAll`   | `() => void`                                   | Destroy all open layers.                                         |
+| `destroy`    | `() => void`                                   | Tear down everything; called automatically on scene shutdown.    |
+| `unregister` | `(layer: SceneUiLayer) => void`                | Internal — removes a layer from tracking.                        |
+
+## SceneUiLayer
+
+### Methods
+
+| Method          | Signature                                                           | Description                                                 |
+| --------------- | ------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `track`         | `<T extends GameObject>(object: T) => T`                            | Adopt an object so it's destroyed with the layer.           |
+| `trackMany`     | `<T extends GameObject>(...objects: T[]) => T[]`                    | Track multiple objects.                                     |
+| `onDestroy`     | `(callback: () => void) => void`                                    | Run a callback when the layer is destroyed.                 |
+| `createOverlay` | `(options?: SceneUiOverlayOptions) => Phaser.GameObjects.Rectangle` | Create a full-camera dim overlay (depth `DEPTH_MODAL - 1`). |
+| `destroy`       | `() => void`                                                        | Tear down the layer.                                        |
+
+`SceneUiOverlayOptions`:
+
+| Field               | Type         | Default    | Description                                         |
+| ------------------- | ------------ | ---------- | --------------------------------------------------- |
+| `alpha`             | `number`     | `0.6`      | Overlay alpha.                                      |
+| `color`             | `number`     | `0x000000` | Overlay fill color.                                 |
+| `closeOnPointerUp`  | `boolean`    | `false`    | Auto-destroy the layer when the overlay is clicked. |
+| `onPointerUp`       | `() => void` | —          | Pointer-up handler.                                 |
+| `activationDelayMs` | `number`     | `0`        | Delay before the overlay accepts pointer events.    |
+
+## Events
+
+None.
+
+## Theming
+
+Independent of theme. Uses `DEPTH_MODAL` from [DepthLayers](./DepthLayers.md).
+
+## See also
+
+- [Modal](./Modal.md)
+- [DepthLayers](./DepthLayers.md)

--- a/packages/spacebiz-ui/docs/components/ScrollFrame.md
+++ b/packages/spacebiz-ui/docs/components/ScrollFrame.md
@@ -1,0 +1,64 @@
+# ScrollFrame
+
+Single-purpose scrollable viewport. Holds one Container child, clips it via Phaser 4's filter mask, and scrolls vertically on mouse wheel.
+
+The intent is to be the **only** scrollable container in a hierarchy. Children should be content-sized (no internal scroll, no internal mask) so nested clipping doesn't fight the parent.
+
+## Import
+
+```ts
+import { ScrollFrame } from "@spacebiz/ui";
+import type { ScrollFrameConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+const frame = new ScrollFrame(this, { x: 40, y: 80, width: 480, height: 240 });
+const table = new DataTable(this, {
+  x: 0,
+  y: 0,
+  width: 480,
+  height: 240,
+  columns,
+  contentSized: true,
+});
+frame.setContent(table);
+table.setRows(rows);
+```
+
+## Config
+
+| Field        | Type     | Default | Description                                    |
+| ------------ | -------- | ------- | ---------------------------------------------- |
+| `x`          | `number` | —       | X position.                                    |
+| `y`          | `number` | —       | Y position.                                    |
+| `width`      | `number` | —       | Viewport width.                                |
+| `height`     | `number` | —       | Viewport height.                               |
+| `padding`    | `number` | `0`     | Inner padding applied to the content viewport. |
+| `wheelSpeed` | `number` | `0.5`   | Wheel sensitivity multiplier.                  |
+
+## Methods
+
+| Method              | Signature                                       | Description                                                                  |
+| ------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------- |
+| `setContent`        | `(child: Phaser.GameObjects.Container) => void` | Adopt a child; auto-wires `contentResize` and `scrollIntoView` events on it. |
+| `recomputeBounds`   | `() => void`                                    | Recompute scroll range from current content height.                          |
+| `scrollTo`          | `(y: number) => void`                           | Set scroll offset (clamped to `[0, maxScroll]`).                             |
+| `scrollIntoView`    | `(top: number, height: number) => void`         | Scroll so a content-coord range is visible.                                  |
+| `getViewportHeight` | `() => number`                                  | Visible height (minus padding).                                              |
+| `getMaxScroll`      | `() => number`                                  | Maximum scroll offset.                                                       |
+
+## Events
+
+Listens to `contentResize` and `scrollIntoView` on the adopted child Container.
+
+## Theming
+
+Independent of theme. Uses [MaskUtils](./MaskUtils.md) for clipping.
+
+## See also
+
+- [DataTable](./DataTable.md) (use `contentSized: true` when nested)
+- [MaskUtils](./MaskUtils.md)
+- [ScrollableList](./ScrollableList.md)

--- a/packages/spacebiz-ui/docs/components/ScrollableList.md
+++ b/packages/spacebiz-ui/docs/components/ScrollableList.md
@@ -1,0 +1,70 @@
+# ScrollableList
+
+Vertical list of arbitrary `Phaser.GameObjects.Container` items. Handles selection, hover, scrolling, alternating rows, and optional keyboard navigation.
+
+Prefer [ScrollFrame](./ScrollFrame.md) + custom content for new code; use `ScrollableList` when you need ready-made row selection semantics.
+
+## Import
+
+```ts
+import { ScrollableList } from "@spacebiz/ui";
+import type { ScrollableListConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+const list = new ScrollableList(this, {
+  x: 40,
+  y: 80,
+  width: 320,
+  height: 240,
+  itemHeight: 48,
+  keyboardNavigation: true,
+  onSelect: (i) => console.log("selected", i),
+});
+
+for (const ship of fleet) {
+  const item = this.add.container(0, 0, [
+    this.add.text(8, 12, ship.name, { fontSize: "16px" }),
+  ]);
+  list.addItem(item);
+}
+```
+
+## Config
+
+| Field                | Type                      | Default | Description                                  |
+| -------------------- | ------------------------- | ------- | -------------------------------------------- |
+| `x`                  | `number`                  | —       | X position.                                  |
+| `y`                  | `number`                  | —       | Y position.                                  |
+| `width`              | `number`                  | —       | List width.                                  |
+| `height`             | `number`                  | —       | List height (viewport).                      |
+| `itemHeight`         | `number`                  | —       | Fixed height of each row.                    |
+| `onSelect`           | `(index: number) => void` | —       | Fired when a row is selected.                |
+| `onConfirm`          | `(index: number) => void` | —       | Fired on Enter/Space (keyboard nav).         |
+| `onCancel`           | `() => void`              | —       | Fired on Escape (keyboard nav).              |
+| `keyboardNavigation` | `boolean`                 | `false` | Enable arrow/Enter/Escape navigation.        |
+| `autoFocus`          | `boolean`                 | `false` | Select index 0 when the first item is added. |
+
+## Methods
+
+| Method             | Signature                                           | Description                        |
+| ------------------ | --------------------------------------------------- | ---------------------------------- |
+| `addItem`          | `(container: Phaser.GameObjects.Container) => void` | Append a row.                      |
+| `prependItem`      | `(container: Phaser.GameObjects.Container) => void` | Insert a row at the top.           |
+| `clearItems`       | `() => void`                                        | Remove all rows.                   |
+| `getSelectedIndex` | `() => number`                                      | Currently selected index, or `-1`. |
+
+## Events
+
+None on the list itself; selection is delivered via `onSelect`/`onConfirm`/`onCancel`.
+
+## Theming
+
+Reads `theme.colors.{rowEven,rowOdd,rowHover,accent,scrollbarTrack,scrollbarThumb}`. Uses [MaskUtils](./MaskUtils.md) for clipping.
+
+## See also
+
+- [ScrollFrame](./ScrollFrame.md)
+- [DataTable](./DataTable.md)

--- a/packages/spacebiz-ui/docs/components/ShipIcons.md
+++ b/packages/spacebiz-ui/docs/components/ShipIcons.md
@@ -1,0 +1,64 @@
+# ShipIcons
+
+> Domain helpers — slated to move to `@rogue-universe/shared`. Documented here while they live in `@spacebiz/ui`.
+
+Ship class icon mappings — texture keys, tint colors, and display labels for the thirteen ship classes in Star Freight Tycoon. Icons are 24×24 white-on-transparent CanvasTextures generated at boot time.
+
+## Import
+
+```ts
+import {
+  generateShipIcons,
+  getShipIconKey,
+  getShipColor,
+  getShipLabel,
+  SHIP_COLORS,
+  SHIP_LABELS,
+  SHIP_ICON_PREFIX,
+  SHIP_CLASS_LIST,
+} from "@spacebiz/ui";
+import type { ShipClassValue } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+// In BootScene.create():
+generateShipIcons(this.textures);
+
+// Elsewhere:
+const sprite = this.add.image(x, y, getShipIconKey("starLiner"));
+sprite.setTint(getShipColor("starLiner"));
+```
+
+## Constants
+
+| Name               | Type                             | Description                            |
+| ------------------ | -------------------------------- | -------------------------------------- |
+| `SHIP_CLASS_LIST`  | `readonly [...]`                 | Ordered list of all ship class values. |
+| `SHIP_COLORS`      | `Record<ShipClassValue, number>` | Per-class tint color.                  |
+| `SHIP_LABELS`      | `Record<ShipClassValue, string>` | Display label per class.               |
+| `SHIP_ICON_PREFIX` | `"ship-"`                        | Texture key prefix.                    |
+
+`ShipClassValue` covers: `cargoShuttle`, `passengerShuttle`, `mixedHauler`, `fastCourier`, `bulkFreighter`, `starLiner`, `megaHauler`, `luxuryLiner`, `tug`, `refrigeratedHauler`, `armoredFreighter`, `diplomaticYacht`, `colonyShip`.
+
+## Methods
+
+| Method              | Signature                                            | Description                                       |
+| ------------------- | ---------------------------------------------------- | ------------------------------------------------- |
+| `generateShipIcons` | `(textures: Phaser.Textures.TextureManager) => void` | Generate all CanvasTextures. Call once at boot.   |
+| `getShipIconKey`    | `(shipClass: string) => string`                      | `ship-<shipClass>`.                               |
+| `getShipColor`      | `(shipClass: string) => number`                      | Tint color (accent cyan for unknown).             |
+| `getShipLabel`      | `(shipClass: string) => string`                      | Display label (capitalised fallback for unknown). |
+
+## Events
+
+None.
+
+## Theming
+
+Independent of theme; tint colors are baked per ship class.
+
+## See also
+
+- [CargoIcons](./CargoIcons.md)

--- a/packages/spacebiz-ui/docs/components/Starfield.md
+++ b/packages/spacebiz-ui/docs/components/Starfield.md
@@ -1,0 +1,74 @@
+# Starfield
+
+Multi-layer parallax starfield with twinkle, color-shimmer, drift, and edge feathering. Ambient tweens are auto-cleaned on scene shutdown.
+
+## Import
+
+```ts
+import { createStarfield } from "@spacebiz/ui";
+import type { StarfieldConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+import { createStarfield, DEPTH_STARFIELD } from "@spacebiz/ui";
+
+createStarfield(this, {
+  worldBounds: { minX: 0, maxX: 2400, minY: 0, maxY: 1200 },
+  depth: DEPTH_STARFIELD,
+});
+```
+
+## Config
+
+| Field         | Type                     | Default              | Description                                                     |
+| ------------- | ------------------------ | -------------------- | --------------------------------------------------------------- |
+| `count`       | `number`                 | `120`                | Legacy single-layer count (overridden by `layers`).             |
+| `drift`       | `boolean`                | `true`               | Slow per-star parallax drift.                                   |
+| `depth`       | `number`                 | `-100`               | Render depth.                                                   |
+| `twinkle`     | `boolean`                | `true`               | Stagger alpha twinkle on ~35% of stars.                         |
+| `shimmer`     | `boolean`                | `true`               | Slow tint colour-cycle on ~15% of white stars.                  |
+| `width`       | `number`                 | `scene.scale.width`  | Field width when no `worldBounds`.                              |
+| `height`      | `number`                 | `scene.scale.height` | Field height when no `worldBounds`.                             |
+| `centerX`     | `number`                 | `width/2`            | X center of the field.                                          |
+| `centerY`     | `number`                 | `height/2`           | Y center of the field.                                          |
+| `worldBounds` | `StarfieldWorldBounds`   | —                    | `{ minX, maxX, minY, maxY }` — overrides width/height/center.   |
+| `minZoom`     | `number`                 | `1`                  | Account for camera zoom-out when computing the visible field.   |
+| `overscan`    | `number`                 | `320`                | Extra padding outside the visible viewport (pixels).            |
+| `edgeFeather` | `number`                 | `0.2`                | Fraction of the field that fades toward edges (`[0.05, 0.45]`). |
+| `haze`        | `boolean`                | `true`               | Render soft additive nebulae behind each layer.                 |
+| `layers`      | `StarfieldLayerConfig[]` | 3 default layers     | Per-layer configuration (see source for default values).        |
+
+`StarfieldLayerConfig`:
+
+| Field          | Type       | Description                                      |
+| -------------- | ---------- | ------------------------------------------------ |
+| `count`        | `number`   | Stars in this layer.                             |
+| `scrollFactor` | `number`   | Parallax scroll factor (lower = farther/slower). |
+| `minAlpha`     | `number`   | Lower-bound alpha.                               |
+| `maxAlpha`     | `number`   | Upper-bound alpha.                               |
+| `minScale`     | `number`   | Min star scale.                                  |
+| `maxScale`     | `number`   | Max star scale.                                  |
+| `tints`        | `number[]` | Tint palette to sample.                          |
+| `hazeAlpha`    | `number`   | Optional haze alpha.                             |
+| `hazeScale`    | `number`   | Optional haze scale.                             |
+
+## Methods
+
+| Method            | Signature                                                 | Description                       |
+| ----------------- | --------------------------------------------------------- | --------------------------------- |
+| `createStarfield` | `(scene: Phaser.Scene, config?: StarfieldConfig) => void` | Spawn the starfield in the scene. |
+
+## Events
+
+None.
+
+## Theming
+
+Reads `theme.ambient.{starTwinkleDurationMin,starTwinkleDurationMax,starShimmerDuration}`. Requires the `glow-dot` texture.
+
+## See also
+
+- [AmbientFX](./AmbientFX.md)
+- [DepthLayers](./DepthLayers.md)

--- a/packages/spacebiz-ui/docs/components/StatRow.md
+++ b/packages/spacebiz-ui/docs/components/StatRow.md
@@ -1,0 +1,56 @@
+# StatRow
+
+Single-line key-value row with left-aligned label, right-aligned value, and a faint dotted leader between them.
+
+## Import
+
+```ts
+import { StatRow } from "@spacebiz/ui";
+import type { StatRowConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+const row = new StatRow(this, {
+  x: 16,
+  y: 16,
+  width: 240,
+  label: "Credits",
+  value: "§12,400",
+});
+row.setValue("§13,800", 0x00ff88);
+```
+
+## Config
+
+| Field        | Type      | Default               | Description                           |
+| ------------ | --------- | --------------------- | ------------------------------------- |
+| `x`          | `number`  | —                     | X position.                           |
+| `y`          | `number`  | —                     | Y position.                           |
+| `width`      | `number`  | —                     | Row width.                            |
+| `label`      | `string`  | —                     | Left label text.                      |
+| `value`      | `string`  | —                     | Right value text.                     |
+| `valueColor` | `number`  | `theme.colors.accent` | Value text color.                     |
+| `compact`    | `boolean` | `false`               | Use caption font for compact display. |
+
+## Methods
+
+| Method      | Signature                                 | Description                          |
+| ----------- | ----------------------------------------- | ------------------------------------ |
+| `setValue`  | `(value: string, color?: number) => this` | Update value (and optionally color). |
+| `setLabel`  | `(label: string) => this`                 | Update label.                        |
+| `rowHeight` | getter `number`                           | Height for layout stacking.          |
+
+## Events
+
+None.
+
+## Theming
+
+Reads `theme.colors.{textDim,accent,panelBorder}`, `theme.fonts.{body,caption}`.
+
+## See also
+
+- [InfoCard](./InfoCard.md)
+- [Label](./Label.md)

--- a/packages/spacebiz-ui/docs/components/StatusBadge.md
+++ b/packages/spacebiz-ui/docs/components/StatusBadge.md
@@ -1,0 +1,64 @@
+# StatusBadge
+
+Small pill-shaped status indicator with variant styling (info, success, warning, danger, neutral) and optional pulse.
+
+## Import
+
+```ts
+import { StatusBadge } from "@spacebiz/ui";
+import type { StatusBadgeConfig, BadgeVariant } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+const badge = new StatusBadge(this, {
+  x: 16,
+  y: 16,
+  text: "Active",
+  variant: "success",
+  pulse: true,
+});
+badge.update("Low Fuel", "warning");
+```
+
+## Config
+
+| Field       | Type           | Default     | Description                                                         |
+| ----------- | -------------- | ----------- | ------------------------------------------------------------------- |
+| `x`         | `number`       | —           | X position.                                                         |
+| `y`         | `number`       | —           | Y position.                                                         |
+| `text`      | `string`       | —           | Badge label.                                                        |
+| `variant`   | `BadgeVariant` | `"neutral"` | One of `"info" \| "success" \| "warning" \| "danger" \| "neutral"`. |
+| `pulse`     | `boolean`      | `false`     | Pulse alpha to draw attention.                                      |
+| `bgColor`   | `number`       | per variant | Background color override.                                          |
+| `textColor` | `number`       | per variant | Text color override.                                                |
+
+## Methods
+
+| Method        | Signature                                        | Description                                        |
+| ------------- | ------------------------------------------------ | -------------------------------------------------- |
+| `update`      | `(text: string, variant?: BadgeVariant) => this` | Update text and optionally variant; resizes badge. |
+| `badgeWidth`  | getter `number`                                  | Pill width in pixels.                              |
+| `badgeHeight` | getter `number`                                  | Pill height in pixels.                             |
+
+## Events
+
+None.
+
+## Theming
+
+Reads `theme.colors.{profit,warning,loss,accent,panelBg,textDim}`, `theme.fonts.caption`, `theme.spacing.{xs,sm}`, `theme.ambient.panelIdlePulseDuration`. Variants map:
+
+| Variant   | Background | Text color             |
+| --------- | ---------- | ---------------------- |
+| `info`    | `0x002233` | `theme.colors.accent`  |
+| `success` | `0x003322` | `theme.colors.profit`  |
+| `warning` | `0x332200` | `theme.colors.warning` |
+| `danger`  | `0x330011` | `theme.colors.loss`    |
+| `neutral` | `panelBg`  | `theme.colors.textDim` |
+
+## See also
+
+- [AmbientFX](./AmbientFX.md) (uses `addPulseTween` internally)
+- [StatRow](./StatRow.md)

--- a/packages/spacebiz-ui/docs/components/TabGroup.md
+++ b/packages/spacebiz-ui/docs/components/TabGroup.md
@@ -1,0 +1,67 @@
+# TabGroup
+
+Horizontal tab bar with click-to-switch content panes.
+
+## Import
+
+```ts
+import { TabGroup } from "@spacebiz/ui";
+import type { TabGroupConfig, TabConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+const overview = this.add.container(0, 0);
+const cargo = this.add.container(0, 0);
+
+new TabGroup(this, {
+  x: 40,
+  y: 80,
+  width: 480,
+  tabs: [
+    { label: "Overview", content: overview },
+    { label: "Cargo", content: cargo },
+  ],
+  defaultTab: 0,
+});
+```
+
+## Config
+
+| Field        | Type          | Default               | Description                                     |
+| ------------ | ------------- | --------------------- | ----------------------------------------------- |
+| `x`          | `number`      | —                     | X position.                                     |
+| `y`          | `number`      | —                     | Y position.                                     |
+| `width`      | `number`      | —                     | Total tab-bar width (split evenly across tabs). |
+| `tabHeight`  | `number`      | `theme.button.height` | Tab bar height.                                 |
+| `tabs`       | `TabConfig[]` | —                     | Tab definitions.                                |
+| `defaultTab` | `number`      | `0`                   | Initially active tab index.                     |
+
+`TabConfig`:
+
+| Field     | Type                           | Description                                 |
+| --------- | ------------------------------ | ------------------------------------------- |
+| `label`   | `string`                       | Tab label.                                  |
+| `content` | `Phaser.GameObjects.Container` | Container shown below the tabs when active. |
+
+## Methods
+
+| Method           | Signature                 | Description                   |
+| ---------------- | ------------------------- | ----------------------------- |
+| `setActiveTab`   | `(index: number) => void` | Programmatically switch tabs. |
+| `getActiveIndex` | `() => number`            | Currently active tab index.   |
+| `getTabWidth`    | `() => number`            | Total tab-bar width.          |
+
+## Events
+
+None on the Container. Plays `ui_tab_switch` via [UiSound](./UiSound.md).
+
+## Theming
+
+Reads `theme.colors.{panelBg,headerBg,buttonHover,accent,textDim,panelBorder}`, `theme.fonts.body`, `theme.button.height`, `theme.spacing.sm`.
+
+## See also
+
+- [Panel](./Panel.md)
+- [DataTable](./DataTable.md)

--- a/packages/spacebiz-ui/docs/components/TextMetrics.md
+++ b/packages/spacebiz-ui/docs/components/TextMetrics.md
@@ -1,0 +1,58 @@
+# TextMetrics
+
+Text measurement helpers — measure rendered pixel size, fit text with ellipsis, auto-size buttons, and pick the largest font that fits.
+
+## Import
+
+```ts
+import {
+  measureText,
+  fitTextWithEllipsis,
+  autoButtonWidth,
+  fitFontSize,
+} from "@spacebiz/ui";
+import type { TextSize } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+import { fitTextWithEllipsis, autoButtonWidth } from "@spacebiz/ui";
+
+const trimmed = fitTextWithEllipsis(
+  this,
+  "A very long planet name",
+  120,
+  "monospace",
+  16,
+);
+const w = autoButtonWidth(this, "Save Changes", "monospace", 16, 80);
+```
+
+## Methods
+
+| Method                | Signature                                                             | Description                                                      |
+| --------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `measureText`         | `(scene, text, fontFamily, fontSize) => TextSize`                     | Measure pixel width/height by creating an offscreen probe.       |
+| `fitTextWithEllipsis` | `(scene, text, maxWidth, fontFamily, fontSize) => string`             | Trim text and append `…` if it overflows `maxWidth`.             |
+| `autoButtonWidth`     | `(scene, label, fontFamily, fontSize, minWidth, paddingX?) => number` | Compute ideal button width for a label, clamped to `minWidth`.   |
+| `fitFontSize`         | `(scene, text, fontFamily, maxWidth, candidates) => number`           | Pick the largest size from `candidates` that fits in `maxWidth`. |
+
+`TextSize` is `{ width: number; height: number }`.
+
+## Config
+
+None.
+
+## Events
+
+None.
+
+## Theming
+
+Independent of theme; callers pass in font family/size explicitly.
+
+## See also
+
+- [Button](./Button.md)
+- [Theme](./Theme.md)

--- a/packages/spacebiz-ui/docs/components/Theme.md
+++ b/packages/spacebiz-ui/docs/components/Theme.md
@@ -1,0 +1,53 @@
+# Theme
+
+Global design-token registry: colors, fonts, spacing, panel/button/glow/glass styling, and ambient animation timings.
+
+## Import
+
+```ts
+import {
+  getTheme,
+  setTheme,
+  DEFAULT_THEME,
+  colorToString,
+  lerpColor,
+} from "@spacebiz/ui";
+import type { ThemeConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+import { setTheme, DEFAULT_THEME } from "@spacebiz/ui";
+
+setTheme({
+  ...DEFAULT_THEME,
+  colors: { ...DEFAULT_THEME.colors, accent: 0xff66cc },
+});
+```
+
+## Config
+
+`ThemeConfig` is the full theme shape. See [Theming](../theming.md) for the per-field reference.
+
+## Methods
+
+| Method          | Signature                                       | Description                                      |
+| --------------- | ----------------------------------------------- | ------------------------------------------------ |
+| `getTheme`      | `() => ThemeConfig`                             | Read the current theme.                          |
+| `setTheme`      | `(theme: ThemeConfig) => void`                  | Replace the global theme.                        |
+| `colorToString` | `(color: number) => string`                     | Convert `0xRRGGBB` to `#rrggbb`.                 |
+| `lerpColor`     | `(c1: number, c2: number, t: number) => number` | Linear-interpolate two hex colors (`t` ∈ [0,1]). |
+
+## Events
+
+None.
+
+## Theming
+
+This is the theming subsystem itself; every other component depends on it.
+
+## See also
+
+- [Theming](../theming.md)
+- [DepthLayers](./DepthLayers.md)

--- a/packages/spacebiz-ui/docs/components/Tooltip.md
+++ b/packages/spacebiz-ui/docs/components/Tooltip.md
@@ -1,0 +1,45 @@
+# Tooltip
+
+Delayed hover tooltip attachable to any interactive `Phaser.GameObjects.GameObject`. Single shared tooltip per scene; track multiple objects via `attachTo`.
+
+## Import
+
+```ts
+import { Tooltip } from "@spacebiz/ui";
+import type { TooltipConfig } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+const tooltip = new Tooltip(this, { showDelay: 400 });
+tooltip.attachTo(myButton, "Launch the next supply mission");
+tooltip.attachTo(myIcon, "Empire reputation: friendly");
+```
+
+## Config
+
+| Field       | Type     | Default | Description                             |
+| ----------- | -------- | ------- | --------------------------------------- |
+| `maxWidth`  | `number` | `250`   | Max tooltip text width before wrapping. |
+| `showDelay` | `number` | `500`   | Hover delay before showing (ms).        |
+
+## Methods
+
+| Method       | Signature                                                           | Description                      |
+| ------------ | ------------------------------------------------------------------- | -------------------------------- |
+| `attachTo`   | `(gameObject: Phaser.GameObjects.GameObject, text: string) => void` | Attach the tooltip to an object. |
+| `detachFrom` | `(gameObject: Phaser.GameObjects.GameObject) => void`               | Stop tracking the object.        |
+
+## Events
+
+None.
+
+## Theming
+
+Reads `theme.colors.{panelBorder,panelBg,text}`, `theme.fonts.caption`, `theme.spacing.{xs,sm}`.
+
+## See also
+
+- [DataTable](./DataTable.md) (has its own row tooltip support via `rowTooltipFn`)
+- [InfoCard](./InfoCard.md)

--- a/packages/spacebiz-ui/docs/components/UiSound.md
+++ b/packages/spacebiz-ui/docs/components/UiSound.md
@@ -1,0 +1,56 @@
+# UiSound
+
+Pluggable SFX hook. The library emits semantic sound keys; the consuming game wires them to its audio engine. No-op if no handler is registered.
+
+## Import
+
+```ts
+import { registerUiSoundHandler } from "@spacebiz/ui";
+import type { UiSoundHandler } from "@spacebiz/ui";
+```
+
+## Quick example
+
+```ts
+import { registerUiSoundHandler } from "@spacebiz/ui";
+
+registerUiSoundHandler({
+  sfx: (key) => audioDirector.sfx(key),
+});
+```
+
+## Methods
+
+| Method                   | Signature                           | Description                                          |
+| ------------------------ | ----------------------------------- | ---------------------------------------------------- |
+| `registerUiSoundHandler` | `(handler: UiSoundHandler) => void` | Register the audio back-end. Call once at game boot. |
+
+`UiSoundHandler` is `{ sfx(key: string): void }`.
+
+## Sound keys emitted
+
+| Key                | Source components                        |
+| ------------------ | ---------------------------------------- |
+| `ui_hover`         | Button, IconButton                       |
+| `ui_click_primary` | Button, IconButton                       |
+| `ui_click`         | Dropdown                                 |
+| `ui_row_select`    | DataTable                                |
+| `ui_tab_switch`    | TabGroup, DataTable (column sort header) |
+
+## Config
+
+None.
+
+## Events
+
+None.
+
+## Theming
+
+Independent of theme.
+
+## See also
+
+- [Button](./Button.md)
+- [IconButton](./IconButton.md)
+- [Dropdown](./Dropdown.md)

--- a/packages/spacebiz-ui/docs/getting-started.md
+++ b/packages/spacebiz-ui/docs/getting-started.md
@@ -1,0 +1,90 @@
+# Getting started
+
+`@spacebiz/ui` is a Phaser 4 UI component library. All components extend `Phaser.GameObjects.Container` (or wrap one) and follow the constructor-config pattern: `new Component(scene, config)`.
+
+## Install
+
+The package is currently published as a workspace package inside this repo. To consume it from another workspace, add it to `package.json`:
+
+```json
+{
+  "dependencies": {
+    "@spacebiz/ui": "workspace:*",
+    "phaser": "^4.0.0"
+  }
+}
+```
+
+## Phaser 4 game scaffold
+
+```ts
+import * as Phaser from "phaser";
+import { Button, getTheme } from "@spacebiz/ui";
+
+class HelloScene extends Phaser.Scene {
+  create(): void {
+    const theme = getTheme();
+    this.cameras.main.setBackgroundColor(theme.colors.background);
+
+    new Button(this, {
+      x: 100,
+      y: 100,
+      label: "Click me",
+      onClick: () => console.log("clicked"),
+    });
+  }
+}
+
+new Phaser.Game({
+  type: Phaser.AUTO,
+  width: 1280,
+  height: 720,
+  scene: HelloScene,
+});
+```
+
+Phaser 4 has named exports only. Always use `import * as Phaser from "phaser"` — there is no default export.
+
+## Required textures
+
+Several primitives expect themed nine-slice textures generated at boot time. Your boot scene must create:
+
+- `panel-bg`, `panel-glow` — used by [Panel](./components/Panel.md) and nine-slice composites.
+- `btn-normal`, `btn-hover`, `btn-pressed`, `btn-disabled` — used by [Button](./components/Button.md).
+- `glow-dot` — used by [Starfield](./components/Starfield.md) and other ambient FX.
+
+These can be generated with `Phaser.Textures.TextureManager.generate` or pre-rendered as PNGs. See the consuming game's `BootScene` for a reference implementation.
+
+## Theme overview
+
+Every visual primitive reads from a single global `ThemeConfig`. Override colors, fonts, and spacing once at boot:
+
+```ts
+import { setTheme, DEFAULT_THEME } from "@spacebiz/ui";
+
+setTheme({
+  ...DEFAULT_THEME,
+  colors: { ...DEFAULT_THEME.colors, accent: 0xff00ff },
+});
+```
+
+See [Theming](./theming.md) for the full `ThemeConfig` shape.
+
+## Sound integration
+
+The library is audio-engine agnostic. Wire it to your game's audio system once at boot:
+
+```ts
+import { registerUiSoundHandler } from "@spacebiz/ui";
+
+registerUiSoundHandler({
+  sfx: (key) => audioDirector.sfx(key),
+});
+```
+
+The library emits keys like `ui_hover`, `ui_click_primary`, `ui_click`, `ui_row_select`, `ui_tab_switch`. If no handler is registered, sound calls are silent no-ops.
+
+## Next steps
+
+- Browse [components](./README.md#components-by-category).
+- Read [Theming](./theming.md) to customise the look.

--- a/packages/spacebiz-ui/docs/theming.md
+++ b/packages/spacebiz-ui/docs/theming.md
@@ -1,0 +1,159 @@
+# Theming
+
+`@spacebiz/ui` is fully theme-driven. A single `ThemeConfig` object holds every color, font, spacing, and animation timing constant. Components read from `getTheme()` at render time, so changing the theme propagates to newly created components.
+
+## API
+
+```ts
+import {
+  getTheme,
+  setTheme,
+  DEFAULT_THEME,
+  colorToString,
+  lerpColor,
+} from "@spacebiz/ui";
+import type { ThemeConfig } from "@spacebiz/ui";
+
+// Read the current theme.
+const theme = getTheme();
+
+// Replace the theme entirely.
+setTheme(myCustomTheme);
+```
+
+| Function        | Signature                                       | Description                                        |
+| --------------- | ----------------------------------------------- | -------------------------------------------------- |
+| `getTheme`      | `() => ThemeConfig`                             | Returns the current theme.                         |
+| `setTheme`      | `(theme: ThemeConfig) => void`                  | Replaces the global theme.                         |
+| `colorToString` | `(color: number) => string`                     | Convert a `0xRRGGBB` number to a `#rrggbb` string. |
+| `lerpColor`     | `(c1: number, c2: number, t: number) => number` | Linear-interpolate two colors.                     |
+| `DEFAULT_THEME` | `ThemeConfig`                                   | The library's built-in dark sci-fi theme.          |
+
+Existing component instances do not auto-rebuild on theme changes; reposition or recreate them if you swap the theme mid-game.
+
+## Defining a custom theme
+
+The simplest pattern is to spread `DEFAULT_THEME` and override the fields you care about:
+
+```ts
+import { setTheme, DEFAULT_THEME } from "@spacebiz/ui";
+
+setTheme({
+  ...DEFAULT_THEME,
+  colors: {
+    ...DEFAULT_THEME.colors,
+    accent: 0xff66cc,
+    accentHover: 0xff99dd,
+  },
+  fonts: {
+    ...DEFAULT_THEME.fonts,
+    heading: { size: 28, family: "'Press Start 2P', monospace" },
+  },
+});
+```
+
+## `ThemeConfig` shape
+
+All colors are `number` (`0xRRGGBB`); all sizes are pixels; all durations are milliseconds.
+
+### `colors`
+
+| Field            | Description                                   |
+| ---------------- | --------------------------------------------- |
+| `background`     | Scene clear color.                            |
+| `panelBg`        | Panel and modal fill.                         |
+| `panelBorder`    | Border / scrollbar track.                     |
+| `text`           | Primary text color.                           |
+| `textDim`        | Secondary / disabled text.                    |
+| `accent`         | Accent (titles, indicators, primary buttons). |
+| `accentHover`    | Accent hover state.                           |
+| `profit`         | Positive / success.                           |
+| `loss`           | Negative / danger.                            |
+| `warning`        | Warning state.                                |
+| `buttonBg`       | Button rest fill.                             |
+| `buttonHover`    | Button hover fill.                            |
+| `buttonPressed`  | Button pressed fill.                          |
+| `buttonDisabled` | Button disabled fill.                         |
+| `scrollbarTrack` | Scrollbar track.                              |
+| `scrollbarThumb` | Scrollbar thumb.                              |
+| `headerBg`       | Table header / title bar background.          |
+| `rowEven`        | Even-row background in tables/lists.          |
+| `rowOdd`         | Odd-row background in tables/lists.           |
+| `rowHover`       | Hovered/selected row background.              |
+| `modalOverlay`   | Modal backdrop color.                         |
+
+### `fonts`
+
+Each entry has `{ size: number; family: string }`. The four entries are `heading`, `body`, `caption`, and `value`.
+
+### `spacing`
+
+Tokens `xs` (4), `sm` (8), `md` (16), `lg` (24), `xl` (32) by default. Use these in custom layouts to stay consistent with library components.
+
+### `panel`
+
+| Field          | Description                                 |
+| -------------- | ------------------------------------------- |
+| `borderWidth`  | Pixel width of inner panel border.          |
+| `cornerRadius` | Logical corner radius of nine-slice frames. |
+| `titleHeight`  | Pixel height of the title bar.              |
+
+### `button`
+
+| Field         | Description                           |
+| ------------- | ------------------------------------- |
+| `height`      | Default button height.                |
+| `minWidth`    | Minimum button width.                 |
+| `borderWidth` | Pixel width of button border accents. |
+
+### `glow`
+
+| Field         | Description                                              |
+| ------------- | -------------------------------------------------------- |
+| `width`       | Pixel inset for glow nine-slice halos.                   |
+| `alpha`       | Idle glow alpha.                                         |
+| `activeAlpha` | Glow alpha while a panel is in the active/focused state. |
+| `pulseMin`    | Min alpha during ambient breathing.                      |
+| `pulseMax`    | Max alpha during ambient breathing.                      |
+
+### `glass`
+
+| Field              | Description                                 |
+| ------------------ | ------------------------------------------- |
+| `bgAlpha`          | Glass panel base alpha.                     |
+| `gradientSteps`    | Number of vertical gradient bands rendered. |
+| `topTint`          | Top tint color of the glass gradient.       |
+| `bottomTint`       | Bottom tint color.                          |
+| `innerBorderAlpha` | Inner highlight border alpha.               |
+
+### `chamfer`
+
+| Field  | Description                                  |
+| ------ | -------------------------------------------- |
+| `size` | Pixel size of corner chamfer cuts on frames. |
+
+### `ambient`
+
+Animation timings shared by ambient FX. All values are milliseconds unless noted.
+
+| Field                       | Description                                |
+| --------------------------- | ------------------------------------------ |
+| `starTwinkleDurationMin`    | Fastest star twinkle half-cycle.           |
+| `starTwinkleDurationMax`    | Slowest star twinkle half-cycle.           |
+| `starShimmerDuration`       | Slow tint-shift half-cycle on white stars. |
+| `routePulseDuration`        | Route line breathing half-cycle.           |
+| `routePulseAlphaMin`        | Route line minimum alpha.                  |
+| `routePulseAlphaMax`        | Route line maximum alpha.                  |
+| `routeFlowDuration`         | Route flow-pip travel time.                |
+| `panelIdlePulseDuration`    | Panel idle glow half-cycle.                |
+| `buttonIdleShimmerDuration` | Button accent shimmer half-cycle.          |
+| `orbitalRotationDuration`   | Orbital decoration full rotation duration. |
+
+## Helper functions
+
+```ts
+import { colorToString, lerpColor } from "@spacebiz/ui";
+
+colorToString(0x00ffcc); // "#00ffcc"
+lerpColor(0x000000, 0xffffff, 0.5); // 0x808080
+```


### PR DESCRIPTION
## Summary

- Adds `packages/spacebiz-ui/docs/` with one MD page per component (29 pages) plus a top-level README index, getting-started guide, and theming reference.
- Each component page follows the same template: 1-line description, import, quick example, config table, methods, events, theming notes, and see-also links.
- Components are organized by category (Foundation / Primitives / Composites / Feedback / Ambient / Utility / Domain). Layout, Input, Notifications, and Misc categories are listed as planned for upcoming units.
- IP-bearing helpers (`MilestoneOverlay`, `CargoIcons`, `ShipIcons`) carry a notice that they are slated to move to the future `@rogue-universe/shared` package per Unit 15.

This is Unit 14 of the 3-tier UI library plan (`vivid-knitting-lagoon`). Doc-only change.

## Test plan

- [x] `npm run check` (typecheck, lint, format:check, test, build) — all green.
- [x] `npx prettier --check packages/spacebiz-ui/docs/` — formatted.
- [ ] Skim component docs for accuracy after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)