### PR TITLE
test(ui): add headless component test harness (jsdom + node-canvas)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "three": "^0.184.0"
       },
       "devDependencies": {
+        "@napi-rs/canvas": "^0.1.56",
         "@playwright/test": "^1.59.1",
         "@typescript-eslint/parser": "^8.59.0",
         "@typescript-eslint/rule-tester": "^8.59.0",
@@ -24,12 +25,27 @@
         "eslint": "^9.39.4",
         "husky": "^9.1.7",
         "jiti": "^2.6.1",
+        "jsdom": "^25.0.1",
         "lint-staged": "^16.4.0",
         "prettier": "^3.8.3",
         "sharp": "^0.34.5",
         "typescript": "~5.9.3",
         "vite": "^8.0.0",
         "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -88,6 +104,123 @@
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -985,6 +1118,267 @@
         }
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
@@ -1792,6 +2186,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1807,6 +2202,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -1915,6 +2320,13 @@
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -2098,6 +2510,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -2193,6 +2618,41 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2210,12 +2670,29 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -2272,6 +2749,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -2322,6 +2812,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -2347,6 +2853,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2637,6 +3144,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2825,6 +3333,46 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2977,6 +3525,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -2994,8 +3558,22 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/html-escaper": {
@@ -3023,6 +3601,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/husky": {
@@ -3157,6 +3763,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -3214,6 +3827,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3245,6 +3859,48 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -3673,6 +4329,13 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3842,6 +4505,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3974,6 +4644,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4024,6 +4707,7 @@
       "resolved": "https://registry.npmjs.org/phaser/-/phaser-4.0.0.tgz",
       "integrity": "sha512-f9oYpu3/UymB5JJDZRqOsNQm5FkMMC7u8eL8yQuqGAa54wTbgE2QbTOn70vgvlOVuYeQcw2mOQ52PpJHBSBkfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.4"
       }
@@ -4311,11 +4995,31 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -4671,6 +5375,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/three": {
       "version": "0.184.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
@@ -4721,6 +5432,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -4728,6 +5459,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4784,6 +5541,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4833,6 +5591,7 @@
       "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
@@ -4912,6 +5671,7 @@
       "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0",
         "@vitest/mocker": "4.1.0",
@@ -4986,6 +5746,80 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -5085,6 +5919,45 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -5119,6 +5992,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     ]
   },
   "devDependencies": {
+    "@napi-rs/canvas": "^0.1.56",
     "@playwright/test": "^1.59.1",
     "@typescript-eslint/parser": "^8.59.0",
     "@typescript-eslint/rule-tester": "^8.59.0",
@@ -43,6 +44,7 @@
     "eslint": "^9.39.4",
     "husky": "^9.1.7",
     "jiti": "^2.6.1",
+    "jsdom": "^25.0.1",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.3",
     "sharp": "^0.34.5",

--- a/packages/spacebiz-ui/src/__tests__/_harness/__tests__/harness.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/_harness/__tests__/harness.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { Button } from "../../../Button.ts";
+import { mockScene, mountComponent } from "../index.ts";
+import type { MountedComponent } from "../index.ts";
+
+describe("test harness", () => {
+  describe("mockScene", () => {
+    it("returns isolated scenes with a real EventEmitter", () => {
+      const a = mockScene();
+      const b = mockScene();
+      expect(a.events).not.toBe(b.events);
+      let fired = 0;
+      a.events.on("ping", () => fired++);
+      a.events.emit("ping");
+      b.events.emit("ping");
+      expect(fired).toBe(1);
+    });
+
+    it("exposes plausible defaults for scale and cameras", () => {
+      const s = mockScene();
+      expect(s.scale.width).toBe(1280);
+      expect(s.cameras.main.centerX).toBe(640);
+    });
+  });
+
+  describe("mountComponent", () => {
+    let mounted: MountedComponent<Button> | undefined;
+
+    afterEach(() => {
+      mounted?.destroy();
+      mounted = undefined;
+    });
+
+    it("constructs a real Button in a headless Phaser scene", async () => {
+      mounted = await mountComponent(
+        (scene) =>
+          new Button(scene, {
+            x: 0,
+            y: 0,
+            label: "Hi",
+            onClick: () => undefined,
+          }),
+      );
+      expect(mounted.component).toBeDefined();
+      expect(mounted.scene).toBeDefined();
+      // Container holds bg + accent line + label = 3 children (per Button.ts).
+      expect(mounted.component.list.length).toBeGreaterThanOrEqual(3);
+    }, 15000);
+
+    it("supports setLabel after mount", async () => {
+      mounted = await mountComponent(
+        (scene) =>
+          new Button(scene, {
+            x: 0,
+            y: 0,
+            label: "Original",
+            onClick: () => undefined,
+          }),
+      );
+      mounted.component.setLabel("Updated");
+      // Reach into the Container's children to find the Text label.
+      const textChild = mounted.component.list.find(
+        (child) => "text" in (child as unknown as Record<string, unknown>),
+      ) as unknown as { text: string } | undefined;
+      expect(textChild?.text).toBe("Updated");
+    }, 15000);
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/_harness/index.ts
+++ b/packages/spacebiz-ui/src/__tests__/_harness/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Headless component test harness for `@spacebiz/ui`.
+ *
+ * Three tools, used independently:
+ *
+ *   1. `installCanvasMock()` / `restoreCanvasMock()`
+ *      Polyfill `HTMLCanvasElement.prototype.getContext('2d')` so jsdom can
+ *      satisfy Phaser's text-measurement and texture pipelines. Wired into
+ *      Vitest globally via `setup.ts`; call directly only if you opt out of
+ *      the global setup.
+ *
+ *   2. `mockScene()`
+ *      Returns a minimal Phaser.Scene-shaped object backed by stubs and a
+ *      real EventEmitter. Use for tests that exercise pure logic / wiring
+ *      without instantiating real GameObjects.
+ *
+ *   3. `mountComponent(factory)`
+ *      Boots a real Phaser HEADLESS game on jsdom and resolves with
+ *      `{ scene, component, destroy }` once the component's constructor has
+ *      run inside the scene's `create()`. Use this when assertions depend on
+ *      real GameObject behavior. Always call `destroy()` in `afterEach` to
+ *      avoid leaking the game across tests.
+ *
+ * This module is intentionally not re-exported from the package's public
+ * `src/index.ts` — it's an internal test utility.
+ */
+
+export { installCanvasMock, restoreCanvasMock } from "./mockCanvas.ts";
+export { mockScene } from "./mockScene.ts";
+export type { MockScene } from "./mockScene.ts";
+export { mountComponent } from "./mountComponent.ts";
+export type { MountedComponent } from "./mountComponent.ts";

--- a/packages/spacebiz-ui/src/__tests__/_harness/mockCanvas.ts
+++ b/packages/spacebiz-ui/src/__tests__/_harness/mockCanvas.ts
@@ -1,0 +1,193 @@
+/**
+ * Canvas polyfill installer for Vitest.
+ *
+ * Phaser 4's text/texture pipeline calls into `HTMLCanvasElement.getContext`
+ * during construction (e.g. measuring text bounds, rasterizing glyphs). jsdom
+ * ships canvas elements but no 2D context, so we install a real implementation
+ * via @napi-rs/canvas when available. If the optional dependency is missing we
+ * fall back to a math-free stub that returns plausible no-op shapes — enough
+ * for tests that never inspect actual pixels.
+ */
+
+type CanvasModule = {
+  createCanvas: (width: number, height: number) => unknown;
+};
+
+let originalGetContext:
+  | ((this: HTMLCanvasElement, ...args: unknown[]) => unknown)
+  | undefined;
+let originalImageSrc: PropertyDescriptor | undefined;
+let installed = false;
+
+function tryLoadNapiCanvas(): CanvasModule | null {
+  try {
+    // Indirect require so bundlers / static analysers don't try to resolve it.
+    // The optional native module is CJS-only on some platforms, so a dynamic
+    // require obtained via the Function constructor is the portable shim.
+    const req = new Function("return require")() as (
+      id: string,
+    ) => CanvasModule;
+    return req("@napi-rs/canvas");
+  } catch {
+    return null;
+  }
+}
+
+function buildStubContext(): CanvasRenderingContext2D {
+  // Minimal 2D-context stub: enough surface area for Phaser's text measurer.
+  // Returned values are deterministic placeholders, never inspected for
+  // correctness — tests that need real glyph metrics should ensure
+  // @napi-rs/canvas is installed.
+  const noop = () => undefined;
+  const ctx = {
+    canvas: undefined as unknown as HTMLCanvasElement,
+    fillStyle: "#000",
+    strokeStyle: "#000",
+    font: "10px sans-serif",
+    textAlign: "start",
+    textBaseline: "alphabetic",
+    globalAlpha: 1,
+    globalCompositeOperation: "source-over",
+    lineWidth: 1,
+    measureText: (text: string) => ({
+      width: text.length * 6,
+      actualBoundingBoxAscent: 8,
+      actualBoundingBoxDescent: 2,
+      actualBoundingBoxLeft: 0,
+      actualBoundingBoxRight: text.length * 6,
+      fontBoundingBoxAscent: 8,
+      fontBoundingBoxDescent: 2,
+    }),
+    fillText: noop,
+    strokeText: noop,
+    fillRect: noop,
+    strokeRect: noop,
+    clearRect: noop,
+    beginPath: noop,
+    closePath: noop,
+    moveTo: noop,
+    lineTo: noop,
+    arc: noop,
+    rect: noop,
+    fill: noop,
+    stroke: noop,
+    save: noop,
+    restore: noop,
+    scale: noop,
+    rotate: noop,
+    translate: noop,
+    transform: noop,
+    setTransform: noop,
+    resetTransform: noop,
+    drawImage: noop,
+    createImageData: (w: number, h: number) => ({
+      data: new Uint8ClampedArray(w * h * 4),
+      width: w,
+      height: h,
+    }),
+    getImageData: (_x: number, _y: number, w: number, h: number) => ({
+      data: new Uint8ClampedArray(w * h * 4),
+      width: w,
+      height: h,
+    }),
+    putImageData: noop,
+    createLinearGradient: () => ({ addColorStop: noop }),
+    createRadialGradient: () => ({ addColorStop: noop }),
+    createPattern: () => null,
+    clip: noop,
+    isPointInPath: () => false,
+    isPointInStroke: () => false,
+  } as unknown as CanvasRenderingContext2D;
+  return ctx;
+}
+
+/**
+ * Install a 2D canvas implementation on globalThis.HTMLCanvasElement.prototype.
+ * Safe to call multiple times — subsequent calls are no-ops until restored.
+ */
+export function installCanvasMock(): void {
+  if (installed) return;
+  if (typeof HTMLCanvasElement === "undefined") {
+    // No DOM in this test environment; nothing to patch.
+    return;
+  }
+  const napi = tryLoadNapiCanvas();
+  originalGetContext = HTMLCanvasElement.prototype.getContext as
+    | ((this: HTMLCanvasElement, ...args: unknown[]) => unknown)
+    | undefined;
+  HTMLCanvasElement.prototype.getContext = function (
+    this: HTMLCanvasElement,
+    contextId: string,
+    ...rest: unknown[]
+  ): unknown {
+    if (contextId !== "2d") {
+      // WebGL / bitmaprenderer not supported in headless tests.
+      return null;
+    }
+    if (napi) {
+      const real = napi.createCanvas(
+        this.width || 1,
+        this.height || 1,
+      ) as unknown as { getContext: (id: string) => unknown };
+      const ctx = real.getContext("2d");
+      return ctx;
+    }
+    void rest;
+    return buildStubContext();
+  } as typeof HTMLCanvasElement.prototype.getContext;
+
+  // jsdom's HTMLImageElement never fires onload for data: URIs, which
+  // strands Phaser's TextureManager (it base64-decodes default/missing/white
+  // textures during boot and waits for them before emitting READY). Patch
+  // the `src` setter to dispatch a synthetic load on the next microtask so
+  // boot completes.
+  if (typeof HTMLImageElement !== "undefined") {
+    const proto = HTMLImageElement.prototype as unknown as object;
+    originalImageSrc =
+      Object.getOwnPropertyDescriptor(proto, "src") ?? undefined;
+    Object.defineProperty(proto, "src", {
+      configurable: true,
+      enumerable: true,
+      get(this: HTMLImageElement): string {
+        return (this as unknown as { _src?: string })._src ?? "";
+      },
+      set(this: HTMLImageElement, value: string): void {
+        (this as unknown as { _src?: string })._src = value;
+        queueMicrotask(() => {
+          this.onload?.(new Event("load"));
+          this.dispatchEvent(new Event("load"));
+        });
+      },
+    });
+  }
+  installed = true;
+}
+
+/** Restore the original `getContext` (or remove the polyfill entirely). */
+export function restoreCanvasMock(): void {
+  if (!installed) return;
+  if (typeof HTMLCanvasElement === "undefined") return;
+  if (originalGetContext) {
+    HTMLCanvasElement.prototype.getContext =
+      originalGetContext as typeof HTMLCanvasElement.prototype.getContext;
+  } else {
+    // jsdom always defines getContext, but guard for hand-built environments.
+    delete (
+      HTMLCanvasElement.prototype as unknown as {
+        getContext?: unknown;
+      }
+    ).getContext;
+  }
+  originalGetContext = undefined;
+
+  if (typeof HTMLImageElement !== "undefined") {
+    const proto = HTMLImageElement.prototype as unknown as object;
+    if (originalImageSrc) {
+      Object.defineProperty(proto, "src", originalImageSrc);
+    } else {
+      delete (proto as unknown as { src?: unknown }).src;
+    }
+    originalImageSrc = undefined;
+  }
+  installed = false;
+}

--- a/packages/spacebiz-ui/src/__tests__/_harness/mockScene.ts
+++ b/packages/spacebiz-ui/src/__tests__/_harness/mockScene.ts
@@ -1,0 +1,114 @@
+import * as Phaser from "phaser";
+
+/**
+ * Minimal Phaser.Scene-shaped factory for tests that don't need a real game
+ * instance. Use this for pure logic / config-shape tests; for anything that
+ * actually constructs Phaser GameObjects, prefer `mountComponent`.
+ *
+ * Every method is a plausible no-op or returns a chainable stub. The `events`
+ * EventEmitter is real so subscribers can verify wiring.
+ */
+
+export interface MockScene {
+  add: Record<string, (...args: unknown[]) => unknown>;
+  make: Record<string, (...args: unknown[]) => unknown>;
+  scale: { width: number; height: number; on: () => void; off: () => void };
+  events: Phaser.Events.EventEmitter;
+  tweens: {
+    add: (config: unknown) => unknown;
+    killTweensOf: (target: unknown) => void;
+  };
+  time: {
+    delayedCall: (delay: number, callback: () => void) => unknown;
+    addEvent: (config: unknown) => unknown;
+  };
+  cameras: {
+    main: { width: number; height: number; centerX: number; centerY: number };
+  };
+  textures: {
+    exists: (key: string) => boolean;
+    get: (key: string) => unknown;
+    addCanvas: (key: string, canvas: unknown) => unknown;
+    list: Record<string, unknown>;
+  };
+  input: {
+    on: () => void;
+    off: () => void;
+    keyboard: { on: () => void; off: () => void } | null;
+  };
+  sys: { events: Phaser.Events.EventEmitter };
+  load: { on: () => void; off: () => void; image: () => void };
+}
+
+function chainable(): unknown {
+  // Returns a Proxy where every property access returns the same chainable
+  // stub — covers the fluent setX().setY().setZ() calls Phaser code uses.
+  const target: Record<string | symbol, unknown> = {};
+  const proxy: unknown = new Proxy(target, {
+    get(t, prop) {
+      if (prop in t) return t[prop];
+      const fn = (..._args: unknown[]): unknown => proxy;
+      t[prop] = fn;
+      return fn;
+    },
+  });
+  return proxy;
+}
+
+/** Build a fresh mock scene. Each call returns an isolated instance. */
+export function mockScene(overrides: Partial<MockScene> = {}): MockScene {
+  const events = new Phaser.Events.EventEmitter();
+  const sysEvents = new Phaser.Events.EventEmitter();
+  const stubFactory = () => chainable();
+
+  const base: MockScene = {
+    add: new Proxy(
+      {},
+      {
+        get: () => stubFactory,
+      },
+    ) as Record<string, (...args: unknown[]) => unknown>,
+    make: new Proxy(
+      {},
+      {
+        get: () => stubFactory,
+      },
+    ) as Record<string, (...args: unknown[]) => unknown>,
+    scale: {
+      width: 1280,
+      height: 720,
+      on: () => undefined,
+      off: () => undefined,
+    },
+    events,
+    tweens: {
+      add: () => chainable(),
+      killTweensOf: () => undefined,
+    },
+    time: {
+      delayedCall: () => chainable(),
+      addEvent: () => chainable(),
+    },
+    cameras: {
+      main: { width: 1280, height: 720, centerX: 640, centerY: 360 },
+    },
+    textures: {
+      exists: () => false,
+      get: () => chainable(),
+      addCanvas: () => chainable(),
+      list: {},
+    },
+    input: {
+      on: () => undefined,
+      off: () => undefined,
+      keyboard: { on: () => undefined, off: () => undefined },
+    },
+    sys: { events: sysEvents },
+    load: {
+      on: () => undefined,
+      off: () => undefined,
+      image: () => undefined,
+    },
+  };
+  return { ...base, ...overrides };
+}

--- a/packages/spacebiz-ui/src/__tests__/_harness/mountComponent.ts
+++ b/packages/spacebiz-ui/src/__tests__/_harness/mountComponent.ts
@@ -1,0 +1,106 @@
+import * as Phaser from "phaser";
+
+/**
+ * Boots a real headless Phaser game on the current jsdom DOM and mounts a
+ * component into a transient scene. Returns the live scene + the constructed
+ * component plus a `destroy()` cleanup that tears the game down.
+ *
+ * Use for component-level tests that need to assert on actual Phaser
+ * GameObjects (Container children, Text content, depth, etc). For pure config
+ * shape tests, prefer `mockScene` — booting Phaser per test costs ~30ms.
+ */
+
+export interface MountedComponent<T> {
+  scene: Phaser.Scene;
+  component: T;
+  game: Phaser.Game;
+  destroy: () => void;
+}
+
+/**
+ * Mount a component built by `factory(scene)` and resolve once `create()` has
+ * run. The factory is called during the scene's `create` lifecycle so all
+ * standard Phaser construction patterns work.
+ */
+export function mountComponent<T>(
+  factory: (scene: Phaser.Scene) => T,
+): Promise<MountedComponent<T>> {
+  return new Promise((resolve, reject) => {
+    let resolved = false;
+    let component: T | undefined;
+    let createdScene: Phaser.Scene | undefined;
+
+    class HarnessScene extends Phaser.Scene {
+      constructor() {
+        super("__harness__");
+      }
+      create(): void {
+        try {
+          createdScene = this;
+          component = factory(this);
+        } catch (err) {
+          reject(err);
+        }
+      }
+    }
+
+    let game: Phaser.Game;
+    try {
+      game = new Phaser.Game({
+        type: Phaser.HEADLESS,
+        width: 800,
+        height: 600,
+        banner: false,
+        customEnvironment: true,
+        scene: HarnessScene,
+        audio: { noAudio: true },
+        // jsdom's requestAnimationFrame doesn't fire reliably under Vitest, so
+        // force the setTimeout-driven game loop. Without this, scene init/create
+        // never runs and the harness times out.
+        fps: { forceSetTimeOut: true, target: 60 },
+      });
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    void game;
+
+    // Phaser fires READY after the boot sequence; by then `create` has run on
+    // the start scene. We resolve on the first post-create tick to ensure the
+    // component finished construction.
+    const finalize = (): void => {
+      if (resolved) return;
+      if (!component || !createdScene) return;
+      resolved = true;
+      resolve({
+        scene: createdScene,
+        component,
+        game,
+        destroy: () => game.destroy(true, false),
+      });
+    };
+
+    game.events.once(Phaser.Core.Events.READY, () => {
+      // One more event-loop tick so any synchronous create() side effects
+      // settle before the test inspects them.
+      queueMicrotask(finalize);
+    });
+
+    // Safety net: if READY never fires (e.g. headless boot path differs
+    // between Phaser versions), poll a few times then bail.
+    let pollCount = 0;
+    const poll = (): void => {
+      if (resolved) return;
+      if (component && createdScene) {
+        finalize();
+        return;
+      }
+      if (++pollCount > 50) {
+        reject(new Error("mountComponent: scene create() never ran"));
+        return;
+      }
+      setTimeout(poll, 10);
+    };
+    setTimeout(poll, 10);
+  });
+}

--- a/packages/spacebiz-ui/src/__tests__/_harness/setup.ts
+++ b/packages/spacebiz-ui/src/__tests__/_harness/setup.ts
@@ -1,0 +1,13 @@
+// Vitest setup file. Runs once per test file before any test code.
+// Installs the canvas polyfill so Phaser's text/texture pipeline can boot
+// inside jsdom without throwing on `getContext('2d')`.
+import { installCanvasMock } from "./mockCanvas.ts";
+
+installCanvasMock();
+
+// jsdom logs "Not implemented: window.focus" whenever Phaser starts the game
+// loop. The call is harmless — replace it with a no-op so the noise doesn't
+// drown out real test output.
+if (typeof window !== "undefined") {
+  window.focus = () => undefined;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,7 +76,12 @@ export default defineConfig({
   },
   test: {
     globals: true,
-    environment: "node",
+    // jsdom enables real Phaser GameObjects under Vitest. The headless harness
+    // (packages/spacebiz-ui/src/__tests__/_harness) installs a canvas polyfill
+    // via setupFiles so Phaser's text/texture pipeline can boot. Pure-logic
+    // tests don't depend on `node` env specifically and run unchanged.
+    environment: "jsdom",
+    setupFiles: ["packages/spacebiz-ui/src/__tests__/_harness/setup.ts"],
     exclude: [
       "node_modules",
       "dist",


### PR DESCRIPTION
## Summary

Adds `packages/spacebiz-ui/src/__tests__/_harness/` so component-level Vitest tests can instantiate real Phaser GameObjects without a browser. Unit 6 of 21 in the UI 3-tier formalization plan.

- `mockCanvas.ts` — `installCanvasMock()` / `restoreCanvasMock()` polyfill `HTMLCanvasElement.getContext('2d')` (using `@napi-rs/canvas` when available, otherwise a math-free stub) and patches `HTMLImageElement.src` so Phaser's TextureManager can finish booting under jsdom (data URIs never fire `onload` in jsdom).
- `mockScene.ts` — minimal `Phaser.Scene`-shaped factory backed by stubs and a real `EventEmitter`, for tests that don't need a live Phaser game.
- `mountComponent.ts` — boots a real `Phaser.HEADLESS` game on jsdom and resolves `{ scene, component, game, destroy }` once `create()` runs. Uses `fps.forceSetTimeOut: true` because jsdom's `requestAnimationFrame` doesn't drive Phaser reliably.
- `index.ts` — public surface, with a doc comment explaining the three tools.
- `setup.ts` — Vitest setup file that installs the canvas polyfill and stubs `window.focus` (Phaser's `VisibilityHandler` calls it during boot, which jsdom otherwise logs as not-implemented).

`vite.config.ts` switches the test environment to `jsdom` and registers `setupFiles`. The 898 existing tests pass unchanged. Adds `jsdom` and `@napi-rs/canvas` as devDependencies.

A self-test (`__tests__/harness.test.ts`) mounts a real `Button`, asserts construction, and exercises `setLabel` to prove the harness end-to-end.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (no new errors; pre-existing testid warnings unchanged)
- [x] `npm run format:check`
- [x] `npm run test` — 900 tests passing across 65 files, including 4 new harness tests
- [x] `npm run build` — both main + styleguide bundles produced
- [x] Skipped e2e per plan (test-infrastructure-only unit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)