### PR TITLE
feat(ui-tier-1): keyboard navigation and focus management for interactive components

### DIFF
--- a/packages/spacebiz-ui/docs/accessibility.md
+++ b/packages/spacebiz-ui/docs/accessibility.md
@@ -1,0 +1,99 @@
+# Accessibility (Tier 1 UI)
+
+This document describes the keyboard-focus model used by `@spacebiz/ui`
+components and how a consumer wires it into a Phaser scene.
+
+## Focus model
+
+There is exactly one focused widget per scene at any time. Focus is tracked by
+a per-scene `FocusManager` (in `foundation/FocusManager.ts`) which:
+
+- Keeps an ordered list of registered `Focusable` widgets.
+- Cycles focus on `Tab` (forward) and `Shift+Tab` (backward).
+- Skips widgets whose `isFocusable()` returns `false` (disabled / hidden).
+- Calls the widget's `focus()` / `blur()` methods so the widget can show or
+  hide its focus ring.
+
+Components that participate in focus implement the `Focusable` interface:
+
+```ts
+interface Focusable {
+  focus(): void;
+  blur(): void;
+  isFocusable(): boolean;
+}
+```
+
+The visible focus indicator is a 2 px ring drawn around the widget's bounds
+with a 2 px offset, using the theme's `focusRing.color`. All of these are
+configurable via `ThemeConfig.focusRing`:
+
+```ts
+focusRing: {
+  color: 0x33ffdd,
+  width: 2,
+  offset: 2,
+}
+```
+
+## Wiring up a scene
+
+`Button`, `Dropdown`, and `TabGroup` register themselves with the per-scene
+`FocusManager` automatically — there is nothing to wire up for the basic case.
+The manager is lazily created the first time any focusable widget asks for it
+and is torn down on scene shutdown.
+
+If you want to programmatically focus a specific widget (for example, the
+"Start Game" button on a menu screen), call `setFocus(true)`:
+
+```ts
+import { Button } from "@spacebiz/ui";
+
+const start = new Button(this, { x: 100, y: 100, label: "Start", onClick });
+start.setFocus(true);
+```
+
+To inspect or drive the focus directly (testing, custom flows):
+
+```ts
+import { FocusManager } from "@spacebiz/ui";
+
+const mgr = FocusManager.forScene(this);
+mgr.focusNext(); // Tab
+mgr.focusPrev(); // Shift+Tab
+mgr.setFocus(myWidget); // explicit
+mgr.getFocused(); // current
+```
+
+## Per-component keyboard shortcuts
+
+| Component  | Key                        | Behaviour                                          |
+| ---------- | -------------------------- | -------------------------------------------------- |
+| `Button`   | `Enter` or `Space`         | Activate when focused.                             |
+| `Modal`    | `Tab` / `Shift+Tab`        | Cycle focus among the modal's internal buttons.    |
+|            | `Enter` / `Space`          | Activate the focused button (defaults to OK).      |
+|            | `Escape`                   | Cancel and close (only when `closable !== false`). |
+| `Dropdown` | `Enter` or `Space`         | Toggle the option list open / commit selection.    |
+|            | `ArrowUp` / `ArrowDown`    | Open the list and move highlight.                  |
+|            | `Escape`                   | Close the list without committing.                 |
+| `TabGroup` | `ArrowLeft` / `ArrowRight` | Move to the previous / next tab.                   |
+|            | `Home` / `End`             | Jump to the first / last tab.                      |
+
+## Modal focus trap
+
+A `Modal` does not register with the scene-level `FocusManager`. Instead it
+runs its own focus trap so `Tab` cannot escape the modal while it is showing.
+The trap cycles among the close glyph (when `closable`), the OK button, and
+the Cancel button (when an `onCancel` is provided). Initial focus lands on the
+OK button so the most common interaction — confirm — only requires `Enter`.
+
+When `closable: false` is passed in the config, the close glyph is hidden,
+the overlay click is a no-op, and `Escape` is ignored.
+
+## Testing notes
+
+`FocusManager` is the source of truth and is exhaustively unit-tested
+(`packages/spacebiz-ui/src/__tests__/a11y/FocusManager.test.ts`). Component
+tests rely on the same `Focusable` contract, so any new widget can be unit
+tested by stubbing the scene's keyboard / events and asserting the manager
+state after key events.

--- a/packages/spacebiz-ui/src/Button.ts
+++ b/packages/spacebiz-ui/src/Button.ts
@@ -3,6 +3,11 @@ import { getTheme, colorToString } from "./Theme.ts";
 import { playUiSfx } from "./UiSound.ts";
 import { autoButtonWidth, fitTextWithEllipsis } from "./TextMetrics.ts";
 import { registerWidget, slugifyLabel } from "./WidgetHooks.ts";
+import {
+  FocusManager,
+  createFocusRing,
+  type Focusable,
+} from "./foundation/FocusManager.ts";
 
 export interface ButtonConfig {
   x: number;
@@ -43,16 +48,20 @@ export interface ButtonConfig {
   fontSize?: number;
 }
 
-export class Button extends Phaser.GameObjects.Container {
+export class Button extends Phaser.GameObjects.Container implements Focusable {
   private bg: Phaser.GameObjects.NineSlice;
   private label: Phaser.GameObjects.Text;
   private accentLine: Phaser.GameObjects.Rectangle;
+  private focusRing: Phaser.GameObjects.Rectangle | null = null;
   private hitZone: Phaser.GameObjects.Zone | null = null;
   private widthPx: number;
   private heightPx: number;
   private isDisabled: boolean;
+  private isFocused = false;
   private onClickFn: () => void;
   private idleShimmerTween: Phaser.Tweens.Tween | null = null;
+  private focusManager: FocusManager | null = null;
+  private keyHandler: ((event: KeyboardEvent) => void) | null = null;
   private readonly hitPaddingX = 10;
   private readonly hitPaddingY = 8;
 
@@ -131,13 +140,21 @@ export class Button extends Phaser.GameObjects.Container {
       .setOrigin(0, 0)
       .setAlpha(this.isDisabled ? 0.25 : 0.4);
 
-    this.add([this.bg, this.accentLine, this.label]);
+    // Focus ring — drawn behind everything else, hidden until focused.
+    this.focusRing = createFocusRing(scene, width, height);
+    this.add([this.focusRing, this.bg, this.accentLine, this.label]);
 
     if (!this.isDisabled) {
       this.setupInteractive();
     }
 
     scene.add.existing(this);
+
+    // Register with the scene's FocusManager so Tab can reach this button.
+    this.focusManager = FocusManager.forScene(scene);
+    this.focusManager.register(this);
+    this.keyHandler = (event: KeyboardEvent) => this.handleKey(event);
+    scene.input.keyboard?.on("keydown", this.keyHandler);
 
     const unregister = registerWidget({
       testId: config.testId ?? slugifyLabel(config.label, "button"),
@@ -240,11 +257,51 @@ export class Button extends Phaser.GameObjects.Container {
       this.hitZone.disableInteractive();
       this.label.setColor(colorToString(theme.colors.textDim));
       this.accentLine.setAlpha(0.25);
+      // Disabled buttons cannot be focused; drop focus if we had it.
+      if (this.isFocused) {
+        this.focusManager?.setFocus(null);
+      }
     } else {
       this.bg.setTexture("btn-normal");
       this.setupInteractive();
       this.label.setColor(colorToString(theme.colors.text));
       this.accentLine.setAlpha(0.4);
+    }
+  }
+
+  // ── Focusable ────────────────────────────────────────────────────────────
+
+  /** Programmatically focus or blur this button. */
+  setFocus(focused: boolean): void {
+    if (focused) {
+      this.focusManager?.setFocus(this);
+    } else if (this.isFocused) {
+      this.focusManager?.setFocus(null);
+    }
+  }
+
+  focus(): void {
+    if (this.isFocused) return;
+    this.isFocused = true;
+    this.focusRing?.setVisible(true);
+  }
+
+  blur(): void {
+    if (!this.isFocused) return;
+    this.isFocused = false;
+    this.focusRing?.setVisible(false);
+  }
+
+  isFocusable(): boolean {
+    return !this.isDisabled && this.visible && this.active;
+  }
+
+  private handleKey(event: KeyboardEvent): void {
+    if (!this.isFocused || this.isDisabled || !this.visible) return;
+    if (event.code === "Enter" || event.code === "Space") {
+      playUiSfx("ui_click_primary");
+      this.onClickFn();
+      event.preventDefault();
     }
   }
 
@@ -321,6 +378,12 @@ export class Button extends Phaser.GameObjects.Container {
       this.idleShimmerTween.stop();
       this.idleShimmerTween = null;
     }
+    if (this.keyHandler && this.scene) {
+      this.scene.input.keyboard?.off("keydown", this.keyHandler);
+      this.keyHandler = null;
+    }
+    this.focusManager?.unregister(this);
+    this.focusManager = null;
     this.hitZone?.destroy();
     this.hitZone = null;
     super.destroy(fromScene);

--- a/packages/spacebiz-ui/src/Dropdown.ts
+++ b/packages/spacebiz-ui/src/Dropdown.ts
@@ -1,6 +1,11 @@
 import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import { playUiSfx } from "./UiSound.ts";
+import {
+  FocusManager,
+  createFocusRing,
+  type Focusable,
+} from "./foundation/FocusManager.ts";
 
 export interface DropdownOption {
   label: string;
@@ -19,19 +24,28 @@ export interface DropdownConfig {
   fontSize?: number;
 }
 
-export class Dropdown extends Phaser.GameObjects.Container {
+export class Dropdown
+  extends Phaser.GameObjects.Container
+  implements Focusable
+{
   private bg: Phaser.GameObjects.Rectangle;
   private label: Phaser.GameObjects.Text;
   private arrow: Phaser.GameObjects.Text;
   private border: Phaser.GameObjects.Rectangle;
+  private focusRing: Phaser.GameObjects.Rectangle;
   private options: DropdownOption[];
   private selectedIndex: number;
+  private highlightedIndex = -1;
   private dropdownOpen = false;
   private overlayObjects: Phaser.GameObjects.GameObject[] = [];
+  private optionBgs: Phaser.GameObjects.Rectangle[] = [];
   private onChangeFn?: (value: string, index: number) => void;
   private widthPx: number;
   private heightPx: number;
   private fontSize: number;
+  private isFocused = false;
+  private focusManager: FocusManager | null = null;
+  private keyHandler: ((event: KeyboardEvent) => void) | null = null;
   /** Click-away listener registered on the canvas */
   private canvasClickHandler: ((e: MouseEvent) => void) | null = null;
 
@@ -112,13 +126,108 @@ export class Dropdown extends Phaser.GameObjects.Container {
       }
     });
 
+    // Focus ring
+    this.focusRing = createFocusRing(scene, this.widthPx, this.heightPx);
+    this.add(this.focusRing);
+
     this.setSize(this.widthPx, this.heightPx);
     scene.add.existing(this);
+
+    // Register with the scene's focus manager and listen for keys.
+    this.focusManager = FocusManager.forScene(scene);
+    this.focusManager.register(this);
+    this.keyHandler = (event: KeyboardEvent) => this.handleKey(event);
+    scene.input.keyboard?.on("keydown", this.keyHandler);
 
     // Cleanup on scene shutdown
     this.scene.events.once("shutdown", () => {
       this.closeDropdown();
     });
+  }
+
+  // ── Focusable ────────────────────────────────────────────────────────────
+
+  setFocus(focused: boolean): void {
+    if (focused) {
+      this.focusManager?.setFocus(this);
+    } else if (this.isFocused) {
+      this.focusManager?.setFocus(null);
+    }
+  }
+
+  focus(): void {
+    if (this.isFocused) return;
+    this.isFocused = true;
+    this.focusRing.setVisible(true);
+  }
+
+  blur(): void {
+    if (!this.isFocused) return;
+    this.isFocused = false;
+    this.focusRing.setVisible(false);
+    if (this.dropdownOpen) this.closeDropdown();
+  }
+
+  isFocusable(): boolean {
+    return this.visible && this.active;
+  }
+
+  private handleKey(event: KeyboardEvent): void {
+    if (!this.isFocused || !this.visible) return;
+    if (this.dropdownOpen) {
+      if (event.code === "ArrowDown") {
+        this.setHighlight(
+          (this.highlightedIndex + 1 + this.options.length) %
+            this.options.length,
+        );
+        event.preventDefault();
+      } else if (event.code === "ArrowUp") {
+        this.setHighlight(
+          (this.highlightedIndex - 1 + this.options.length) %
+            this.options.length,
+        );
+        event.preventDefault();
+      } else if (event.code === "Enter" || event.code === "Space") {
+        if (this.highlightedIndex >= 0) {
+          this.commitSelection(this.highlightedIndex);
+        }
+        event.preventDefault();
+      } else if (event.code === "Escape") {
+        this.closeDropdown();
+        event.preventDefault();
+      }
+    } else {
+      if (event.code === "Enter" || event.code === "Space") {
+        this.openDropdown();
+        event.preventDefault();
+      } else if (event.code === "ArrowDown" || event.code === "ArrowUp") {
+        this.openDropdown();
+        event.preventDefault();
+      }
+    }
+  }
+
+  private setHighlight(index: number): void {
+    const theme = getTheme();
+    if (this.highlightedIndex >= 0 && this.optionBgs[this.highlightedIndex]) {
+      this.optionBgs[this.highlightedIndex].setFillStyle(
+        this.highlightedIndex === this.selectedIndex
+          ? theme.colors.buttonHover
+          : theme.colors.headerBg,
+      );
+    }
+    this.highlightedIndex = index;
+    if (index >= 0 && this.optionBgs[index]) {
+      this.optionBgs[index].setFillStyle(theme.colors.rowHover);
+    }
+  }
+
+  private commitSelection(index: number): void {
+    playUiSfx("ui_click");
+    this.selectedIndex = index;
+    this.label.setText(this.options[index].label);
+    this.closeDropdown();
+    this.onChangeFn?.(this.options[index].value, index);
   }
 
   getSelectedIndex(): number {
@@ -139,6 +248,7 @@ export class Dropdown extends Phaser.GameObjects.Container {
     if (this.dropdownOpen) return;
     this.dropdownOpen = true;
     playUiSfx("ui_click");
+    this.optionBgs = [];
 
     const theme = getTheme();
     const optH = this.heightPx;
@@ -162,6 +272,7 @@ export class Dropdown extends Phaser.GameObjects.Container {
         .setOrigin(0, 0)
         .setDepth(1000);
       this.overlayObjects.push(optBg);
+      this.optionBgs.push(optBg);
 
       const optBorder = this.scene.add
         .rectangle(worldPos.tx, optY, this.widthPx, optH)
@@ -210,15 +321,13 @@ export class Dropdown extends Phaser.GameObjects.Container {
 
       const selectIdx = i; // capture
       optBg.on("pointerdown", () => {
-        playUiSfx("ui_click");
-        this.selectedIndex = selectIdx;
-        this.label.setText(this.options[selectIdx].label);
-        this.closeDropdown();
-        if (this.onChangeFn) {
-          this.onChangeFn(this.options[selectIdx].value, selectIdx);
-        }
+        this.commitSelection(selectIdx);
       });
     }
+
+    // Start keyboard highlight on the currently selected option.
+    this.highlightedIndex = -1;
+    this.setHighlight(this.selectedIndex);
 
     // Close when clicking outside — use a delayed listener so the current
     // click doesn't immediately fire it.
@@ -261,6 +370,8 @@ export class Dropdown extends Phaser.GameObjects.Container {
       obj.destroy();
     }
     this.overlayObjects = [];
+    this.optionBgs = [];
+    this.highlightedIndex = -1;
 
     if (this.canvasClickHandler) {
       this.scene.game.canvas.removeEventListener(
@@ -275,6 +386,12 @@ export class Dropdown extends Phaser.GameObjects.Container {
   }
 
   destroy(fromScene?: boolean): void {
+    if (this.keyHandler && this.scene) {
+      this.scene.input.keyboard?.off("keydown", this.keyHandler);
+      this.keyHandler = null;
+    }
+    this.focusManager?.unregister(this);
+    this.focusManager = null;
     this.closeDropdown();
     super.destroy(fromScene);
   }

--- a/packages/spacebiz-ui/src/Modal.ts
+++ b/packages/spacebiz-ui/src/Modal.ts
@@ -2,6 +2,7 @@ import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import { autoButtonWidth } from "./TextMetrics.ts";
 import { registerWidget } from "./WidgetHooks.ts";
+import { createFocusRing } from "./foundation/FocusManager.ts";
 
 export interface ModalConfig {
   title: string;
@@ -14,6 +15,16 @@ export interface ModalConfig {
   height?: number;
   /** Test id prefix. The modal registers `${testId}-ok`, `${testId}-cancel`, `${testId}-close`. */
   testId?: string;
+  /**
+   * When false, the modal cannot be dismissed by ESC, the close glyph, or
+   * clicking the overlay. Useful for blocking confirmations. Defaults to true.
+   */
+  closable?: boolean;
+}
+
+interface InternalFocusable {
+  ring: Phaser.GameObjects.Rectangle;
+  activate: () => void;
 }
 
 export class Modal extends Phaser.GameObjects.Container {
@@ -21,10 +32,14 @@ export class Modal extends Phaser.GameObjects.Container {
   private panel: Phaser.GameObjects.Container;
   private config: ModalConfig;
   private isShowing = false;
+  private internalFocusables: InternalFocusable[] = [];
+  private focusedIndex = -1;
+  private readonly closable: boolean;
 
   constructor(scene: Phaser.Scene, config: ModalConfig) {
     super(scene, 0, 0);
     this.config = config;
+    this.closable = config.closable !== false;
     const theme = getTheme();
 
     const gameWidth = scene.cameras.main.width;
@@ -38,6 +53,7 @@ export class Modal extends Phaser.GameObjects.Container {
       .setOrigin(0, 0)
       .setInteractive();
     this.overlay.on("pointerup", () => {
+      if (!this.closable) return;
       if (config.onCancel) {
         config.onCancel();
       }
@@ -116,21 +132,40 @@ export class Modal extends Phaser.GameObjects.Container {
         fontFamily: theme.fonts.heading.family,
         color: colorToString(theme.colors.textDim),
       })
-      .setOrigin(1, 0)
-      .setInteractive({ useHandCursor: true });
-    closeText.on("pointerover", () => {
-      closeText.setColor(colorToString(theme.colors.accent));
-    });
-    closeText.on("pointerout", () => {
-      closeText.setColor(colorToString(theme.colors.textDim));
-    });
-    closeText.on("pointerup", () => {
-      config.onCancel?.();
-      if (this.scene) {
-        this.hide();
-      }
-    });
+      .setOrigin(1, 0);
+    if (this.closable) {
+      closeText.setInteractive({ useHandCursor: true });
+      closeText.on("pointerover", () => {
+        closeText.setColor(colorToString(theme.colors.accent));
+      });
+      closeText.on("pointerout", () => {
+        closeText.setColor(colorToString(theme.colors.textDim));
+      });
+      closeText.on("pointerup", () => {
+        this.cancel();
+      });
+    } else {
+      closeText.setVisible(false);
+    }
     this.panel.add(closeText);
+
+    if (this.closable) {
+      // The close glyph is right-anchored, so use its bounds as the ring's
+      // top-left origin in panel-local space.
+      const closeBounds = closeText.getBounds();
+      const closeRing = createFocusRing(
+        scene,
+        closeBounds.width,
+        closeBounds.height,
+        closeBounds.x,
+        closeText.y,
+      );
+      this.panel.add(closeRing);
+      this.internalFocusables.push({
+        ring: closeRing,
+        activate: () => this.cancel(),
+      });
+    }
 
     // Body text
     const bodyText = scene.add.text(
@@ -229,7 +264,18 @@ export class Modal extends Phaser.GameObjects.Container {
       okLabel.setColor(colorToString(theme.colors.text));
     });
 
-    this.panel.add([okBg, okLabel]);
+    const okRing = createFocusRing(
+      scene,
+      buttonWidth,
+      buttonHeight,
+      okX,
+      buttonY,
+    );
+    this.panel.add([okBg, okLabel, okRing]);
+    this.internalFocusables.push({
+      ring: okRing,
+      activate: () => this.confirm(),
+    });
 
     // Cancel button (optional)
     if (hasCancelBtn) {
@@ -289,7 +335,18 @@ export class Modal extends Phaser.GameObjects.Container {
         cancelLabel.setColor(colorToString(theme.colors.textDim));
       });
 
-      this.panel.add([cancelBg, cancelLabel]);
+      const cancelRing = createFocusRing(
+        scene,
+        buttonWidth,
+        buttonHeight,
+        cancelX,
+        buttonY,
+      );
+      this.panel.add([cancelBg, cancelLabel, cancelRing]);
+      this.internalFocusables.push({
+        ring: cancelRing,
+        activate: () => this.cancel(),
+      });
     }
 
     this.add(this.panel);
@@ -361,30 +418,73 @@ export class Modal extends Phaser.GameObjects.Container {
   show(): void {
     this.isShowing = true;
     this.setVisible(true);
+    // Prefer the OK button so Enter immediately confirms. The internal
+    // focusables are pushed in order [close?, ok, cancel?]; OK is therefore
+    // index 1 when the modal is closable and index 0 otherwise.
+    const okIndex = this.closable ? 1 : 0;
+    if (this.internalFocusables[okIndex]) {
+      this.setFocusedIndex(okIndex);
+    }
   }
 
   hide(): void {
     this.isShowing = false;
     this.setVisible(false);
+    this.setFocusedIndex(-1);
+  }
+
+  private setFocusedIndex(index: number): void {
+    if (this.focusedIndex >= 0 && this.internalFocusables[this.focusedIndex]) {
+      this.internalFocusables[this.focusedIndex].ring.setVisible(false);
+    }
+    this.focusedIndex = index;
+    if (index >= 0 && this.internalFocusables[index]) {
+      this.internalFocusables[index].ring.setVisible(true);
+    }
+  }
+
+  private cycleFocus(direction: 1 | -1): void {
+    const n = this.internalFocusables.length;
+    if (n === 0) return;
+    const current = this.focusedIndex < 0 ? -1 : this.focusedIndex;
+    const next = (current + direction + n) % n;
+    this.setFocusedIndex(next);
+  }
+
+  private confirm(): void {
+    this.config.onOk?.();
+    if (this.scene) this.hide();
+  }
+
+  private cancel(): void {
+    if (!this.closable) return;
+    this.config.onCancel?.();
+    if (this.scene) this.hide();
   }
 
   private handleKeyDown(event: KeyboardEvent): void {
     if (!this.isShowing || !this.visible) return;
 
-    if (event.code === "Enter") {
-      this.config.onOk?.();
-      if (this.scene) {
-        this.hide();
+    if (event.code === "Tab") {
+      this.cycleFocus(event.shiftKey ? -1 : 1);
+      event.preventDefault();
+      return;
+    }
+
+    if (event.code === "Enter" || event.code === "Space") {
+      const focused = this.internalFocusables[this.focusedIndex];
+      if (focused) {
+        focused.activate();
+      } else {
+        this.confirm();
       }
       event.preventDefault();
       return;
     }
 
     if (event.code === "Escape") {
-      this.config.onCancel?.();
-      if (this.scene) {
-        this.hide();
-      }
+      if (!this.closable) return;
+      this.cancel();
       event.preventDefault();
     }
   }

--- a/packages/spacebiz-ui/src/TabGroup.ts
+++ b/packages/spacebiz-ui/src/TabGroup.ts
@@ -1,6 +1,11 @@
 import * as Phaser from "phaser";
 import { getTheme, colorToString } from "./Theme.ts";
 import { playUiSfx } from "./UiSound.ts";
+import {
+  FocusManager,
+  createFocusRing,
+  type Focusable,
+} from "./foundation/FocusManager.ts";
 
 export interface TabConfig {
   label: string;
@@ -16,12 +21,19 @@ export interface TabGroupConfig {
   defaultTab?: number;
 }
 
-export class TabGroup extends Phaser.GameObjects.Container {
+export class TabGroup
+  extends Phaser.GameObjects.Container
+  implements Focusable
+{
   private tabs: TabConfig[];
   private tabButtons: Phaser.GameObjects.Container[] = [];
   private activeIndex: number;
   private tabHeight: number;
   private tabGroupWidth: number;
+  private focusRing: Phaser.GameObjects.Rectangle | null = null;
+  private isFocused = false;
+  private focusManager: FocusManager | null = null;
+  private keyHandler: ((event: KeyboardEvent) => void) | null = null;
 
   constructor(scene: Phaser.Scene, config: TabGroupConfig) {
     super(scene, config.x, config.y);
@@ -131,7 +143,75 @@ export class TabGroup extends Phaser.GameObjects.Container {
       this.add(tab.content);
     });
 
+    // Focus ring sized to one tab; repositioned over the active tab.
+    this.focusRing = createFocusRing(scene, tabWidth, this.tabHeight);
+    this.add(this.focusRing);
+    this.positionFocusRing();
+
     scene.add.existing(this);
+
+    this.focusManager = FocusManager.forScene(scene);
+    this.focusManager.register(this);
+    this.keyHandler = (event: KeyboardEvent) => this.handleKey(event);
+    scene.input.keyboard?.on("keydown", this.keyHandler);
+  }
+
+  private positionFocusRing(): void {
+    if (!this.focusRing) return;
+    const tabWidth = this.tabGroupWidth / this.tabs.length;
+    const theme = getTheme();
+    const ringOffset = theme.focusRing.offset;
+    this.focusRing.setPosition(
+      tabWidth * this.activeIndex - ringOffset,
+      -ringOffset,
+    );
+  }
+
+  // ── Focusable ────────────────────────────────────────────────────────────
+
+  setFocus(focused: boolean): void {
+    if (focused) {
+      this.focusManager?.setFocus(this);
+    } else if (this.isFocused) {
+      this.focusManager?.setFocus(null);
+    }
+  }
+
+  focus(): void {
+    if (this.isFocused) return;
+    this.isFocused = true;
+    this.focusRing?.setVisible(true);
+  }
+
+  blur(): void {
+    if (!this.isFocused) return;
+    this.isFocused = false;
+    this.focusRing?.setVisible(false);
+  }
+
+  isFocusable(): boolean {
+    return this.visible && this.active && this.tabs.length > 0;
+  }
+
+  private handleKey(event: KeyboardEvent): void {
+    if (!this.isFocused || !this.visible) return;
+    let target = -1;
+    if (event.code === "ArrowRight") {
+      target = (this.activeIndex + 1) % this.tabs.length;
+    } else if (event.code === "ArrowLeft") {
+      target = (this.activeIndex - 1 + this.tabs.length) % this.tabs.length;
+    } else if (event.code === "Home") {
+      target = 0;
+    } else if (event.code === "End") {
+      target = this.tabs.length - 1;
+    } else {
+      return;
+    }
+    if (target !== this.activeIndex) {
+      playUiSfx("ui_tab_switch");
+      this.setActiveTab(target);
+    }
+    event.preventDefault();
   }
 
   setActiveTab(index: number): void {
@@ -145,6 +225,17 @@ export class TabGroup extends Phaser.GameObjects.Container {
     this.activeIndex = index;
     this.updateTabVisuals(index, true);
     this.tabs[index].content.setVisible(true);
+    this.positionFocusRing();
+  }
+
+  destroy(fromScene?: boolean): void {
+    if (this.keyHandler && this.scene) {
+      this.scene.input.keyboard?.off("keydown", this.keyHandler);
+      this.keyHandler = null;
+    }
+    this.focusManager?.unregister(this);
+    this.focusManager = null;
+    super.destroy(fromScene);
   }
 
   private updateTabVisuals(index: number, active: boolean): void {

--- a/packages/spacebiz-ui/src/Theme.ts
+++ b/packages/spacebiz-ui/src/Theme.ts
@@ -84,6 +84,16 @@ export interface ThemeConfig {
     /** Orbital decoration full-rotation duration (ms). */
     orbitalRotationDuration: number;
   };
+  /**
+   * Keyboard focus ring drawn around the currently focused widget.
+   * Width is the stroke thickness in pixels; offset is the gap between the
+   * widget bounds and the ring.
+   */
+  focusRing: {
+    color: number;
+    width: number;
+    offset: number;
+  };
 }
 
 export const DEFAULT_THEME: ThemeConfig = {
@@ -147,6 +157,11 @@ export const DEFAULT_THEME: ThemeConfig = {
     panelIdlePulseDuration: 4000,
     buttonIdleShimmerDuration: 3000,
     orbitalRotationDuration: 90000,
+  },
+  focusRing: {
+    color: 0x33ffdd,
+    width: 2,
+    offset: 2,
   },
 };
 

--- a/packages/spacebiz-ui/src/__tests__/a11y/FocusManager.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/a11y/FocusManager.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type * as Phaser from "phaser";
+import { FocusManager, type Focusable } from "../../foundation/FocusManager.ts";
+
+/** Minimal scene-like stub good enough for FocusManager. */
+function makeScene(): {
+  scene: Phaser.Scene;
+  fireKey: (event: KeyboardEvent) => void;
+  shutdown: () => void;
+} {
+  const keyListeners: Array<(event: KeyboardEvent) => void> = [];
+  const sceneListeners = new Map<string, Array<() => void>>();
+  const scene = {
+    input: {
+      keyboard: {
+        on: (_evt: string, fn: (event: KeyboardEvent) => void) => {
+          keyListeners.push(fn);
+        },
+        off: (_evt: string, fn: (event: KeyboardEvent) => void) => {
+          const idx = keyListeners.indexOf(fn);
+          if (idx >= 0) keyListeners.splice(idx, 1);
+        },
+      },
+    },
+    events: {
+      once: (evt: string, fn: () => void) => {
+        const list = sceneListeners.get(evt) ?? [];
+        list.push(fn);
+        sceneListeners.set(evt, list);
+      },
+    },
+  } as unknown as Phaser.Scene;
+  return {
+    scene,
+    fireKey: (event) => keyListeners.slice().forEach((fn) => fn(event)),
+    shutdown: () => {
+      const list = sceneListeners.get("shutdown") ?? [];
+      list.forEach((fn) => fn());
+    },
+  };
+}
+
+class FakeWidget implements Focusable {
+  focused = false;
+  enabled = true;
+  focusCalls = 0;
+  blurCalls = 0;
+  focus(): void {
+    this.focused = true;
+    this.focusCalls++;
+  }
+  blur(): void {
+    this.focused = false;
+    this.blurCalls++;
+  }
+  isFocusable(): boolean {
+    return this.enabled;
+  }
+}
+
+describe("FocusManager", () => {
+  let env: ReturnType<typeof makeScene>;
+  let mgr: FocusManager;
+
+  beforeEach(() => {
+    env = makeScene();
+    mgr = FocusManager.forScene(env.scene);
+  });
+
+  it("returns the same manager for repeated forScene() calls", () => {
+    const second = FocusManager.forScene(env.scene);
+    expect(second).toBe(mgr);
+  });
+
+  it("setFocus blurs the previous widget and focuses the next", () => {
+    const a = new FakeWidget();
+    const b = new FakeWidget();
+    mgr.register(a);
+    mgr.register(b);
+    mgr.setFocus(a);
+    expect(a.focused).toBe(true);
+    mgr.setFocus(b);
+    expect(a.focused).toBe(false);
+    expect(b.focused).toBe(true);
+    expect(mgr.getFocused()).toBe(b);
+  });
+
+  it("setFocus skips widgets that report not focusable", () => {
+    const a = new FakeWidget();
+    a.enabled = false;
+    mgr.register(a);
+    mgr.setFocus(a);
+    expect(a.focused).toBe(false);
+    expect(mgr.getFocused()).toBeNull();
+  });
+
+  it("focusNext cycles in registration order and wraps", () => {
+    const widgets = [new FakeWidget(), new FakeWidget(), new FakeWidget()];
+    widgets.forEach((w) => mgr.register(w));
+    mgr.focusNext();
+    expect(mgr.getFocused()).toBe(widgets[0]);
+    mgr.focusNext();
+    expect(mgr.getFocused()).toBe(widgets[1]);
+    mgr.focusNext();
+    expect(mgr.getFocused()).toBe(widgets[2]);
+    mgr.focusNext();
+    expect(mgr.getFocused()).toBe(widgets[0]);
+  });
+
+  it("focusPrev cycles backwards and wraps", () => {
+    const widgets = [new FakeWidget(), new FakeWidget(), new FakeWidget()];
+    widgets.forEach((w) => mgr.register(w));
+    mgr.focusPrev();
+    expect(mgr.getFocused()).toBe(widgets[2]);
+    mgr.focusPrev();
+    expect(mgr.getFocused()).toBe(widgets[1]);
+  });
+
+  it("focusNext skips disabled widgets", () => {
+    const a = new FakeWidget();
+    const b = new FakeWidget();
+    const c = new FakeWidget();
+    b.enabled = false;
+    [a, b, c].forEach((w) => mgr.register(w));
+    mgr.focusNext();
+    expect(mgr.getFocused()).toBe(a);
+    mgr.focusNext();
+    expect(mgr.getFocused()).toBe(c);
+  });
+
+  it("Tab keydown advances focus and Shift+Tab moves backwards", () => {
+    const a = new FakeWidget();
+    const b = new FakeWidget();
+    mgr.register(a);
+    mgr.register(b);
+    const tab = {
+      code: "Tab",
+      shiftKey: false,
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent;
+    env.fireKey(tab);
+    expect(mgr.getFocused()).toBe(a);
+    env.fireKey(tab);
+    expect(mgr.getFocused()).toBe(b);
+    const shiftTab = {
+      code: "Tab",
+      shiftKey: true,
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent;
+    env.fireKey(shiftTab);
+    expect(mgr.getFocused()).toBe(a);
+  });
+
+  it("non-Tab keys are ignored", () => {
+    const a = new FakeWidget();
+    mgr.register(a);
+    env.fireKey({
+      code: "Enter",
+      shiftKey: false,
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent);
+    expect(mgr.getFocused()).toBeNull();
+  });
+
+  it("unregister drops the widget and clears focus if it was focused", () => {
+    const a = new FakeWidget();
+    mgr.register(a);
+    mgr.setFocus(a);
+    mgr.unregister(a);
+    expect(mgr.getFocused()).toBeNull();
+    expect(mgr.getWidgets()).not.toContain(a);
+  });
+
+  it("destroy on scene shutdown blurs the focused widget", () => {
+    const a = new FakeWidget();
+    mgr.register(a);
+    mgr.setFocus(a);
+    expect(a.focused).toBe(true);
+    env.shutdown();
+    expect(a.focused).toBe(false);
+  });
+});

--- a/packages/spacebiz-ui/src/foundation/FocusManager.ts
+++ b/packages/spacebiz-ui/src/foundation/FocusManager.ts
@@ -1,0 +1,189 @@
+import type * as Phaser from "phaser";
+import { getTheme } from "../Theme.ts";
+
+/**
+ * Create a hidden focus-ring rectangle sized to wrap a widget of the given
+ * pixel bounds. The ring is drawn with theme-driven stroke color/width and
+ * sits `theme.focusRing.offset` pixels outside the widget on every side.
+ *
+ * Caller is responsible for adding the returned rectangle to a container
+ * (so it inherits the parent transform) and toggling visibility on
+ * focus / blur.
+ */
+export function createFocusRing(
+  scene: Phaser.Scene,
+  width: number,
+  height: number,
+  originX = 0,
+  originY = 0,
+): Phaser.GameObjects.Rectangle {
+  const theme = getTheme();
+  const offset = theme.focusRing.offset;
+  return scene.add
+    .rectangle(
+      originX - offset,
+      originY - offset,
+      width + offset * 2,
+      height + offset * 2,
+    )
+    .setOrigin(0, 0)
+    .setStrokeStyle(theme.focusRing.width, theme.focusRing.color)
+    .setFillStyle(0x000000, 0)
+    .setVisible(false);
+}
+
+/**
+ * Anything that participates in keyboard focus traversal.
+ *
+ * Components implement this so the {@link FocusManager} can move focus among
+ * them with Tab/Shift+Tab. Implementations are responsible for showing /
+ * hiding their focus ring inside `focus()` / `blur()`.
+ */
+export interface Focusable {
+  /** Mark this widget as focused (show focus ring, accept key input). */
+  focus(): void;
+  /** Mark this widget as no longer focused (hide focus ring). */
+  blur(): void;
+  /**
+   * Return true when this widget is currently eligible for focus
+   * (visible, enabled, attached to the scene). Disabled or hidden widgets
+   * should return false so the manager skips over them.
+   */
+  isFocusable(): boolean;
+}
+
+/**
+ * Per-scene keyboard focus tracker.
+ *
+ * The manager owns:
+ *   - The set of {@link Focusable} widgets registered against the scene.
+ *   - The currently focused widget (or `null`).
+ *   - A keyboard listener that handles Tab / Shift+Tab traversal.
+ *
+ * Use {@link FocusManager.forScene} to retrieve the scene-scoped instance.
+ * One manager is lazily created per scene and torn down on scene shutdown.
+ */
+export class FocusManager {
+  private static readonly registry = new WeakMap<Phaser.Scene, FocusManager>();
+
+  private readonly widgets: Focusable[] = [];
+  private focused: Focusable | null = null;
+  private destroyed = false;
+  private readonly scene: Phaser.Scene;
+  private readonly keyHandler: (event: KeyboardEvent) => void;
+
+  private constructor(scene: Phaser.Scene) {
+    this.scene = scene;
+    this.keyHandler = (event: KeyboardEvent) => this.handleKey(event);
+    scene.input.keyboard?.on("keydown", this.keyHandler);
+    scene.events.once("shutdown", () => this.destroy());
+    scene.events.once("destroy", () => this.destroy());
+  }
+
+  /**
+   * Get (or lazily create) the FocusManager for the given scene.
+   * Returns `null` on already-destroyed scenes.
+   */
+  static forScene(scene: Phaser.Scene): FocusManager {
+    let mgr = FocusManager.registry.get(scene);
+    if (!mgr) {
+      mgr = new FocusManager(scene);
+      FocusManager.registry.set(scene, mgr);
+    }
+    return mgr;
+  }
+
+  /** Test-only: discard any cached manager for the given scene. */
+  static reset(scene: Phaser.Scene): void {
+    const existing = FocusManager.registry.get(scene);
+    if (existing) {
+      existing.destroy();
+      FocusManager.registry.delete(scene);
+    }
+  }
+
+  register(widget: Focusable): void {
+    if (this.destroyed) return;
+    if (!this.widgets.includes(widget)) {
+      this.widgets.push(widget);
+    }
+  }
+
+  unregister(widget: Focusable): void {
+    const idx = this.widgets.indexOf(widget);
+    if (idx >= 0) this.widgets.splice(idx, 1);
+    if (this.focused === widget) {
+      this.focused = null;
+    }
+  }
+
+  /** Currently focused widget, or `null`. */
+  getFocused(): Focusable | null {
+    return this.focused;
+  }
+
+  /** All registered widgets, in insertion (tab) order. */
+  getWidgets(): readonly Focusable[] {
+    return this.widgets;
+  }
+
+  /**
+   * Focus a specific widget. Blurs the previous one. No-op if `widget` is
+   * not currently focusable.
+   */
+  setFocus(widget: Focusable | null): void {
+    if (this.focused === widget) return;
+    if (widget && !widget.isFocusable()) return;
+    if (this.focused) {
+      this.focused.blur();
+    }
+    this.focused = widget;
+    if (widget) widget.focus();
+  }
+
+  /** Move focus to the next focusable widget. Wraps around. */
+  focusNext(): void {
+    this.cycle(1);
+  }
+
+  /** Move focus to the previous focusable widget. Wraps around. */
+  focusPrev(): void {
+    this.cycle(-1);
+  }
+
+  private cycle(direction: 1 | -1): void {
+    const focusable = this.widgets.filter((w) => w.isFocusable());
+    if (focusable.length === 0) {
+      this.setFocus(null);
+      return;
+    }
+    let startIdx = this.focused ? focusable.indexOf(this.focused) : -1;
+    if (startIdx < 0) {
+      startIdx = direction === 1 ? -1 : 0;
+    }
+    const next =
+      focusable[(startIdx + direction + focusable.length) % focusable.length];
+    this.setFocus(next);
+  }
+
+  private handleKey(event: KeyboardEvent): void {
+    if (this.destroyed) return;
+    if (event.code !== "Tab") return;
+    if (event.shiftKey) {
+      this.focusPrev();
+    } else {
+      this.focusNext();
+    }
+    event.preventDefault();
+  }
+
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.scene.input.keyboard?.off("keydown", this.keyHandler);
+    if (this.focused) this.focused.blur();
+    this.focused = null;
+    this.widgets.length = 0;
+    FocusManager.registry.delete(this.scene);
+  }
+}

--- a/packages/spacebiz-ui/src/index.ts
+++ b/packages/spacebiz-ui/src/index.ts
@@ -18,6 +18,9 @@ export * from "./Layout.ts";
 export * from "./DepthLayers.ts";
 export * from "./TextMetrics.ts";
 
+export { FocusManager } from "./foundation/FocusManager.ts";
+export type { Focusable } from "./foundation/FocusManager.ts";
+
 // Sound registration (call once at game boot)
 export { registerUiSoundHandler } from "./UiSound.ts";
 export type { UiSoundHandler } from "./UiSound.ts";


### PR DESCRIPTION
## Summary
- Adds a per-scene `FocusManager` and `Focusable` contract; widgets register themselves on construction and unregister on destroy. Tab / Shift+Tab cycle focus through all registered widgets and skip disabled / hidden ones.
- Adds theme-driven focus rings (`theme.focusRing.color | width | offset`) to `Button`, `Dropdown`, and `TabGroup`. Modal owns its own focus trap so Tab cannot escape the dialog while it's showing.
- Wires the spec'd keyboard shortcuts: Button (Enter / Space), Modal (Tab cycle + Enter / ESC), Dropdown (Enter / Space toggle, arrows navigate, ESC close), TabGroup (Left / Right / Home / End).
- New unit tests in `packages/spacebiz-ui/src/__tests__/a11y/FocusManager.test.ts` covering registration, cycling, disabled-skip, key handling, and shutdown teardown.
- New accessibility docs at `packages/spacebiz-ui/docs/accessibility.md`.

Slider / Checkbox aren't included because Unit 2 has not landed yet (per the unit's "if has landed" guard).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (0 errors; pre-existing warnings unchanged)
- [x] `npm run format:check`
- [x] `npm run test` — 906 passing (10 new)
- [x] `npm run build`
- [x] `npm run test:e2e` — 8 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)