### PR TITLE
test(ui): add unit tests for feedback components (Modal, Tooltip, FloatingText, StatusBadge, Starfield, SceneUiDirector)

### DIFF
--- a/packages/spacebiz-ui/src/__tests__/feedback/FloatingText.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/feedback/FloatingText.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("phaser", async () => {
+  const m = await import("./_phaserMock.ts");
+  return m.phaserMockFactory();
+});
+
+import {
+  createMockScene,
+  type MockScene,
+  type MockText,
+} from "./_phaserMock.ts";
+import { FloatingText } from "../../FloatingText.ts";
+
+describe("FloatingText", () => {
+  let scene: MockScene;
+
+  beforeEach(() => {
+    scene = createMockScene(800, 600);
+  });
+
+  it("spawns a Text game object at the requested position", () => {
+    new FloatingText(scene as never, 100, 200, "+§500", 0x00ff88);
+    const texts = scene.children.list.filter(
+      (c) => (c as MockText).type === "Text",
+    ) as MockText[];
+    expect(texts.length).toBe(1);
+    const txt = texts[0]!;
+    expect(txt.x).toBe(100);
+    expect(txt.y).toBe(200);
+    expect(txt.text).toBe("+§500");
+    expect(txt.depth).toBe(1000);
+    // Starts invisible (alpha 0) — pop-in tween fades it up.
+    expect(txt.alpha).toBe(0);
+  });
+
+  it("creates a pop-in tween then chains a settle tween that destroys the text", () => {
+    new FloatingText(scene as never, 0, 0, "x", 0xffffff);
+    const texts = scene.children.list.filter(
+      (c) => (c as MockText).type === "Text",
+    ) as MockText[];
+    const txt = texts[0]!;
+
+    expect(scene.tweens._all.length).toBe(1);
+    // Complete the pop tween — chains the settle tween.
+    scene.tweens._all[0]!.complete();
+    expect(scene.tweens._all.length).toBe(2);
+    expect(txt.destroyed).toBe(false);
+
+    // Complete the settle tween — must destroy the text.
+    scene.tweens._all[1]!.complete();
+    expect(txt.destroyed).toBe(true);
+  });
+
+  it("respects the riseDistance and driftX config when scheduling the settle tween", () => {
+    new FloatingText(scene as never, 100, 200, "x", 0xffffff, {
+      riseDistance: 80,
+      driftX: 25,
+    });
+    scene.tweens._all[0]!.complete();
+    const settle = scene.tweens._all[1]!;
+    expect(settle.config.x).toBe(100 + 25);
+    expect(settle.config.y).toBe(200 - 80);
+  });
+
+  it("scales pop intensity higher when bounce is enabled (default)", () => {
+    new FloatingText(scene as never, 0, 0, "x", 0xffffff, { bounce: true });
+    const popA = scene.tweens._all[0]!;
+    expect(popA.config.scaleX).toBe(1.35);
+
+    const scene2 = createMockScene();
+    new FloatingText(scene2 as never, 0, 0, "x", 0xffffff, { bounce: false });
+    const popB = scene2.tweens._all[0]!;
+    expect(popB.config.scaleX).toBe(1.1);
+  });
+
+  it("respects custom duration in the settle tween", () => {
+    new FloatingText(scene as never, 0, 0, "x", 0xffffff, { duration: 2000 });
+    const popDuration = scene.tweens._all[0]!.config.duration as number;
+    scene.tweens._all[0]!.complete();
+    const settleDuration = scene.tweens._all[1]!.config.duration as number;
+    expect(popDuration + settleDuration).toBe(2000);
+  });
+
+  it("supports the four documented size keys without throwing", () => {
+    for (const size of ["small", "medium", "large", "huge"] as const) {
+      new FloatingText(scene as never, 0, 0, "n", 0xffffff, { size });
+    }
+    const texts = scene.children.list.filter(
+      (c) => (c as MockText).type === "Text",
+    );
+    expect(texts.length).toBe(4);
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/feedback/Modal.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/feedback/Modal.test.ts
@@ -1,0 +1,199 @@
+/* eslint-disable sft/require-widget-testid -- testId is exercised in dedicated cases; other cases construct Modals only to test non-widget behavior. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("phaser", async () => {
+  const m = await import("./_phaserMock.ts");
+  return m.phaserMockFactory();
+});
+
+import {
+  createMockScene,
+  type MockScene,
+  type MockContainer,
+  type MockRectangle,
+  type MockNineslice,
+} from "./_phaserMock.ts";
+import { Modal } from "../../Modal.ts";
+import { setWidgetHook, type WidgetRegistration } from "../../WidgetHooks.ts";
+
+interface ModalShape {
+  visible: boolean;
+  list: Array<MockContainer | MockRectangle>;
+  show(): void;
+  hide(): void;
+  destroy(fromScene?: boolean): void;
+}
+
+function findOverlay(modal: ModalShape): MockRectangle {
+  // The first child added is the overlay rectangle.
+  return modal.list[0] as MockRectangle;
+}
+
+function findPanel(modal: ModalShape): MockContainer {
+  // The second child added is the panel container.
+  return modal.list[1] as MockContainer;
+}
+
+describe("Modal", () => {
+  let scene: MockScene;
+
+  beforeEach(() => {
+    scene = createMockScene(800, 600);
+    setWidgetHook(null);
+  });
+
+  it("starts hidden after construction", () => {
+    const modal = new Modal(scene as never, {
+      title: "Confirm",
+      body: "Proceed?",
+    }) as unknown as ModalShape;
+    expect(modal.visible).toBe(false);
+  });
+
+  it("show() makes it visible and hide() hides it again", () => {
+    const modal = new Modal(scene as never, {
+      title: "T",
+      body: "B",
+    }) as unknown as ModalShape;
+    modal.show();
+    expect(modal.visible).toBe(true);
+    modal.hide();
+    expect(modal.visible).toBe(false);
+  });
+
+  it("renders an OK button only when no onCancel is provided", () => {
+    const modal = new Modal(scene as never, {
+      title: "T",
+      body: "B",
+    }) as unknown as ModalShape;
+    const panel = findPanel(modal);
+    const nineslices = panel.list.filter(
+      (c) => (c as MockNineslice).type === "NineSlice",
+    );
+    // 1 panel bg + 1 OK button = 2 nineslices, no cancel.
+    expect(nineslices.length).toBe(2);
+  });
+
+  it("renders both OK and Cancel buttons when onCancel is provided", () => {
+    const modal = new Modal(scene as never, {
+      title: "T",
+      body: "B",
+      onCancel: () => {},
+    }) as unknown as ModalShape;
+    const panel = findPanel(modal);
+    const nineslices = panel.list.filter(
+      (c) => (c as MockNineslice).type === "NineSlice",
+    );
+    // 1 panel bg + 2 buttons = 3 nineslices.
+    expect(nineslices.length).toBe(3);
+  });
+
+  it("backdrop click invokes onCancel and hides the modal", () => {
+    const onCancel = vi.fn();
+    const modal = new Modal(scene as never, {
+      title: "T",
+      body: "B",
+      onCancel,
+    }) as unknown as ModalShape;
+    modal.show();
+    const overlay = findOverlay(modal);
+    overlay.emit("pointerup");
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(modal.visible).toBe(false);
+  });
+
+  it("ESC keydown fires onCancel and hides the modal", () => {
+    const onCancel = vi.fn();
+    const onOk = vi.fn();
+    const modal = new Modal(scene as never, {
+      title: "T",
+      body: "B",
+      onOk,
+      onCancel,
+    }) as unknown as ModalShape;
+    modal.show();
+    const event = { code: "Escape", preventDefault: vi.fn() };
+    scene.input.keyboard._emit(event);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onOk).not.toHaveBeenCalled();
+    expect(modal.visible).toBe(false);
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it("Enter keydown fires onOk and hides the modal", () => {
+    const onOk = vi.fn();
+    const modal = new Modal(scene as never, {
+      title: "T",
+      body: "B",
+      onOk,
+    }) as unknown as ModalShape;
+    modal.show();
+    scene.input.keyboard._emit({ code: "Enter", preventDefault: () => {} });
+    expect(onOk).toHaveBeenCalledTimes(1);
+    expect(modal.visible).toBe(false);
+  });
+
+  it("ignores keydown events while hidden", () => {
+    const onCancel = vi.fn();
+    new Modal(scene as never, {
+      title: "T",
+      body: "B",
+      onCancel,
+    });
+    // Never shown; must ignore Escape.
+    scene.input.keyboard._emit({ code: "Escape", preventDefault: () => {} });
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("registers OK/cancel/close widgets when a hook is installed", () => {
+    const registrations: WidgetRegistration[] = [];
+    setWidgetHook((reg) => {
+      registrations.push(reg);
+      return () => {};
+    });
+    new Modal(scene as never, {
+      title: "T",
+      body: "B",
+      onCancel: () => {},
+      testId: "my-modal",
+    });
+    const ids = registrations.map((r) => r.testId).sort();
+    expect(ids).toEqual(["my-modal-cancel", "my-modal-close", "my-modal-ok"]);
+  });
+
+  it("widget invoke() fires the registered callback only when shown", () => {
+    let okReg: WidgetRegistration | null = null;
+    setWidgetHook((reg) => {
+      if (reg.testId === "modal-ok") okReg = reg;
+      return () => {};
+    });
+    const onOk = vi.fn();
+    const modal = new Modal(scene as never, {
+      title: "T",
+      body: "B",
+      onOk,
+    }) as unknown as ModalShape;
+    expect(okReg).not.toBeNull();
+    // Modal still hidden — invoke should be a no-op.
+    okReg!.invoke();
+    expect(onOk).not.toHaveBeenCalled();
+
+    modal.show();
+    okReg!.invoke();
+    expect(onOk).toHaveBeenCalledTimes(1);
+  });
+
+  it("destroy() unregisters keyboard listener", () => {
+    const onCancel = vi.fn();
+    const modal = new Modal(scene as never, {
+      title: "T",
+      body: "B",
+      onCancel,
+    }) as unknown as ModalShape;
+    modal.show();
+    modal.destroy();
+    // Keyboard listener should be detached, so emit must not invoke onCancel.
+    scene.input.keyboard._emit({ code: "Escape", preventDefault: () => {} });
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/feedback/SceneUiDirector.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/feedback/SceneUiDirector.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("phaser", async () => {
+  const m = await import("./_phaserMock.ts");
+  return m.phaserMockFactory();
+});
+
+import {
+  createMockScene,
+  type MockScene,
+  type MockRectangle,
+} from "./_phaserMock.ts";
+import { SceneUiDirector } from "../../SceneUiDirector.ts";
+import { DEPTH_MODAL } from "../../DepthLayers.ts";
+
+// The mock objects don't satisfy the full Phaser.GameObjects.GameObject type at
+// compile time (TS sees the real Phaser types via SceneUiDirector's signature).
+// At runtime they're indistinguishable for the slice the director touches, so a
+// type assertion is sound here.
+function asGo<T>(o: T): never {
+  return o as unknown as never;
+}
+
+describe("SceneUiDirector", () => {
+  let scene: MockScene;
+
+  beforeEach(() => {
+    scene = createMockScene(800, 600);
+  });
+
+  it("opens an anonymous layer and adds it to the scene shutdown chain", () => {
+    const dir = new SceneUiDirector(scene as never);
+    expect(scene.events.listenerCount("shutdown")).toBe(1);
+    const layer = dir.openLayer();
+    expect(layer.key).toBeUndefined();
+  });
+
+  it("opens a keyed layer and re-uses the slot when re-opened", () => {
+    const dir = new SceneUiDirector(scene as never);
+    const a = dir.openLayer({ key: "menu" });
+    const b = dir.openLayer({ key: "menu" });
+    expect(a).not.toBe(b);
+    // Re-opening with the same key destroys the previous instance.
+    expect((a as unknown as { isDestroyed: boolean }).isDestroyed).toBe(true);
+    expect(b.key).toBe("menu");
+  });
+
+  it("track() adds the object to the scene display list and returns it", () => {
+    const dir = new SceneUiDirector(scene as never);
+    const layer = dir.openLayer();
+    const rect = scene.add.rectangle(0, 0, 10, 10);
+    // Strip from the display list so we can verify track re-adds it.
+    scene.children.removeFromList(rect);
+    expect(scene.children.exists(rect)).toBe(false);
+    const result = layer.track(asGo<MockRectangle>(rect));
+    expect(result).toBe(rect as unknown);
+    expect(scene.children.exists(rect)).toBe(true);
+  });
+
+  it("trackMany() registers multiple objects in one call", () => {
+    const dir = new SceneUiDirector(scene as never);
+    const layer = dir.openLayer();
+    const r1 = scene.add.rectangle(0, 0, 1, 1);
+    const r2 = scene.add.rectangle(0, 0, 1, 1);
+    const r3 = scene.add.rectangle(0, 0, 1, 1);
+    const out = layer.trackMany(asGo(r1), asGo(r2), asGo(r3));
+    expect(out).toEqual([r1, r2, r3]);
+  });
+
+  it("destroy() destroys all tracked objects and unregisters the layer", () => {
+    const dir = new SceneUiDirector(scene as never);
+    const layer = dir.openLayer({ key: "panel" });
+    const r1 = scene.add.rectangle(0, 0, 1, 1);
+    const r2 = scene.add.rectangle(0, 0, 1, 1);
+    layer.track(asGo(r1));
+    layer.track(asGo(r2));
+    layer.destroy();
+    expect(r1.destroyed).toBe(true);
+    expect(r2.destroyed).toBe(true);
+    // Re-opening the same key should yield a fresh layer.
+    const fresh = dir.openLayer({ key: "panel" });
+    expect(fresh).not.toBe(layer);
+  });
+
+  it("destroy() invokes registered onDestroy callbacks once", () => {
+    const dir = new SceneUiDirector(scene as never);
+    const layer = dir.openLayer();
+    const cb = vi.fn();
+    layer.onDestroy(cb);
+    layer.destroy();
+    expect(cb).toHaveBeenCalledTimes(1);
+    // Second destroy is a no-op.
+    layer.destroy();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("createOverlay() places the overlay one layer below the modal depth", () => {
+    const dir = new SceneUiDirector(scene as never);
+    const layer = dir.openLayer();
+    const overlay = layer.createOverlay();
+    expect(overlay.depth).toBe(DEPTH_MODAL - 1);
+    // It should sit on the camera's full surface.
+    expect(overlay.width).toBe(800);
+    expect(overlay.height).toBe(600);
+  });
+
+  it("createOverlay({ closeOnPointerUp: true }) tears down the layer when clicked", () => {
+    const dir = new SceneUiDirector(scene as never);
+    const layer = dir.openLayer();
+    const r = scene.add.rectangle(0, 0, 1, 1);
+    layer.track(asGo(r));
+    const overlay = layer.createOverlay({ closeOnPointerUp: true });
+    overlay.emit("pointerup");
+    expect(r.destroyed).toBe(true);
+  });
+
+  it("createOverlay({ onPointerUp }) fires the callback without auto-closing", () => {
+    const dir = new SceneUiDirector(scene as never);
+    const layer = dir.openLayer();
+    const cb = vi.fn();
+    const overlay = layer.createOverlay({ onPointerUp: cb });
+    overlay.emit("pointerup");
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect((layer as unknown as { isDestroyed: boolean }).isDestroyed).toBe(
+      false,
+    );
+  });
+
+  it("createOverlay({ activationDelayMs }) defers wiring the pointer handler", () => {
+    const dir = new SceneUiDirector(scene as never);
+    const layer = dir.openLayer();
+    const cb = vi.fn();
+    const overlay = layer.createOverlay({
+      onPointerUp: cb,
+      activationDelayMs: 100,
+    });
+    // No listener attached yet — emit is a no-op.
+    overlay.emit("pointerup");
+    expect(cb).not.toHaveBeenCalled();
+    // Fire the timer; handler is now wired.
+    scene.time._all[0]!.fire();
+    overlay.emit("pointerup");
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("closeAll() destroys both keyed and anonymous layers", () => {
+    const dir = new SceneUiDirector(scene as never);
+    const a = dir.openLayer({ key: "a" });
+    const b = dir.openLayer();
+    dir.closeAll();
+    expect((a as unknown as { isDestroyed: boolean }).isDestroyed).toBe(true);
+    expect((b as unknown as { isDestroyed: boolean }).isDestroyed).toBe(true);
+  });
+
+  it("scene shutdown destroys the director and all open layers", () => {
+    const dir = new SceneUiDirector(scene as never);
+    const a = dir.openLayer({ key: "a" });
+    scene.events.emit("shutdown");
+    expect((a as unknown as { isDestroyed: boolean }).isDestroyed).toBe(true);
+    // Confirm the director also clears its internal maps by opening a new layer.
+    const fresh = dir.openLayer({ key: "a" });
+    expect(fresh).not.toBe(a);
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/feedback/Starfield.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/feedback/Starfield.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("phaser", async () => {
+  const m = await import("./_phaserMock.ts");
+  return m.phaserMockFactory();
+});
+
+import {
+  createMockScene,
+  type MockScene,
+  type MockContainer,
+  type MockImage,
+} from "./_phaserMock.ts";
+import { createStarfield } from "../../Starfield.ts";
+
+function getLayerContainers(scene: MockScene): MockContainer[] {
+  return scene.children.list.filter(
+    (c) => (c as MockContainer).type === "Container",
+  ) as MockContainer[];
+}
+
+function totalStars(scene: MockScene): number {
+  let count = 0;
+  for (const c of getLayerContainers(scene)) {
+    for (const child of c.list) {
+      if ((child as MockImage).type === "Image") count++;
+    }
+  }
+  return count;
+}
+
+describe("Starfield", () => {
+  let scene: MockScene;
+
+  beforeEach(() => {
+    scene = createMockScene(800, 600);
+    // Pre-register the haze texture so haze sprites are produced.
+    scene.textures.add("glow-dot");
+  });
+
+  it("returns void (no handle exposed)", () => {
+    const handle = createStarfield(scene as never);
+    expect(handle).toBeUndefined();
+  });
+
+  it("creates one container per default layer", () => {
+    createStarfield(scene as never, {
+      drift: false,
+      twinkle: false,
+      shimmer: false,
+      haze: false,
+    });
+    // Default config has 3 layers.
+    expect(getLayerContainers(scene).length).toBe(3);
+  });
+
+  it("respects a custom layers config and produces the expected star count", () => {
+    createStarfield(scene as never, {
+      drift: false,
+      twinkle: false,
+      shimmer: false,
+      haze: false,
+      layers: [
+        {
+          count: 5,
+          scrollFactor: 0.1,
+          minAlpha: 0.2,
+          maxAlpha: 0.5,
+          minScale: 0.5,
+          maxScale: 1.0,
+          tints: [0xffffff],
+        },
+        {
+          count: 7,
+          scrollFactor: 0.3,
+          minAlpha: 0.2,
+          maxAlpha: 0.5,
+          minScale: 0.5,
+          maxScale: 1.0,
+          tints: [0xffffff],
+        },
+      ],
+    });
+    expect(getLayerContainers(scene).length).toBe(2);
+    expect(totalStars(scene)).toBe(5 + 7);
+  });
+
+  it("registers cleanup on scene shutdown when ambient tweens are created", () => {
+    createStarfield(scene as never, {
+      // Force at least one perpetual tween via drift.
+      drift: true,
+      twinkle: false,
+      shimmer: false,
+      haze: false,
+      layers: [
+        {
+          count: 3,
+          scrollFactor: 0.1,
+          minAlpha: 0.2,
+          maxAlpha: 0.5,
+          minScale: 0.5,
+          maxScale: 1.0,
+          tints: [0xffffff],
+        },
+      ],
+    });
+    expect(scene.tweens._all.length).toBeGreaterThan(0);
+    const tweens = scene.tweens._all.slice();
+    // Trigger shutdown — registered cleanup should stop all tweens.
+    scene.events.emit("shutdown");
+    for (const t of tweens) {
+      expect(t.stopped).toBe(true);
+    }
+  });
+
+  it("does not register cleanup or create tweens when all animation flags are off", () => {
+    createStarfield(scene as never, {
+      drift: false,
+      twinkle: false,
+      shimmer: false,
+      haze: false,
+      layers: [
+        {
+          count: 2,
+          scrollFactor: 0.1,
+          minAlpha: 0.2,
+          maxAlpha: 0.5,
+          minScale: 0.5,
+          maxScale: 1.0,
+          tints: [0xffffff],
+        },
+      ],
+    });
+    expect(scene.tweens._all.length).toBe(0);
+    expect(scene.events.listenerCount("shutdown")).toBe(0);
+  });
+
+  it("uses the supplied worldBounds when provided", () => {
+    createStarfield(scene as never, {
+      drift: false,
+      twinkle: false,
+      shimmer: false,
+      haze: false,
+      worldBounds: { minX: -200, maxX: 200, minY: -100, maxY: 100 },
+      layers: [
+        {
+          count: 4,
+          scrollFactor: 0.1,
+          minAlpha: 0.4,
+          maxAlpha: 0.4,
+          minScale: 0.5,
+          maxScale: 0.5,
+          tints: [0xffffff],
+        },
+      ],
+    });
+    expect(totalStars(scene)).toBe(4);
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/feedback/StatusBadge.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/feedback/StatusBadge.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("phaser", async () => {
+  const m = await import("./_phaserMock.ts");
+  return m.phaserMockFactory();
+});
+
+import {
+  createMockScene,
+  type MockScene,
+  type MockRectangle,
+  type MockText,
+  type MockGameObject,
+} from "./_phaserMock.ts";
+import { StatusBadge } from "../../StatusBadge.ts";
+import { getTheme } from "../../Theme.ts";
+
+interface BadgeShape extends MockGameObject {
+  list: MockGameObject[];
+  badgeWidth: number;
+  badgeHeight: number;
+  update(
+    text: string,
+    variant?: "info" | "success" | "warning" | "danger" | "neutral",
+  ): BadgeShape;
+  destroy(fromScene?: boolean): void;
+}
+
+function getBg(badge: BadgeShape): MockRectangle {
+  return badge.list[0] as MockRectangle;
+}
+function getLabel(badge: BadgeShape): MockText {
+  return badge.list[1] as MockText;
+}
+
+describe("StatusBadge", () => {
+  let scene: MockScene;
+
+  beforeEach(() => {
+    scene = createMockScene(800, 600);
+  });
+
+  it("defaults to the neutral variant when none is supplied", () => {
+    const theme = getTheme();
+    const badge = new StatusBadge(scene as never, {
+      x: 0,
+      y: 0,
+      text: "Idle",
+    }) as unknown as BadgeShape;
+    const bg = getBg(badge);
+    expect(bg.fillColor).toBe(theme.colors.panelBg);
+  });
+
+  it("maps each variant to its expected background color", () => {
+    const theme = getTheme();
+    const cases: Array<
+      ["info" | "success" | "warning" | "danger" | "neutral", number]
+    > = [
+      ["success", 0x003322],
+      ["warning", 0x332200],
+      ["danger", 0x330011],
+      ["info", 0x002233],
+      ["neutral", theme.colors.panelBg],
+    ];
+    for (const [variant, expected] of cases) {
+      const badge = new StatusBadge(scene as never, {
+        x: 0,
+        y: 0,
+        text: "X",
+        variant,
+      }) as unknown as BadgeShape;
+      expect(getBg(badge).fillColor).toBe(expected);
+    }
+  });
+
+  it("respects bgColor and textColor overrides", () => {
+    const badge = new StatusBadge(scene as never, {
+      x: 0,
+      y: 0,
+      text: "Custom",
+      variant: "info",
+      bgColor: 0x123456,
+      textColor: 0x789abc,
+    }) as unknown as BadgeShape;
+    expect(getBg(badge).fillColor).toBe(0x123456);
+  });
+
+  it("renders the supplied label text", () => {
+    const badge = new StatusBadge(scene as never, {
+      x: 0,
+      y: 0,
+      text: "Hello",
+    }) as unknown as BadgeShape;
+    expect(getLabel(badge).text).toBe("Hello");
+  });
+
+  it("update(text) replaces the label and keeps the variant", () => {
+    const badge = new StatusBadge(scene as never, {
+      x: 0,
+      y: 0,
+      text: "First",
+      variant: "info",
+    }) as unknown as BadgeShape;
+    const initialBg = getBg(badge).fillColor;
+    badge.update("Second");
+    expect(getLabel(badge).text).toBe("Second");
+    expect(getBg(badge).fillColor).toBe(initialBg);
+  });
+
+  it("update(text, variant) swaps the variant colors", () => {
+    const badge = new StatusBadge(scene as never, {
+      x: 0,
+      y: 0,
+      text: "x",
+      variant: "info",
+    }) as unknown as BadgeShape;
+    expect(getBg(badge).fillColor).toBe(0x002233);
+    badge.update("x", "danger");
+    expect(getBg(badge).fillColor).toBe(0x330011);
+  });
+
+  it("does NOT start a pulse tween by default", () => {
+    new StatusBadge(scene as never, { x: 0, y: 0, text: "x" });
+    expect(scene.tweens._all.length).toBe(0);
+  });
+
+  it("starts a pulse tween when pulse: true is set", () => {
+    new StatusBadge(scene as never, {
+      x: 0,
+      y: 0,
+      text: "x",
+      pulse: true,
+    });
+    expect(scene.tweens._all.length).toBe(1);
+    const tween = scene.tweens._all[0]!;
+    expect(tween.config.yoyo).toBe(true);
+    expect(tween.config.repeat).toBe(-1);
+  });
+
+  it("destroy() stops the pulse tween if one was started", () => {
+    const badge = new StatusBadge(scene as never, {
+      x: 0,
+      y: 0,
+      text: "x",
+      pulse: true,
+    }) as unknown as BadgeShape;
+    const tween = scene.tweens._all[0]!;
+    badge.destroy();
+    expect(tween.destroyed).toBe(true);
+  });
+
+  it("badgeWidth and badgeHeight reflect the underlying bg rectangle", () => {
+    const badge = new StatusBadge(scene as never, {
+      x: 0,
+      y: 0,
+      text: "Wide label",
+    }) as unknown as BadgeShape;
+    expect(badge.badgeWidth).toBe(getBg(badge).width);
+    expect(badge.badgeHeight).toBe(getBg(badge).height);
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/feedback/Tooltip.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/feedback/Tooltip.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("phaser", async () => {
+  const m = await import("./_phaserMock.ts");
+  return m.phaserMockFactory();
+});
+
+import {
+  createMockScene,
+  type MockScene,
+  type MockGameObject,
+  MockRectangle,
+} from "./_phaserMock.ts";
+import { Tooltip } from "../../Tooltip.ts";
+
+interface TooltipShape extends MockGameObject {
+  list: MockGameObject[];
+  attachTo(o: MockGameObject, t: string): void;
+  detachFrom(o: MockGameObject): void;
+  destroy(fromScene?: boolean): void;
+}
+
+function makeTarget(scene: MockScene): MockGameObject {
+  // Use a rectangle as a stand-in for any interactive game object.
+  return scene.add.rectangle(0, 0, 50, 50);
+}
+
+describe("Tooltip", () => {
+  let scene: MockScene;
+
+  beforeEach(() => {
+    scene = createMockScene(800, 600);
+  });
+
+  it("starts hidden and at depth 2000", () => {
+    const tt = new Tooltip(scene as never) as unknown as TooltipShape;
+    expect(tt.visible).toBe(false);
+    expect(tt.depth).toBe(2000);
+  });
+
+  it("attachTo schedules the show after the configured delay", () => {
+    const tt = new Tooltip(scene as never, {
+      showDelay: 200,
+    }) as unknown as TooltipShape;
+    const target = makeTarget(scene);
+    tt.attachTo(target, "hello");
+    expect(scene.time._all.length).toBe(0);
+
+    // Simulate hover — pointerover schedules the timer.
+    target.emit("pointerover", { x: 100, y: 50 });
+    expect(scene.time._all.length).toBe(1);
+    expect(scene.time._all[0]!.delay).toBe(200);
+    expect(tt.visible).toBe(false);
+
+    // Fire the timer; tooltip should reveal.
+    scene.time._all[0]!.fire();
+    expect(tt.visible).toBe(true);
+  });
+
+  it("positions the tooltip relative to the pointer with a +12 offset", () => {
+    const tt = new Tooltip(scene as never, {
+      showDelay: 0,
+    }) as unknown as TooltipShape;
+    const target = makeTarget(scene);
+    tt.attachTo(target, "tip");
+    target.emit("pointerover", { x: 50, y: 80 });
+    scene.time._all[0]!.fire();
+    expect(tt.x).toBe(50 + 12);
+    expect(tt.y).toBe(80 + 12);
+  });
+
+  it("pointerout cancels a pending timer and hides the tooltip", () => {
+    const tt = new Tooltip(scene as never, {
+      showDelay: 1000,
+    }) as unknown as TooltipShape;
+    const target = makeTarget(scene);
+    tt.attachTo(target, "tip");
+    target.emit("pointerover", { x: 0, y: 0 });
+    const timer = scene.time._all[0]!;
+    target.emit("pointerout");
+    expect(timer.destroyed).toBe(true);
+    expect(tt.visible).toBe(false);
+  });
+
+  it("updates label text when shown", () => {
+    const tt = new Tooltip(scene as never, {
+      showDelay: 0,
+    }) as unknown as TooltipShape;
+    const target = makeTarget(scene);
+    tt.attachTo(target, "first");
+    target.emit("pointerover", { x: 0, y: 0 });
+    scene.time._all[0]!.fire();
+    // The label is the third child added (border, bg, label).
+    const label = tt.list[2] as MockGameObject & { text: string };
+    expect(label.text).toBe("first");
+
+    // Re-attach with new text and re-trigger.
+    tt.attachTo(target, "second");
+    target.emit("pointerover", { x: 0, y: 0 });
+    scene.time._all[1]!.fire();
+    expect(label.text).toBe("second");
+  });
+
+  it("resizes the border/background to wrap the label", () => {
+    const tt = new Tooltip(scene as never, {
+      showDelay: 0,
+    }) as unknown as TooltipShape;
+    const target = makeTarget(scene);
+    tt.attachTo(target, "x");
+    target.emit("pointerover", { x: 0, y: 0 });
+    scene.time._all[0]!.fire();
+
+    const border = tt.list[0] as MockRectangle;
+    const bg = tt.list[1] as MockRectangle;
+    // Border and bg widths must be positive after layout.
+    expect(border.width).toBeGreaterThan(0);
+    expect(border.height).toBeGreaterThan(0);
+    // BG inset by 1px on each side relative to border.
+    expect(bg.width).toBe(border.width - 2);
+    expect(bg.height).toBe(border.height - 2);
+    expect(bg.x).toBe(1);
+    expect(bg.y).toBe(1);
+  });
+
+  it("detachFrom() removes pointer listeners on the target", () => {
+    const tt = new Tooltip(scene as never, {
+      showDelay: 50,
+    }) as unknown as TooltipShape;
+    const target = makeTarget(scene);
+    tt.attachTo(target, "x");
+    expect(target.listenerCount("pointerover")).toBeGreaterThan(0);
+    tt.detachFrom(target);
+    expect(target.listenerCount("pointerover")).toBe(0);
+    expect(target.listenerCount("pointerout")).toBe(0);
+  });
+});

--- a/packages/spacebiz-ui/src/__tests__/feedback/_phaserMock.ts
+++ b/packages/spacebiz-ui/src/__tests__/feedback/_phaserMock.ts
@@ -1,0 +1,535 @@
+/**
+ * Minimal Phaser stub for headless feedback-component unit tests.
+ *
+ * This is a temporary harness for the feedback test unit. When the formal
+ * harness from unit 6 lands under `__tests__/_harness/`, these tests should
+ * migrate to it.
+ *
+ * Usage in a test file:
+ *
+ *   import { vi } from "vitest";
+ *   import { phaserMockFactory, createMockScene } from "./_phaserMock.ts";
+ *   vi.mock("phaser", phaserMockFactory);
+ *
+ *   // …then import the component under test, AFTER the vi.mock call.
+ */
+
+// ─── Tiny event-emitter that mimics the slice of Phaser.Events.EventEmitter
+//     used by feedback components ────────────────────────────────────────────
+export class MiniEmitter {
+  private listeners = new Map<string, Array<{ fn: Function; ctx?: unknown }>>();
+  private onceListeners = new Map<
+    string,
+    Array<{ fn: Function; ctx?: unknown }>
+  >();
+
+  on(event: string, fn: Function, ctx?: unknown): this {
+    let arr = this.listeners.get(event);
+    if (!arr) {
+      arr = [];
+      this.listeners.set(event, arr);
+    }
+    arr.push({ fn, ctx });
+    return this;
+  }
+
+  once(event: string, fn: Function, ctx?: unknown): this {
+    let arr = this.onceListeners.get(event);
+    if (!arr) {
+      arr = [];
+      this.onceListeners.set(event, arr);
+    }
+    arr.push({ fn, ctx });
+    return this;
+  }
+
+  off(event: string, fn?: Function, _ctx?: unknown): this {
+    const filter = (
+      arr: Array<{ fn: Function; ctx?: unknown }> | undefined,
+    ) => {
+      if (!arr) return undefined;
+      if (!fn) return [];
+      return arr.filter((l) => l.fn !== fn);
+    };
+    const a = filter(this.listeners.get(event));
+    if (a) this.listeners.set(event, a);
+    const b = filter(this.onceListeners.get(event));
+    if (b) this.onceListeners.set(event, b);
+    return this;
+  }
+
+  emit(event: string, ...args: unknown[]): boolean {
+    const a = this.listeners.get(event);
+    if (a) for (const l of [...a]) l.fn.apply(l.ctx, args);
+    const b = this.onceListeners.get(event);
+    if (b) {
+      this.onceListeners.set(event, []);
+      for (const l of b) l.fn.apply(l.ctx, args);
+    }
+    return true;
+  }
+
+  listenerCount(event: string): number {
+    return (
+      (this.listeners.get(event)?.length ?? 0) +
+      (this.onceListeners.get(event)?.length ?? 0)
+    );
+  }
+
+  removeAllListeners(event?: string): this {
+    if (event) {
+      this.listeners.delete(event);
+      this.onceListeners.delete(event);
+    } else {
+      this.listeners.clear();
+      this.onceListeners.clear();
+    }
+    return this;
+  }
+}
+
+// ─── Game object stubs ──────────────────────────────────────────────────────
+export class MockGameObject extends MiniEmitter {
+  scene: MockScene;
+  type = "GameObject";
+  visible = true;
+  alpha = 1;
+  x = 0;
+  y = 0;
+  width = 0;
+  height = 0;
+  depth = 0;
+  scaleX = 1;
+  scaleY = 1;
+  rotation = 0;
+  input: { cursor?: string } | null = null;
+  destroyed = false;
+
+  constructor(scene: MockScene, x = 0, y = 0) {
+    super();
+    this.scene = scene;
+    this.x = x;
+    this.y = y;
+  }
+
+  setOrigin(_x?: number, _y?: number): this {
+    return this;
+  }
+  setVisible(v: boolean): this {
+    this.visible = v;
+    return this;
+  }
+  setAlpha(a: number): this {
+    this.alpha = a;
+    return this;
+  }
+  setDepth(d: number): this {
+    this.depth = d;
+    return this;
+  }
+  setScale(s: number): this {
+    this.scaleX = s;
+    this.scaleY = s;
+    return this;
+  }
+  setPosition(x: number, y: number): this {
+    this.x = x;
+    this.y = y;
+    return this;
+  }
+  setSize(w: number, h: number): this {
+    this.width = w;
+    this.height = h;
+    return this;
+  }
+  setInteractive(_hitArea?: unknown, _callback?: unknown): this {
+    this.input = { cursor: undefined };
+    return this;
+  }
+  setTint(_tint: number): this {
+    return this;
+  }
+  setBlendMode(_mode: number): this {
+    return this;
+  }
+  setStrokeStyle(_w?: number, _c?: number, _a?: number): this {
+    return this;
+  }
+  setFillStyle(_c?: number, _a?: number): this {
+    return this;
+  }
+  setScrollFactor(_f: number): this {
+    return this;
+  }
+  setTexture(_key: string): this {
+    return this;
+  }
+  setText(t: string): this {
+    (this as MockGameObject & { text?: string }).text = String(t);
+    return this;
+  }
+  setColor(_c: string): this {
+    return this;
+  }
+  destroy(_fromScene?: boolean): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.emit("destroy");
+    if (this.scene) {
+      this.scene.children.removeFromList(this);
+    }
+  }
+}
+
+export class MockContainer extends MockGameObject {
+  type = "Container";
+  list: MockGameObject[] = [];
+  add(child: MockGameObject | MockGameObject[]): this {
+    const arr = Array.isArray(child) ? child : [child];
+    for (const c of arr) this.list.push(c);
+    return this;
+  }
+  remove(child: MockGameObject): this {
+    const i = this.list.indexOf(child);
+    if (i >= 0) this.list.splice(i, 1);
+    return this;
+  }
+}
+
+export class MockText extends MockGameObject {
+  type = "Text";
+  text: string;
+  width = 100;
+  height = 20;
+  constructor(scene: MockScene, x: number, y: number, text: string) {
+    super(scene, x, y);
+    this.text = String(text ?? "");
+    // Approximate width from text length
+    this.width = Math.max(10, this.text.length * 8);
+  }
+  setText(t: string): this {
+    this.text = String(t);
+    this.width = Math.max(10, this.text.length * 8);
+    return this;
+  }
+}
+
+export class MockRectangle extends MockGameObject {
+  type = "Rectangle";
+  fillColor: number;
+  fillAlpha: number;
+  constructor(
+    scene: MockScene,
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    color = 0,
+    alpha = 1,
+  ) {
+    super(scene, x, y);
+    this.width = w;
+    this.height = h;
+    this.fillColor = color;
+    this.fillAlpha = alpha;
+  }
+  setFillStyle(c?: number, a?: number): this {
+    if (c !== undefined) this.fillColor = c;
+    if (a !== undefined) this.fillAlpha = a;
+    return this;
+  }
+}
+
+export class MockImage extends MockGameObject {
+  type = "Image";
+  texture: string;
+  constructor(scene: MockScene, x: number, y: number, key: string) {
+    super(scene, x, y);
+    this.texture = key;
+  }
+}
+
+export class MockNineslice extends MockGameObject {
+  type = "NineSlice";
+  texture: string;
+  constructor(
+    scene: MockScene,
+    x: number,
+    y: number,
+    key: string,
+    w = 100,
+    h = 100,
+  ) {
+    super(scene, x, y);
+    this.texture = key;
+    this.width = w;
+    this.height = h;
+  }
+  setTexture(k: string): this {
+    this.texture = k;
+    return this;
+  }
+}
+
+// ─── Tween stubs ────────────────────────────────────────────────────────────
+export interface MockTween {
+  config: Record<string, unknown>;
+  isPlaying: () => boolean;
+  stop: () => void;
+  destroy: () => void;
+  stopped: boolean;
+  destroyed: boolean;
+  /** Trigger the configured onComplete callback synchronously. */
+  complete: () => void;
+}
+
+function makeTween(config: Record<string, unknown>): MockTween {
+  let stopped = false;
+  let destroyed = false;
+  return {
+    config,
+    isPlaying: () => !stopped && !destroyed,
+    stop: () => {
+      stopped = true;
+    },
+    destroy: () => {
+      destroyed = true;
+    },
+    get stopped() {
+      return stopped;
+    },
+    get destroyed() {
+      return destroyed;
+    },
+    complete: () => {
+      const fn = config.onComplete as (() => void) | undefined;
+      if (fn) fn();
+    },
+  };
+}
+
+export class MockTimerEvent {
+  destroyed = false;
+  fired = false;
+  delay: number;
+  callback: () => void;
+  constructor(delay: number, callback: () => void) {
+    this.delay = delay;
+    this.callback = callback;
+  }
+  destroy(): void {
+    this.destroyed = true;
+  }
+  fire(): void {
+    if (this.destroyed) return;
+    this.fired = true;
+    this.callback();
+  }
+}
+
+// ─── Scene stub ─────────────────────────────────────────────────────────────
+export class MockScene {
+  cameras: { main: { width: number; height: number; zoom: number } };
+  scale: { width: number; height: number };
+  textures: {
+    exists: (k: string) => boolean;
+    add: (k: string) => void;
+    _set: Set<string>;
+  };
+  events = new MiniEmitter();
+  input: {
+    keyboard: {
+      on: (e: string, fn: Function, ctx?: unknown) => void;
+      off: (e: string, fn: Function, ctx?: unknown) => void;
+      _emit: (event: { code: string; preventDefault?: () => void }) => void;
+    };
+  };
+
+  children: {
+    list: MockGameObject[];
+    exists: (o: MockGameObject) => boolean;
+    removeFromList: (o: MockGameObject) => void;
+  };
+
+  add: {
+    container: (x?: number, y?: number) => MockContainer;
+    rectangle: (
+      x: number,
+      y: number,
+      w: number,
+      h: number,
+      color?: number,
+      alpha?: number,
+    ) => MockRectangle;
+    text: (x: number, y: number, t: string, _style?: unknown) => MockText;
+    image: (x: number, y: number, key: string) => MockImage;
+    nineslice: (
+      x: number,
+      y: number,
+      key: string,
+      _frame?: unknown,
+      w?: number,
+      h?: number,
+      _l?: number,
+      _r?: number,
+      _t?: number,
+      _b?: number,
+    ) => MockNineslice;
+    existing: <T extends MockGameObject>(o: T) => T;
+  };
+
+  tweens: {
+    add: (config: Record<string, unknown>) => MockTween;
+    _all: MockTween[];
+  };
+
+  time: {
+    delayedCall: (delay: number, cb: () => void) => MockTimerEvent;
+    _all: MockTimerEvent[];
+  };
+
+  constructor(width = 800, height = 600) {
+    this.cameras = { main: { width, height, zoom: 1 } };
+    this.scale = { width, height };
+
+    const textureSet = new Set<string>();
+    this.textures = {
+      exists: (k) => textureSet.has(k),
+      add: (k) => {
+        textureSet.add(k);
+      },
+      _set: textureSet,
+    };
+
+    const childList: MockGameObject[] = [];
+    this.children = {
+      list: childList,
+      exists: (o) => childList.includes(o),
+      removeFromList: (o) => {
+        const i = childList.indexOf(o);
+        if (i >= 0) childList.splice(i, 1);
+      },
+    };
+
+    const tweens: MockTween[] = [];
+    this.tweens = {
+      add: (config) => {
+        const t = makeTween(config);
+        tweens.push(t);
+        return t;
+      },
+      _all: tweens,
+    };
+
+    const timers: MockTimerEvent[] = [];
+    this.time = {
+      delayedCall: (delay, cb) => {
+        const t = new MockTimerEvent(delay, cb);
+        timers.push(t);
+        return t;
+      },
+      _all: timers,
+    };
+
+    const kbEmitter = new MiniEmitter();
+    this.input = {
+      keyboard: {
+        on: (e, fn, ctx) => {
+          kbEmitter.on(e, fn, ctx);
+        },
+        off: (e, fn, ctx) => {
+          kbEmitter.off(e, fn, ctx);
+        },
+        _emit: (event) => {
+          kbEmitter.emit("keydown", event);
+        },
+      },
+    };
+
+    const self = this;
+    this.add = {
+      container: (x = 0, y = 0) => {
+        const c = new MockContainer(self, x, y);
+        childList.push(c);
+        return c;
+      },
+      rectangle: (x, y, w, h, color, alpha) => {
+        const r = new MockRectangle(self, x, y, w, h, color, alpha);
+        childList.push(r);
+        return r;
+      },
+      text: (x, y, t) => {
+        const tx = new MockText(self, x, y, t);
+        childList.push(tx);
+        return tx;
+      },
+      image: (x, y, key) => {
+        const im = new MockImage(self, x, y, key);
+        childList.push(im);
+        return im;
+      },
+      nineslice: (x, y, key, _frame, w, h) => {
+        const n = new MockNineslice(self, x, y, key, w, h);
+        childList.push(n);
+        return n;
+      },
+      existing: (o) => {
+        if (!childList.includes(o)) childList.push(o);
+        return o;
+      },
+    };
+  }
+}
+
+export function createMockScene(width = 800, height = 600): MockScene {
+  return new MockScene(width, height);
+}
+
+// ─── vi.mock factory ────────────────────────────────────────────────────────
+/** Module factory for `vi.mock("phaser", phaserMockFactory)`. */
+export function phaserMockFactory() {
+  return {
+    GameObjects: {
+      Container: MockContainer,
+      Rectangle: MockRectangle,
+      Text: MockText,
+      Image: MockImage,
+      GameObject: MockGameObject,
+    },
+    Geom: {
+      Rectangle: class GeomRect {
+        x: number;
+        y: number;
+        w: number;
+        h: number;
+        constructor(x: number, y: number, w: number, h: number) {
+          this.x = x;
+          this.y = y;
+          this.w = w;
+          this.h = h;
+        }
+        static Contains(
+          rect: { x: number; y: number; w: number; h: number },
+          x: number,
+          y: number,
+        ): boolean {
+          return (
+            x >= rect.x &&
+            x <= rect.x + rect.w &&
+            y >= rect.y &&
+            y <= rect.y + rect.h
+          );
+        }
+      },
+    },
+    Math: {
+      Clamp: (v: number, lo: number, hi: number) =>
+        Math.max(lo, Math.min(hi, v)),
+    },
+    BlendModes: { ADD: 1, NORMAL: 0 },
+    Tweens: { Tween: class Tween {} },
+    Time: { TimerEvent: MockTimerEvent },
+    Input: { Pointer: class Pointer {} },
+    Events: { EventEmitter: MiniEmitter },
+  };
+}


### PR DESCRIPTION
## Summary

Adds the first feedback-tier component test suite for `packages/spacebiz-ui/` as work unit 10 of the 3-tier UI library plan.

- **53 new tests** across `Modal`, `Tooltip`, `FloatingText`, `StatusBadge`, `Starfield`, and `SceneUiDirector`.
- Adds a temporary inline Phaser stub at `packages/spacebiz-ui/src/__tests__/feedback/_phaserMock.ts` (mock scene + game objects + tweens + timers + keyboard emitter). The header documents that this is a stand-in for the formal `_harness/` from unit 6 — feedback tests should migrate when that harness lands.
- Each test file uses `vi.mock("phaser", async () => …)` so the components-under-test resolve against the mock without needing jsdom or a canvas polyfill.

Coverage highlights:
- **Modal**: open/close, backdrop click closes, ESC/Enter key handlers, OK-only vs OK+Cancel button rendering, callback firing, widget hook registration with `testId`, destroy unhooks the keyboard listener.
- **Tooltip**: starts hidden at depth 2000, delayed show on hover, position +12/+12 from pointer, label updates, border/bg auto-resize, detachFrom removes listeners.
- **FloatingText**: text spawning at coords, two-phase tween (pop → settle) with destroy on completion, `riseDistance`/`driftX`/`bounce`/`duration` honored, all four size keys.
- **StatusBadge**: variant→color mapping for all five variants, color overrides, label updates with and without variant swap, pulse tween only when requested, destroy stops pulse.
- **Starfield**: layer container per layer, star count matches config, `worldBounds` accepted, ambient tweens registered for shutdown cleanup, no tweens when all animation flags are off.
- **SceneUiDirector**: anonymous + keyed layer lifecycle, key collision destroys previous layer, `track`/`trackMany`, `onDestroy` callbacks fire once, `createOverlay` depth/size/`closeOnPointerUp`/`onPointerUp`/`activationDelayMs`, `closeAll`, scene shutdown propagation.

## Test plan

- [x] `npm run check` (typecheck + lint + format:check + test + build) passes — 948/948 tests, build succeeds.
- [x] No new lint errors (lint warnings already pervasive in the repo; the Modal test file silences the `sft/require-widget-testid` rule with an inline disable since it intentionally exercises both with-testId and without-testId construction paths).
- [x] No e2e — per the plan's worker recipe, test-only units skip e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)