### PR TITLE
feat(ui-tier-1): add layout primitives (HSizer/VSizer/GridSizer/FixWidthSizer/Anchor/ResizeHost)

### DIFF
--- a/packages/spacebiz-ui/src/index.ts
+++ b/packages/spacebiz-ui/src/index.ts
@@ -18,6 +18,9 @@ export * from "./Layout.ts";
 export * from "./DepthLayers.ts";
 export * from "./TextMetrics.ts";
 
+// Layout primitives (Sizer-style flex containers + resize contract)
+export * from "./layout/index.ts";
+
 // Sound registration (call once at game boot)
 export { registerUiSoundHandler } from "./UiSound.ts";
 export type { UiSoundHandler } from "./UiSound.ts";

--- a/packages/spacebiz-ui/src/layout/Anchor.ts
+++ b/packages/spacebiz-ui/src/layout/Anchor.ts
@@ -1,0 +1,84 @@
+import * as Phaser from "phaser";
+import { computeAnchor } from "./anchorMath.ts";
+import { applyChildSize, placeChild, readChildSize } from "./sizerBase.ts";
+import type { AnchorFill, AnchorPosition, Insets, Resizable } from "./types.ts";
+import { normalizeInsets } from "./types.ts";
+import type { LayoutMetrics } from "../Layout.ts";
+
+export interface AnchorConfig {
+  to: AnchorPosition;
+  offset?: { x?: number; y?: number };
+  fill?: AnchorFill;
+  insets?: number | Partial<Insets>;
+  /** Initial parent size; updated via onLayout / setParentSize. */
+  parentWidth?: number;
+  parentHeight?: number;
+}
+
+/**
+ * Pin a single child to a corner/edge/center of a parent box.
+ */
+export class Anchor extends Phaser.GameObjects.Container implements Resizable {
+  private to: AnchorPosition;
+  private offset: { x?: number; y?: number };
+  private fill: AnchorFill | undefined;
+  private insets: Insets;
+  private parentWidth: number;
+  private parentHeight: number;
+  private target: Phaser.GameObjects.GameObject | null = null;
+
+  constructor(scene: Phaser.Scene, config: AnchorConfig) {
+    super(scene, 0, 0);
+    this.to = config.to;
+    this.offset = config.offset ?? {};
+    this.fill = config.fill;
+    this.insets = normalizeInsets(config.insets ?? 0);
+    this.parentWidth = config.parentWidth ?? scene.scale.width;
+    this.parentHeight = config.parentHeight ?? scene.scale.height;
+    scene.add.existing(this);
+  }
+
+  add(
+    child: Phaser.GameObjects.GameObject | Phaser.GameObjects.GameObject[],
+  ): this {
+    const items = Array.isArray(child) ? child : [child];
+    for (const item of items) {
+      super.add(item);
+      this.target = item;
+    }
+    this.apply();
+    return this;
+  }
+
+  setParentSize(width: number, height: number): this {
+    this.parentWidth = width;
+    this.parentHeight = height;
+    this.apply();
+    return this;
+  }
+
+  onLayout(metrics: LayoutMetrics): void {
+    this.parentWidth = metrics.gameWidth;
+    this.parentHeight = metrics.gameHeight;
+    this.apply();
+  }
+
+  private apply(): void {
+    if (!this.target) return;
+    const size = readChildSize(this.target);
+    const result = computeAnchor({
+      parentWidth: this.parentWidth,
+      parentHeight: this.parentHeight,
+      childWidth: size.width,
+      childHeight: size.height,
+      to: this.to,
+      offset: this.offset,
+      fill: this.fill,
+      insets: this.insets,
+    });
+    if (this.fill) {
+      applyChildSize(this.target, result.width, result.height);
+    }
+    placeChild(this.target, result.x, result.y);
+  }
+}

--- a/packages/spacebiz-ui/src/layout/FixWidthSizer.ts
+++ b/packages/spacebiz-ui/src/layout/FixWidthSizer.ts
@@ -1,0 +1,108 @@
+import * as Phaser from "phaser";
+import { computeWrap } from "./wrapMath.ts";
+import { placeChild, readChildSize } from "./sizerBase.ts";
+import type { Insets, Resizable } from "./types.ts";
+import { normalizeInsets } from "./types.ts";
+import type { LayoutMetrics } from "../Layout.ts";
+
+export interface FixWidthSizerConfig {
+  x?: number;
+  y?: number;
+  width: number;
+  height?: number;
+  columnGap?: number;
+  rowGap?: number;
+  hAlign?: "start" | "center" | "end";
+  padding?: number | Partial<Insets>;
+}
+
+export class FixWidthSizer
+  extends Phaser.GameObjects.Container
+  implements Resizable
+{
+  private fixedWidth: number;
+  private fixedHeight: number | null;
+  private columnGap: number;
+  private rowGap: number;
+  private hAlign: "start" | "center" | "end";
+  private padding: Insets;
+  private entries: Phaser.GameObjects.GameObject[] = [];
+  private contentWidth = 0;
+  private contentHeight = 0;
+
+  constructor(scene: Phaser.Scene, config: FixWidthSizerConfig) {
+    super(scene, config.x ?? 0, config.y ?? 0);
+    this.fixedWidth = config.width;
+    this.fixedHeight = config.height ?? null;
+    this.columnGap = config.columnGap ?? 0;
+    this.rowGap = config.rowGap ?? 0;
+    this.hAlign = config.hAlign ?? "start";
+    this.padding = normalizeInsets(config.padding ?? 0);
+    super.setSize(this.fixedWidth, this.fixedHeight ?? 0);
+    scene.add.existing(this);
+  }
+
+  add(
+    child: Phaser.GameObjects.GameObject | Phaser.GameObjects.GameObject[],
+  ): this {
+    const items = Array.isArray(child) ? child : [child];
+    for (const item of items) {
+      super.add(item);
+      this.entries.push(item);
+    }
+    this.layout();
+    return this;
+  }
+
+  remove<T extends Phaser.GameObjects.GameObject>(
+    child: T | T[],
+    destroyChild?: boolean,
+  ): this {
+    const list = Array.isArray(child) ? child : [child];
+    super.remove(child, destroyChild);
+    this.entries = this.entries.filter((c) => !list.includes(c as T));
+    this.layout();
+    return this;
+  }
+
+  setSize(width: number, height: number): this {
+    this.fixedWidth = width;
+    this.fixedHeight = height;
+    super.setSize(width, height);
+    this.layout();
+    return this;
+  }
+
+  onLayout(_metrics: LayoutMetrics): void {
+    this.layout();
+  }
+
+  layout(): void {
+    const padH = this.padding.left + this.padding.right;
+    const padV = this.padding.top + this.padding.bottom;
+    const measured = this.entries.map((c) => readChildSize(c));
+    const result = computeWrap({
+      containerWidth: Math.max(0, this.fixedWidth - padH),
+      columnGap: this.columnGap,
+      rowGap: this.rowGap,
+      children: measured,
+      hAlign: this.hAlign,
+    });
+
+    for (let i = 0; i < this.entries.length; i++) {
+      placeChild(
+        this.entries[i],
+        this.padding.left + result.positions[i].x,
+        this.padding.top + result.positions[i].y,
+      );
+    }
+
+    this.contentWidth = this.fixedWidth;
+    this.contentHeight = (this.fixedHeight ?? result.totalHeight) + padV;
+    super.setSize(this.fixedWidth, this.contentHeight);
+  }
+
+  getContentSize(): { width: number; height: number } {
+    return { width: this.contentWidth, height: this.contentHeight };
+  }
+}

--- a/packages/spacebiz-ui/src/layout/GridSizer.ts
+++ b/packages/spacebiz-ui/src/layout/GridSizer.ts
@@ -1,0 +1,199 @@
+import * as Phaser from "phaser";
+import { applyChildSize, placeChild, readChildSize } from "./sizerBase.ts";
+import { placeGrid, spanSize, trackOffset } from "./gridMath.ts";
+import type {
+  GridChildOptions,
+  HAlign,
+  Insets,
+  Resizable,
+  VAlign,
+} from "./types.ts";
+import { normalizeInsets } from "./types.ts";
+import type { LayoutMetrics } from "../Layout.ts";
+
+export interface GridSizerConfig {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  columns: number;
+  rows?: number;
+  columnGap?: number;
+  rowGap?: number;
+  hAlign?: HAlign;
+  vAlign?: VAlign;
+  padding?: number | Partial<Insets>;
+}
+
+interface ChildEntry {
+  child: Phaser.GameObjects.GameObject;
+  options: GridChildOptions;
+}
+
+export class GridSizer
+  extends Phaser.GameObjects.Container
+  implements Resizable
+{
+  private columns: number;
+  private rows: number | undefined;
+  private columnGap: number;
+  private rowGap: number;
+  private hAlign: HAlign;
+  private vAlign: VAlign;
+  private padding: Insets;
+  private fixedWidth: number | null;
+  private fixedHeight: number | null;
+  private entries: ChildEntry[] = [];
+  private contentWidth = 0;
+  private contentHeight = 0;
+
+  constructor(scene: Phaser.Scene, config: GridSizerConfig) {
+    super(scene, config.x ?? 0, config.y ?? 0);
+    this.columns = Math.max(1, config.columns);
+    this.rows = config.rows;
+    this.columnGap = config.columnGap ?? 0;
+    this.rowGap = config.rowGap ?? 0;
+    this.hAlign = config.hAlign ?? "left";
+    this.vAlign = config.vAlign ?? "top";
+    this.padding = normalizeInsets(config.padding ?? 0);
+    this.fixedWidth = config.width ?? null;
+    this.fixedHeight = config.height ?? null;
+    if (this.fixedWidth !== null && this.fixedHeight !== null) {
+      super.setSize(this.fixedWidth, this.fixedHeight);
+    }
+    scene.add.existing(this);
+  }
+
+  add(
+    child: Phaser.GameObjects.GameObject | Phaser.GameObjects.GameObject[],
+    options?: GridChildOptions,
+  ): this {
+    const items = Array.isArray(child) ? child : [child];
+    for (const item of items) {
+      super.add(item);
+      this.entries.push({ child: item, options: options ?? {} });
+    }
+    this.layout();
+    return this;
+  }
+
+  remove<T extends Phaser.GameObjects.GameObject>(
+    child: T | T[],
+    destroyChild?: boolean,
+  ): this {
+    const list = Array.isArray(child) ? child : [child];
+    super.remove(child, destroyChild);
+    this.entries = this.entries.filter((e) => !list.includes(e.child as T));
+    this.layout();
+    return this;
+  }
+
+  setSize(width: number, height: number): this {
+    this.fixedWidth = width;
+    this.fixedHeight = height;
+    super.setSize(width, height);
+    this.layout();
+    return this;
+  }
+
+  onLayout(_metrics: LayoutMetrics): void {
+    this.layout();
+  }
+
+  layout(): void {
+    const padH = this.padding.left + this.padding.right;
+    const padV = this.padding.top + this.padding.bottom;
+
+    const measured = this.entries.map((e) => readChildSize(e.child));
+    const result = placeGrid({
+      columns: this.columns,
+      rows: this.rows,
+      columnGap: this.columnGap,
+      rowGap: this.rowGap,
+      children: this.entries.map((e, i) => ({
+        width: measured[i].width,
+        height: measured[i].height,
+        colspan: e.options.colspan ?? 1,
+        rowspan: e.options.rowspan ?? 1,
+      })),
+    });
+
+    let cols = result.columnWidths.slice();
+    let rows = result.rowHeights.slice();
+
+    if (this.fixedWidth !== null) {
+      const usable = Math.max(0, this.fixedWidth - padH);
+      const natural = result.totalWidth;
+      if (natural > 0 && usable !== natural) {
+        const ratio = usable / natural;
+        cols = cols.map((w) => w * ratio);
+      }
+    }
+    if (this.fixedHeight !== null) {
+      const usable = Math.max(0, this.fixedHeight - padV);
+      const natural = result.totalHeight;
+      if (natural > 0 && usable !== natural) {
+        const ratio = usable / natural;
+        rows = rows.map((h) => h * ratio);
+      }
+    }
+
+    for (let i = 0; i < this.entries.length; i++) {
+      const entry = this.entries[i];
+      const place = result.placements[i];
+      const cellX = trackOffset(cols, this.columnGap, place.col);
+      const cellY = trackOffset(rows, this.rowGap, place.row);
+      const cellW = spanSize(cols, this.columnGap, place.col, place.colspan);
+      const cellH = spanSize(rows, this.rowGap, place.row, place.rowspan);
+
+      const hAlign = entry.options.hAlign ?? this.hAlign;
+      const vAlign = entry.options.vAlign ?? this.vAlign;
+
+      let drawW = measured[i].width;
+      let drawH = measured[i].height;
+      let dx = 0;
+      let dy = 0;
+      if (hAlign === "stretch") {
+        drawW = cellW;
+      } else if (hAlign === "center") {
+        dx = (cellW - drawW) / 2;
+      } else if (hAlign === "right") {
+        dx = cellW - drawW;
+      }
+      if (vAlign === "stretch") {
+        drawH = cellH;
+      } else if (vAlign === "center") {
+        dy = (cellH - drawH) / 2;
+      } else if (vAlign === "bottom") {
+        dy = cellH - drawH;
+      }
+      if (hAlign === "stretch" || vAlign === "stretch") {
+        applyChildSize(entry.child, drawW, drawH);
+      }
+      placeChild(
+        entry.child,
+        this.padding.left + cellX + dx,
+        this.padding.top + cellY + dy,
+      );
+    }
+
+    const totalW =
+      cols.reduce((a, b) => a + b, 0) +
+      this.columnGap * Math.max(0, cols.length - 1);
+    const totalH =
+      rows.reduce((a, b) => a + b, 0) +
+      this.rowGap * Math.max(0, rows.length - 1);
+    this.contentWidth = totalW + padH;
+    this.contentHeight = totalH + padV;
+    if (this.fixedWidth === null || this.fixedHeight === null) {
+      super.setSize(
+        this.fixedWidth ?? this.contentWidth,
+        this.fixedHeight ?? this.contentHeight,
+      );
+    }
+  }
+
+  getContentSize(): { width: number; height: number } {
+    return { width: this.contentWidth, height: this.contentHeight };
+  }
+}

--- a/packages/spacebiz-ui/src/layout/HSizer.ts
+++ b/packages/spacebiz-ui/src/layout/HSizer.ts
@@ -1,0 +1,163 @@
+import * as Phaser from "phaser";
+import { computeFlex, alignCross } from "./flexMath.ts";
+import { applyChildSize, placeChild, readChildSize } from "./sizerBase.ts";
+import type {
+  Insets,
+  Justify,
+  Resizable,
+  SizerChildOptions,
+  VAlign,
+} from "./types.ts";
+import { normalizeInsets } from "./types.ts";
+import type { LayoutMetrics } from "../Layout.ts";
+
+export interface HSizerConfig {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  gap?: number;
+  align?: VAlign;
+  justify?: Justify;
+  padding?: number | Partial<Insets>;
+}
+
+interface ChildEntry {
+  child: Phaser.GameObjects.GameObject;
+  options: SizerChildOptions;
+}
+
+export class HSizer extends Phaser.GameObjects.Container implements Resizable {
+  private gap: number;
+  private align: VAlign;
+  private justify: Justify;
+  private padding: Insets;
+  private fixedWidth: number | null;
+  private fixedHeight: number | null;
+  private entries: ChildEntry[] = [];
+  private contentWidth = 0;
+  private contentHeight = 0;
+
+  constructor(scene: Phaser.Scene, config: HSizerConfig = {}) {
+    super(scene, config.x ?? 0, config.y ?? 0);
+    this.gap = config.gap ?? 0;
+    this.align = config.align ?? "top";
+    this.justify = config.justify ?? "start";
+    this.padding = normalizeInsets(config.padding ?? 0);
+    this.fixedWidth = config.width ?? null;
+    this.fixedHeight = config.height ?? null;
+    if (this.fixedWidth !== null && this.fixedHeight !== null) {
+      super.setSize(this.fixedWidth, this.fixedHeight);
+    }
+    scene.add.existing(this);
+  }
+
+  add(
+    child: Phaser.GameObjects.GameObject | Phaser.GameObjects.GameObject[],
+    options?: SizerChildOptions,
+  ): this {
+    const items = Array.isArray(child) ? child : [child];
+    for (const item of items) {
+      super.add(item);
+      this.entries.push({ child: item, options: options ?? {} });
+    }
+    this.layout();
+    return this;
+  }
+
+  remove<T extends Phaser.GameObjects.GameObject>(
+    child: T | T[],
+    destroyChild?: boolean,
+  ): this {
+    const list = Array.isArray(child) ? child : [child];
+    super.remove(child, destroyChild);
+    this.entries = this.entries.filter((e) => !list.includes(e.child as T));
+    this.layout();
+    return this;
+  }
+
+  setSize(width: number, height: number): this {
+    this.fixedWidth = width;
+    this.fixedHeight = height;
+    super.setSize(width, height);
+    this.layout();
+    return this;
+  }
+
+  onLayout(_metrics: LayoutMetrics): void {
+    this.layout();
+  }
+
+  layout(): void {
+    const padH = this.padding.left + this.padding.right;
+    const padV = this.padding.top + this.padding.bottom;
+
+    const measured = this.entries.map((e) => readChildSize(e.child));
+    const containerW =
+      this.fixedWidth !== null
+        ? Math.max(0, this.fixedWidth - padH)
+        : measured.reduce((a, m) => a + m.width, 0) +
+          this.gap * Math.max(0, measured.length - 1);
+
+    const flex = computeFlex({
+      containerSize: containerW,
+      gap: this.gap,
+      justify: this.justify,
+      children: this.entries.map((e) => ({
+        width: 0,
+        height: 0,
+        flex: e.options.flex,
+      })),
+      mainSizes: measured.map((m) => m.width),
+    });
+
+    const tallest = measured.reduce((max, m) => Math.max(max, m.height), 0);
+    const containerH =
+      this.fixedHeight !== null
+        ? Math.max(0, this.fixedHeight - padV)
+        : tallest;
+
+    for (let i = 0; i < this.entries.length; i++) {
+      const entry = this.entries[i];
+      const childAlign = (entry.options.align ?? this.align) as
+        | "top"
+        | "center"
+        | "bottom"
+        | "stretch";
+      const crossAlign =
+        childAlign === "top"
+          ? "start"
+          : childAlign === "bottom"
+            ? "end"
+            : childAlign;
+      const cross = alignCross(measured[i].height, containerH, crossAlign);
+      const flexed = (entry.options.flex ?? 0) > 0;
+      const stretched = childAlign === "stretch";
+      if (flexed || stretched) {
+        applyChildSize(
+          entry.child,
+          flexed ? flex.sizes[i] : measured[i].width,
+          stretched ? cross.size : measured[i].height,
+        );
+      }
+      placeChild(
+        entry.child,
+        this.padding.left + flex.positions[i],
+        this.padding.top + cross.offset,
+      );
+    }
+
+    this.contentWidth = containerW + padH;
+    this.contentHeight = containerH + padV;
+    if (this.fixedWidth === null || this.fixedHeight === null) {
+      super.setSize(
+        this.fixedWidth ?? this.contentWidth,
+        this.fixedHeight ?? this.contentHeight,
+      );
+    }
+  }
+
+  getContentSize(): { width: number; height: number } {
+    return { width: this.contentWidth, height: this.contentHeight };
+  }
+}

--- a/packages/spacebiz-ui/src/layout/ResizeHost.ts
+++ b/packages/spacebiz-ui/src/layout/ResizeHost.ts
@@ -1,0 +1,121 @@
+import { getLayout, updateLayout } from "../Layout.ts";
+import type { LayoutMetrics } from "../Layout.ts";
+import type { Resizable } from "./types.ts";
+
+// Phaser scene-event identifiers, declared as literals so this module can be
+// imported in a node test environment without pulling in Phaser (which needs
+// `window`). They mirror Phaser.Scenes.Events.SHUTDOWN / DESTROY.
+const SCENE_SHUTDOWN = "shutdown";
+const SCENE_DESTROY = "destroy";
+
+// Minimal Phaser scene shape that ResizeHost actually relies on. Avoids a
+// hard import of Phaser at module load.
+interface ResizeHostScene {
+  scale: {
+    width: number;
+    height: number;
+    gameSize: { width: number; height: number };
+    on(
+      event: "resize",
+      fn: (size: { width: number; height: number }) => void,
+    ): unknown;
+    off(
+      event: "resize",
+      fn: (size: { width: number; height: number }) => void,
+    ): unknown;
+  };
+  events: {
+    once(event: string, fn: () => void): unknown;
+  };
+}
+
+const HOST_KEY = "__spacebiz_resize_host__";
+
+type ResizeCallback = (metrics: LayoutMetrics) => void;
+
+interface ResizeHostState {
+  resizables: Set<Resizable>;
+  callbacks: Set<ResizeCallback>;
+  handler: (gameSize: { width: number; height: number }) => void;
+  shutdown: () => void;
+}
+
+type SceneWithHost = ResizeHostScene & { [HOST_KEY]?: ResizeHostState };
+
+export class ResizeHost {
+  private constructor() {}
+
+  /** Get or create the per-scene ResizeHost state. */
+  static attach(scene: ResizeHostScene): ResizeHostState {
+    const sc = scene as SceneWithHost;
+    const existing = sc[HOST_KEY];
+    if (existing) return existing;
+
+    const state: ResizeHostState = {
+      resizables: new Set(),
+      callbacks: new Set(),
+      handler: (gameSize) => {
+        updateLayout(gameSize.width, gameSize.height);
+        const metrics = getLayout();
+        for (const r of state.resizables) {
+          try {
+            r.onLayout(metrics);
+          } catch (err) {
+            console.error("[ResizeHost] resizable.onLayout threw:", err);
+          }
+        }
+        for (const cb of state.callbacks) {
+          try {
+            cb(metrics);
+          } catch (err) {
+            console.error("[ResizeHost] callback threw:", err);
+          }
+        }
+      },
+      shutdown: () => {
+        scene.scale.off("resize", state.handler);
+        state.resizables.clear();
+        state.callbacks.clear();
+        delete sc[HOST_KEY];
+      },
+    };
+
+    scene.scale.on("resize", state.handler);
+    scene.events.once(SCENE_SHUTDOWN, state.shutdown);
+    scene.events.once(SCENE_DESTROY, state.shutdown);
+
+    sc[HOST_KEY] = state;
+    return state;
+  }
+
+  /** Register a Resizable to receive `onLayout` on every resize. */
+  static register(scene: ResizeHostScene, resizable: Resizable): () => void {
+    const state = ResizeHost.attach(scene);
+    state.resizables.add(resizable);
+    return () => state.resizables.delete(resizable);
+  }
+
+  /** Subscribe an ad-hoc callback (auto-removed on scene shutdown). */
+  static subscribe(
+    scene: ResizeHostScene,
+    callback: ResizeCallback,
+  ): () => void {
+    const state = ResizeHost.attach(scene);
+    state.callbacks.add(callback);
+    return () => state.callbacks.delete(callback);
+  }
+
+  /** Trigger a resize broadcast immediately using current scale. */
+  static broadcast(scene: ResizeHostScene): void {
+    const state = ResizeHost.attach(scene);
+    state.handler(scene.scale.gameSize);
+  }
+}
+
+/** Hook-style helper: subscribe to layout metrics with auto-cleanup. */
+export function useResize(
+  scene: ResizeHostScene,
+  callback: (metrics: LayoutMetrics) => void,
+): () => void {
+  return ResizeHost.subscribe(scene, callback);
+}

--- a/packages/spacebiz-ui/src/layout/VSizer.ts
+++ b/packages/spacebiz-ui/src/layout/VSizer.ts
@@ -1,0 +1,161 @@
+import * as Phaser from "phaser";
+import { computeFlex, alignCross } from "./flexMath.ts";
+import { applyChildSize, placeChild, readChildSize } from "./sizerBase.ts";
+import type {
+  HAlign,
+  Insets,
+  Justify,
+  Resizable,
+  SizerChildOptions,
+} from "./types.ts";
+import { normalizeInsets } from "./types.ts";
+import type { LayoutMetrics } from "../Layout.ts";
+
+export interface VSizerConfig {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  gap?: number;
+  align?: HAlign;
+  justify?: Justify;
+  padding?: number | Partial<Insets>;
+}
+
+interface ChildEntry {
+  child: Phaser.GameObjects.GameObject;
+  options: SizerChildOptions;
+}
+
+export class VSizer extends Phaser.GameObjects.Container implements Resizable {
+  private gap: number;
+  private align: HAlign;
+  private justify: Justify;
+  private padding: Insets;
+  private fixedWidth: number | null;
+  private fixedHeight: number | null;
+  private entries: ChildEntry[] = [];
+  private contentWidth = 0;
+  private contentHeight = 0;
+
+  constructor(scene: Phaser.Scene, config: VSizerConfig = {}) {
+    super(scene, config.x ?? 0, config.y ?? 0);
+    this.gap = config.gap ?? 0;
+    this.align = config.align ?? "left";
+    this.justify = config.justify ?? "start";
+    this.padding = normalizeInsets(config.padding ?? 0);
+    this.fixedWidth = config.width ?? null;
+    this.fixedHeight = config.height ?? null;
+    if (this.fixedWidth !== null && this.fixedHeight !== null) {
+      super.setSize(this.fixedWidth, this.fixedHeight);
+    }
+    scene.add.existing(this);
+  }
+
+  add(
+    child: Phaser.GameObjects.GameObject | Phaser.GameObjects.GameObject[],
+    options?: SizerChildOptions,
+  ): this {
+    const items = Array.isArray(child) ? child : [child];
+    for (const item of items) {
+      super.add(item);
+      this.entries.push({ child: item, options: options ?? {} });
+    }
+    this.layout();
+    return this;
+  }
+
+  remove<T extends Phaser.GameObjects.GameObject>(
+    child: T | T[],
+    destroyChild?: boolean,
+  ): this {
+    const list = Array.isArray(child) ? child : [child];
+    super.remove(child, destroyChild);
+    this.entries = this.entries.filter((e) => !list.includes(e.child as T));
+    this.layout();
+    return this;
+  }
+
+  setSize(width: number, height: number): this {
+    this.fixedWidth = width;
+    this.fixedHeight = height;
+    super.setSize(width, height);
+    this.layout();
+    return this;
+  }
+
+  onLayout(_metrics: LayoutMetrics): void {
+    this.layout();
+  }
+
+  layout(): void {
+    const padH = this.padding.left + this.padding.right;
+    const padV = this.padding.top + this.padding.bottom;
+
+    const measured = this.entries.map((e) => readChildSize(e.child));
+    const containerH =
+      this.fixedHeight !== null
+        ? Math.max(0, this.fixedHeight - padV)
+        : measured.reduce((a, m) => a + m.height, 0) +
+          this.gap * Math.max(0, measured.length - 1);
+
+    const flex = computeFlex({
+      containerSize: containerH,
+      gap: this.gap,
+      justify: this.justify,
+      children: this.entries.map((e) => ({
+        width: 0,
+        height: 0,
+        flex: e.options.flex,
+      })),
+      mainSizes: measured.map((m) => m.height),
+    });
+
+    const widest = measured.reduce((max, m) => Math.max(max, m.width), 0);
+    const containerW =
+      this.fixedWidth !== null ? Math.max(0, this.fixedWidth - padH) : widest;
+
+    for (let i = 0; i < this.entries.length; i++) {
+      const entry = this.entries[i];
+      const childAlign = (entry.options.align ?? this.align) as
+        | "left"
+        | "center"
+        | "right"
+        | "stretch";
+      const crossAlign =
+        childAlign === "left"
+          ? "start"
+          : childAlign === "right"
+            ? "end"
+            : childAlign;
+      const cross = alignCross(measured[i].width, containerW, crossAlign);
+      const flexed = (entry.options.flex ?? 0) > 0;
+      const stretched = childAlign === "stretch";
+      if (flexed || stretched) {
+        applyChildSize(
+          entry.child,
+          stretched ? cross.size : measured[i].width,
+          flexed ? flex.sizes[i] : measured[i].height,
+        );
+      }
+      placeChild(
+        entry.child,
+        this.padding.left + cross.offset,
+        this.padding.top + flex.positions[i],
+      );
+    }
+
+    this.contentWidth = containerW + padH;
+    this.contentHeight = containerH + padV;
+    if (this.fixedWidth === null || this.fixedHeight === null) {
+      super.setSize(
+        this.fixedWidth ?? this.contentWidth,
+        this.fixedHeight ?? this.contentHeight,
+      );
+    }
+  }
+
+  getContentSize(): { width: number; height: number } {
+    return { width: this.contentWidth, height: this.contentHeight };
+  }
+}

--- a/packages/spacebiz-ui/src/layout/__tests__/anchor.test.ts
+++ b/packages/spacebiz-ui/src/layout/__tests__/anchor.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { computeAnchor } from "../anchorMath.ts";
+
+const base = {
+  parentWidth: 1000,
+  parentHeight: 800,
+  childWidth: 100,
+  childHeight: 50,
+  insets: { top: 0, right: 0, bottom: 0, left: 0 },
+};
+
+describe("computeAnchor", () => {
+  it("pins to topLeft", () => {
+    const r = computeAnchor({ ...base, to: "topLeft" });
+    expect(r).toMatchObject({ x: 0, y: 0, width: 100, height: 50 });
+  });
+
+  it("pins to topRight", () => {
+    const r = computeAnchor({ ...base, to: "topRight" });
+    expect(r.x).toBe(900);
+    expect(r.y).toBe(0);
+  });
+
+  it("pins to bottomRight", () => {
+    const r = computeAnchor({ ...base, to: "bottomRight" });
+    expect(r.x).toBe(900);
+    expect(r.y).toBe(750);
+  });
+
+  it("pins to center", () => {
+    const r = computeAnchor({ ...base, to: "center" });
+    expect(r.x).toBe(450);
+    expect(r.y).toBe(375);
+  });
+
+  it("applies offsets", () => {
+    const r = computeAnchor({
+      ...base,
+      to: "topLeft",
+      offset: { x: 10, y: 20 },
+    });
+    expect(r).toMatchObject({ x: 10, y: 20 });
+  });
+
+  it("applies insets to inner edges", () => {
+    const r = computeAnchor({
+      ...base,
+      to: "topRight",
+      insets: { top: 10, right: 20, bottom: 30, left: 40 },
+    });
+    // inner right = 1000 - 20 = 980; pin x = 980 - 100 = 880
+    expect(r.x).toBe(880);
+    expect(r.y).toBe(10);
+  });
+
+  it("fills horizontally", () => {
+    const r = computeAnchor({
+      ...base,
+      to: "top",
+      fill: "horizontal",
+      insets: { top: 0, right: 12, bottom: 0, left: 12 },
+    });
+    expect(r.width).toBe(976);
+    expect(r.x).toBe(12);
+    expect(r.y).toBe(0);
+  });
+
+  it("fills vertically", () => {
+    const r = computeAnchor({
+      ...base,
+      to: "left",
+      fill: "vertical",
+    });
+    expect(r.height).toBe(800);
+    expect(r.y).toBe(0);
+  });
+
+  it("fills both", () => {
+    const r = computeAnchor({
+      ...base,
+      to: "center",
+      fill: "both",
+      insets: { top: 5, right: 5, bottom: 5, left: 5 },
+    });
+    expect(r.width).toBe(990);
+    expect(r.height).toBe(790);
+    expect(r.x).toBe(5);
+    expect(r.y).toBe(5);
+  });
+});

--- a/packages/spacebiz-ui/src/layout/__tests__/flex.test.ts
+++ b/packages/spacebiz-ui/src/layout/__tests__/flex.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { alignCross, computeFlex } from "../flexMath.ts";
+
+describe("computeFlex", () => {
+  it("returns empty result for no children", () => {
+    const r = computeFlex({
+      containerSize: 100,
+      gap: 0,
+      justify: "start",
+      children: [],
+      mainSizes: [],
+    });
+    expect(r.sizes).toEqual([]);
+    expect(r.positions).toEqual([]);
+  });
+
+  it("packs children at start with gap", () => {
+    const r = computeFlex({
+      containerSize: 200,
+      gap: 10,
+      justify: "start",
+      children: [
+        { width: 0, height: 0 },
+        { width: 0, height: 0 },
+      ],
+      mainSizes: [40, 40],
+    });
+    expect(r.positions).toEqual([0, 50]);
+    expect(r.sizes).toEqual([40, 40]);
+  });
+
+  it("centers children in extra space", () => {
+    const r = computeFlex({
+      containerSize: 200,
+      gap: 0,
+      justify: "center",
+      children: [{ width: 0, height: 0 }],
+      mainSizes: [60],
+    });
+    expect(r.positions[0]).toBe(70);
+  });
+
+  it("applies space-between", () => {
+    const r = computeFlex({
+      containerSize: 300,
+      gap: 0,
+      justify: "space-between",
+      children: [
+        { width: 0, height: 0 },
+        { width: 0, height: 0 },
+        { width: 0, height: 0 },
+      ],
+      mainSizes: [50, 50, 50],
+    });
+    expect(r.positions).toEqual([0, 125, 250]);
+  });
+
+  it("distributes flex weight across free space", () => {
+    const r = computeFlex({
+      containerSize: 300,
+      gap: 0,
+      justify: "start",
+      children: [
+        { width: 0, height: 0, flex: 0 },
+        { width: 0, height: 0, flex: 1 },
+        { width: 0, height: 0, flex: 2 },
+      ],
+      mainSizes: [60, 60, 60],
+    });
+    expect(r.sizes[0]).toBe(60);
+    // free = 300 - 180 = 120 → 40 to flex=1, 80 to flex=2
+    expect(r.sizes[1]).toBeCloseTo(100);
+    expect(r.sizes[2]).toBeCloseTo(140);
+    expect(r.positions[0]).toBe(0);
+    expect(r.positions[1]).toBeCloseTo(60);
+    expect(r.positions[2]).toBeCloseTo(160);
+  });
+
+  it("ignores justify when flex absorbs space", () => {
+    const r = computeFlex({
+      containerSize: 200,
+      gap: 0,
+      justify: "space-between",
+      children: [
+        { width: 0, height: 0, flex: 1 },
+        { width: 0, height: 0, flex: 1 },
+      ],
+      mainSizes: [10, 10],
+    });
+    expect(r.positions[0]).toBe(0);
+    // sizes 10 + 90 each → second starts at 100
+    expect(r.positions[1]).toBeCloseTo(100);
+  });
+});
+
+describe("alignCross", () => {
+  it("centers on the cross axis", () => {
+    const a = alignCross(40, 100, "center");
+    expect(a.offset).toBe(30);
+    expect(a.size).toBe(40);
+  });
+  it("stretches", () => {
+    const a = alignCross(40, 100, "stretch");
+    expect(a.size).toBe(100);
+    expect(a.offset).toBe(0);
+  });
+  it("end-aligns", () => {
+    const a = alignCross(40, 100, "end");
+    expect(a.offset).toBe(60);
+  });
+});

--- a/packages/spacebiz-ui/src/layout/__tests__/grid.test.ts
+++ b/packages/spacebiz-ui/src/layout/__tests__/grid.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { placeGrid, spanSize, trackOffset } from "../gridMath.ts";
+
+describe("placeGrid", () => {
+  it("packs children left-to-right, top-to-bottom", () => {
+    const r = placeGrid({
+      columns: 3,
+      columnGap: 0,
+      rowGap: 0,
+      children: [
+        { width: 10, height: 10, colspan: 1, rowspan: 1 },
+        { width: 10, height: 10, colspan: 1, rowspan: 1 },
+        { width: 10, height: 10, colspan: 1, rowspan: 1 },
+        { width: 10, height: 10, colspan: 1, rowspan: 1 },
+      ],
+    });
+    expect(r.placements[0]).toEqual({ col: 0, row: 0, colspan: 1, rowspan: 1 });
+    expect(r.placements[2]).toEqual({ col: 2, row: 0, colspan: 1, rowspan: 1 });
+    expect(r.placements[3]).toEqual({ col: 0, row: 1, colspan: 1, rowspan: 1 });
+  });
+
+  it("respects colspan and skips occupied cells", () => {
+    const r = placeGrid({
+      columns: 3,
+      columnGap: 0,
+      rowGap: 0,
+      children: [
+        { width: 20, height: 10, colspan: 2, rowspan: 1 },
+        { width: 10, height: 10, colspan: 1, rowspan: 1 },
+        { width: 10, height: 10, colspan: 1, rowspan: 1 },
+      ],
+    });
+    expect(r.placements[0]).toEqual({ col: 0, row: 0, colspan: 2, rowspan: 1 });
+    expect(r.placements[1]).toEqual({ col: 2, row: 0, colspan: 1, rowspan: 1 });
+    expect(r.placements[2]).toEqual({ col: 0, row: 1, colspan: 1, rowspan: 1 });
+  });
+
+  it("respects rowspan", () => {
+    const r = placeGrid({
+      columns: 2,
+      columnGap: 0,
+      rowGap: 0,
+      children: [
+        { width: 10, height: 30, colspan: 1, rowspan: 2 },
+        { width: 10, height: 10, colspan: 1, rowspan: 1 },
+        { width: 10, height: 10, colspan: 1, rowspan: 1 },
+      ],
+    });
+    expect(r.placements[0]).toEqual({ col: 0, row: 0, colspan: 1, rowspan: 2 });
+    expect(r.placements[1]).toEqual({ col: 1, row: 0, colspan: 1, rowspan: 1 });
+    expect(r.placements[2]).toEqual({ col: 1, row: 1, colspan: 1, rowspan: 1 });
+  });
+
+  it("computes total size including gaps", () => {
+    const r = placeGrid({
+      columns: 2,
+      columnGap: 5,
+      rowGap: 5,
+      children: [
+        { width: 10, height: 10, colspan: 1, rowspan: 1 },
+        { width: 10, height: 10, colspan: 1, rowspan: 1 },
+        { width: 10, height: 10, colspan: 1, rowspan: 1 },
+        { width: 10, height: 10, colspan: 1, rowspan: 1 },
+      ],
+    });
+    expect(r.totalWidth).toBe(25);
+    expect(r.totalHeight).toBe(25);
+  });
+});
+
+describe("trackOffset / spanSize", () => {
+  it("computes offsets across tracks", () => {
+    expect(trackOffset([10, 20, 30], 5, 0)).toBe(0);
+    expect(trackOffset([10, 20, 30], 5, 1)).toBe(15);
+    expect(trackOffset([10, 20, 30], 5, 2)).toBe(40);
+  });
+  it("computes span sizes including internal gaps", () => {
+    expect(spanSize([10, 20, 30], 5, 0, 1)).toBe(10);
+    expect(spanSize([10, 20, 30], 5, 0, 2)).toBe(35);
+    expect(spanSize([10, 20, 30], 5, 0, 3)).toBe(70);
+  });
+});

--- a/packages/spacebiz-ui/src/layout/__tests__/resizeHost.test.ts
+++ b/packages/spacebiz-ui/src/layout/__tests__/resizeHost.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest";
+import { ResizeHost, useResize } from "../ResizeHost.ts";
+
+// Minimal Phaser.Scene-shaped stub. ResizeHost only touches scene.scale,
+// scene.events, and the SHUTDOWN/DESTROY string events.
+function makeMockScene(width = 1280, height = 720) {
+  const handlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+  const scaleHandlers: Array<
+    (size: { width: number; height: number }) => void
+  > = [];
+
+  const scene = {
+    scale: {
+      width,
+      height,
+      gameSize: { width, height },
+      on(event: string, fn: (size: { width: number; height: number }) => void) {
+        if (event === "resize") scaleHandlers.push(fn);
+      },
+      off(
+        event: string,
+        fn: (size: { width: number; height: number }) => void,
+      ) {
+        if (event !== "resize") return;
+        const idx = scaleHandlers.indexOf(fn);
+        if (idx >= 0) scaleHandlers.splice(idx, 1);
+      },
+      emit(width: number, height: number) {
+        for (const fn of scaleHandlers.slice()) fn({ width, height });
+      },
+    },
+    events: {
+      once(event: string, fn: (...args: unknown[]) => void) {
+        (handlers[event] ??= []).push(fn);
+      },
+      fire(event: string) {
+        const list = handlers[event] ?? [];
+        handlers[event] = [];
+        for (const fn of list) fn();
+      },
+    },
+  };
+
+  return scene;
+}
+
+describe("ResizeHost", () => {
+  it("attaches once per scene and reuses state", () => {
+    const scene = makeMockScene();
+    const a = ResizeHost.attach(scene as never);
+    const b = ResizeHost.attach(scene as never);
+    expect(a).toBe(b);
+  });
+
+  it("notifies registered Resizables on resize", () => {
+    const scene = makeMockScene();
+    const target = { onLayout: vi.fn() };
+    ResizeHost.register(scene as never, target);
+    scene.scale.emit(1600, 900);
+    expect(target.onLayout).toHaveBeenCalledTimes(1);
+    const metrics = target.onLayout.mock.calls[0][0];
+    expect(metrics.gameWidth).toBe(1600);
+    expect(metrics.gameHeight).toBe(900);
+  });
+
+  it("notifies ad-hoc subscribers and supports unsubscribe", () => {
+    const scene = makeMockScene();
+    const cb = vi.fn();
+    const off = useResize(scene as never, cb);
+    scene.scale.emit(1280, 720);
+    expect(cb).toHaveBeenCalledTimes(1);
+    off();
+    scene.scale.emit(1280, 720);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears subscribers on scene shutdown", () => {
+    const scene = makeMockScene();
+    const cb = vi.fn();
+    useResize(scene as never, cb);
+    scene.events.fire("shutdown");
+    scene.scale.emit(1280, 720);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("isolates subscriber errors", () => {
+    const scene = makeMockScene();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    useResize(scene as never, () => {
+      throw new Error("boom");
+    });
+    const ok = vi.fn();
+    useResize(scene as never, ok);
+    scene.scale.emit(1280, 720);
+    expect(ok).toHaveBeenCalledTimes(1);
+    errSpy.mockRestore();
+  });
+
+  it("broadcast() pushes current size to subscribers", () => {
+    const scene = makeMockScene(1024, 768);
+    const cb = vi.fn();
+    useResize(scene as never, cb);
+    ResizeHost.broadcast(scene as never);
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0][0].gameWidth).toBe(1024);
+  });
+});

--- a/packages/spacebiz-ui/src/layout/__tests__/wrap.test.ts
+++ b/packages/spacebiz-ui/src/layout/__tests__/wrap.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { computeWrap } from "../wrapMath.ts";
+
+describe("computeWrap", () => {
+  it("handles empty input", () => {
+    const r = computeWrap({
+      containerWidth: 100,
+      columnGap: 0,
+      rowGap: 0,
+      children: [],
+    });
+    expect(r.positions).toEqual([]);
+    expect(r.totalHeight).toBe(0);
+    expect(r.rows).toEqual([]);
+  });
+
+  it("flows in one row when items fit", () => {
+    const r = computeWrap({
+      containerWidth: 100,
+      columnGap: 5,
+      rowGap: 5,
+      children: [
+        { width: 30, height: 20 },
+        { width: 30, height: 20 },
+      ],
+    });
+    expect(r.positions).toEqual([
+      { x: 0, y: 0 },
+      { x: 35, y: 0 },
+    ]);
+    expect(r.totalHeight).toBe(20);
+    expect(r.rows).toHaveLength(1);
+  });
+
+  it("wraps to a new row when overflowing", () => {
+    const r = computeWrap({
+      containerWidth: 70,
+      columnGap: 5,
+      rowGap: 4,
+      children: [
+        { width: 30, height: 20 },
+        { width: 30, height: 20 },
+        { width: 30, height: 20 },
+      ],
+    });
+    // first row: 0 + 30 + 5 + 30 = 65 (fits). Adding third: 65 + 5 + 30 = 100 > 70.
+    expect(r.positions[0]).toEqual({ x: 0, y: 0 });
+    expect(r.positions[1]).toEqual({ x: 35, y: 0 });
+    expect(r.positions[2]).toEqual({ x: 0, y: 24 });
+    expect(r.totalHeight).toBe(44);
+    expect(r.rows).toHaveLength(2);
+  });
+
+  it("uses tallest item as row height", () => {
+    const r = computeWrap({
+      containerWidth: 100,
+      columnGap: 0,
+      rowGap: 0,
+      children: [
+        { width: 20, height: 10 },
+        { width: 20, height: 30 },
+        { width: 20, height: 15 },
+      ],
+    });
+    expect(r.totalHeight).toBe(30);
+  });
+
+  it("center-aligns rows", () => {
+    const r = computeWrap({
+      containerWidth: 100,
+      columnGap: 0,
+      rowGap: 0,
+      hAlign: "center",
+      children: [{ width: 40, height: 20 }],
+    });
+    expect(r.positions[0].x).toBe(30);
+  });
+
+  it("end-aligns rows", () => {
+    const r = computeWrap({
+      containerWidth: 100,
+      columnGap: 0,
+      rowGap: 0,
+      hAlign: "end",
+      children: [{ width: 40, height: 20 }],
+    });
+    expect(r.positions[0].x).toBe(60);
+  });
+});

--- a/packages/spacebiz-ui/src/layout/anchorMath.ts
+++ b/packages/spacebiz-ui/src/layout/anchorMath.ts
@@ -1,0 +1,88 @@
+// Pure anchor math for the Anchor component.
+
+import type { AnchorFill, AnchorPosition, Insets } from "./types.ts";
+
+export interface AnchorComputeInput {
+  parentWidth: number;
+  parentHeight: number;
+  childWidth: number;
+  childHeight: number;
+  to: AnchorPosition;
+  offset?: { x?: number; y?: number };
+  fill?: AnchorFill;
+  insets: Insets;
+}
+
+export interface AnchorComputeResult {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export function computeAnchor(input: AnchorComputeInput): AnchorComputeResult {
+  const { parentWidth, parentHeight, to, fill, insets } = input;
+  const offsetX = input.offset?.x ?? 0;
+  const offsetY = input.offset?.y ?? 0;
+
+  const innerLeft = insets.left;
+  const innerTop = insets.top;
+  const innerRight = parentWidth - insets.right;
+  const innerBottom = parentHeight - insets.bottom;
+  const innerWidth = Math.max(0, innerRight - innerLeft);
+  const innerHeight = Math.max(0, innerBottom - innerTop);
+
+  let width = input.childWidth;
+  let height = input.childHeight;
+
+  if (fill === "horizontal" || fill === "both") {
+    width = innerWidth;
+  }
+  if (fill === "vertical" || fill === "both") {
+    height = innerHeight;
+  }
+
+  let x = innerLeft;
+  let y = innerTop;
+
+  switch (to) {
+    case "topLeft":
+      x = innerLeft;
+      y = innerTop;
+      break;
+    case "top":
+      x = innerLeft + (innerWidth - width) / 2;
+      y = innerTop;
+      break;
+    case "topRight":
+      x = innerRight - width;
+      y = innerTop;
+      break;
+    case "left":
+      x = innerLeft;
+      y = innerTop + (innerHeight - height) / 2;
+      break;
+    case "center":
+      x = innerLeft + (innerWidth - width) / 2;
+      y = innerTop + (innerHeight - height) / 2;
+      break;
+    case "right":
+      x = innerRight - width;
+      y = innerTop + (innerHeight - height) / 2;
+      break;
+    case "bottomLeft":
+      x = innerLeft;
+      y = innerBottom - height;
+      break;
+    case "bottom":
+      x = innerLeft + (innerWidth - width) / 2;
+      y = innerBottom - height;
+      break;
+    case "bottomRight":
+      x = innerRight - width;
+      y = innerBottom - height;
+      break;
+  }
+
+  return { x: x + offsetX, y: y + offsetY, width, height };
+}

--- a/packages/spacebiz-ui/src/layout/flexMath.ts
+++ b/packages/spacebiz-ui/src/layout/flexMath.ts
@@ -1,0 +1,97 @@
+// Pure flex layout math, used by HSizer / VSizer. No Phaser imports — fully
+// unit-testable.
+
+import type { Justify, MeasuredChild } from "./types.ts";
+
+export interface FlexInput {
+  containerSize: number;
+  gap: number;
+  justify: Justify;
+  children: MeasuredChild[];
+  /** Natural-content size of each child along the main axis. */
+  mainSizes: number[];
+}
+
+export interface FlexResult {
+  /** Final size assigned to each child along the main axis. */
+  sizes: number[];
+  /** Top-left position of each child along the main axis. */
+  positions: number[];
+  /** Total content size after layout (sum of sizes + gaps). */
+  totalSize: number;
+}
+
+export function computeFlex(input: FlexInput): FlexResult {
+  const { containerSize, gap, justify, children, mainSizes } = input;
+  const n = children.length;
+  if (n === 0) {
+    return { sizes: [], positions: [], totalSize: 0 };
+  }
+
+  const sizes = mainSizes.slice();
+  const totalGap = gap * Math.max(0, n - 1);
+  const naturalTotal = sizes.reduce((a, b) => a + b, 0) + totalGap;
+
+  const totalFlex = children.reduce((acc, c) => acc + (c.flex ?? 0), 0);
+  if (totalFlex > 0 && containerSize > naturalTotal) {
+    const free = containerSize - naturalTotal;
+    for (let i = 0; i < n; i++) {
+      const f = children[i].flex ?? 0;
+      if (f > 0) sizes[i] += (free * f) / totalFlex;
+    }
+  }
+
+  const usedSize = sizes.reduce((a, b) => a + b, 0) + totalGap;
+  const positions = new Array<number>(n);
+
+  // When flex absorbed the free space, justification is implicitly "start".
+  const effectiveJustify = totalFlex > 0 ? "start" : justify;
+  const free = Math.max(0, containerSize - usedSize);
+
+  let cursor = 0;
+  let extraGap = 0;
+
+  switch (effectiveJustify) {
+    case "start":
+      cursor = 0;
+      break;
+    case "center":
+      cursor = free / 2;
+      break;
+    case "end":
+      cursor = free;
+      break;
+    case "space-between":
+      cursor = 0;
+      extraGap = n > 1 ? free / (n - 1) : 0;
+      break;
+    case "space-around":
+      extraGap = n > 0 ? free / n : 0;
+      cursor = extraGap / 2;
+      break;
+  }
+
+  for (let i = 0; i < n; i++) {
+    positions[i] = cursor;
+    cursor += sizes[i] + gap + extraGap;
+  }
+
+  return { sizes, positions, totalSize: usedSize + (n - 1) * extraGap };
+}
+
+export function alignCross(
+  childSize: number,
+  containerSize: number,
+  align: "start" | "center" | "end" | "stretch",
+): { offset: number; size: number } {
+  if (align === "stretch") {
+    return { offset: 0, size: containerSize };
+  }
+  if (align === "center") {
+    return { offset: (containerSize - childSize) / 2, size: childSize };
+  }
+  if (align === "end") {
+    return { offset: containerSize - childSize, size: childSize };
+  }
+  return { offset: 0, size: childSize };
+}

--- a/packages/spacebiz-ui/src/layout/gridMath.ts
+++ b/packages/spacebiz-ui/src/layout/gridMath.ts
@@ -1,0 +1,157 @@
+// Pure 2D grid layout math for GridSizer.
+
+export interface GridChildSpec {
+  width: number;
+  height: number;
+  colspan: number;
+  rowspan: number;
+}
+
+export interface GridInput {
+  columns: number;
+  rows?: number;
+  columnGap: number;
+  rowGap: number;
+  children: GridChildSpec[];
+}
+
+export interface GridCellPlacement {
+  col: number;
+  row: number;
+  colspan: number;
+  rowspan: number;
+}
+
+export interface GridResult {
+  /** Final col/row of each child, parallel to input.children. */
+  placements: GridCellPlacement[];
+  /** Width of each column. */
+  columnWidths: number[];
+  /** Height of each row. */
+  rowHeights: number[];
+  /** Total grid width including gaps. */
+  totalWidth: number;
+  /** Total grid height including gaps. */
+  totalHeight: number;
+}
+
+export function placeGrid(input: GridInput): GridResult {
+  const { columns, columnGap, rowGap, children } = input;
+  const colCount = Math.max(1, columns);
+
+  // First pass: assign each child a (col, row) honoring colspan/rowspan with
+  // a left-to-right, top-to-bottom scan that skips occupied cells.
+  const occupied: boolean[][] = [];
+  const placements: GridCellPlacement[] = [];
+
+  function isFree(col: number, row: number, cs: number, rs: number): boolean {
+    if (col + cs > colCount) return false;
+    for (let r = row; r < row + rs; r++) {
+      for (let c = col; c < col + cs; c++) {
+        if (occupied[r] && occupied[r][c]) return false;
+      }
+    }
+    return true;
+  }
+
+  function ensureRow(r: number): void {
+    while (occupied.length <= r) {
+      occupied.push(new Array<boolean>(colCount).fill(false));
+    }
+  }
+
+  function markOccupied(
+    col: number,
+    row: number,
+    cs: number,
+    rs: number,
+  ): void {
+    for (let r = row; r < row + rs; r++) {
+      ensureRow(r);
+      for (let c = col; c < col + cs; c++) {
+        occupied[r][c] = true;
+      }
+    }
+  }
+
+  let cursorRow = 0;
+  let cursorCol = 0;
+  for (const child of children) {
+    const cs = Math.max(1, Math.min(child.colspan, colCount));
+    const rs = Math.max(1, child.rowspan);
+    while (true) {
+      ensureRow(cursorRow);
+      if (isFree(cursorCol, cursorRow, cs, rs)) {
+        placements.push({
+          col: cursorCol,
+          row: cursorRow,
+          colspan: cs,
+          rowspan: rs,
+        });
+        markOccupied(cursorCol, cursorRow, cs, rs);
+        cursorCol += cs;
+        if (cursorCol >= colCount) {
+          cursorCol = 0;
+          cursorRow += 1;
+        }
+        break;
+      }
+      cursorCol += 1;
+      if (cursorCol >= colCount) {
+        cursorCol = 0;
+        cursorRow += 1;
+      }
+    }
+  }
+
+  const rowCount = Math.max(input.rows ?? 0, occupied.length);
+
+  // Second pass: derive column widths and row heights from children.
+  // For spans, distribute the natural size evenly across spanned tracks
+  // (simple but predictable; matches Rex behavior closely enough).
+  const columnWidths = new Array<number>(colCount).fill(0);
+  const rowHeights = new Array<number>(rowCount).fill(0);
+
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    const place = placements[i];
+    const wPer = child.width / place.colspan;
+    const hPer = child.height / place.rowspan;
+    for (let c = place.col; c < place.col + place.colspan; c++) {
+      if (wPer > columnWidths[c]) columnWidths[c] = wPer;
+    }
+    for (let r = place.row; r < place.row + place.rowspan; r++) {
+      if (hPer > rowHeights[r]) rowHeights[r] = hPer;
+    }
+  }
+
+  const totalWidth =
+    columnWidths.reduce((a, b) => a + b, 0) +
+    columnGap * Math.max(0, colCount - 1);
+  const totalHeight =
+    rowHeights.reduce((a, b) => a + b, 0) + rowGap * Math.max(0, rowCount - 1);
+
+  return { placements, columnWidths, rowHeights, totalWidth, totalHeight };
+}
+
+export function trackOffset(
+  tracks: number[],
+  gap: number,
+  index: number,
+): number {
+  let offset = 0;
+  for (let i = 0; i < index; i++) offset += tracks[i] + gap;
+  return offset;
+}
+
+export function spanSize(
+  tracks: number[],
+  gap: number,
+  start: number,
+  span: number,
+): number {
+  let size = 0;
+  for (let i = start; i < start + span; i++) size += tracks[i];
+  size += gap * Math.max(0, span - 1);
+  return size;
+}

--- a/packages/spacebiz-ui/src/layout/index.ts
+++ b/packages/spacebiz-ui/src/layout/index.ts
@@ -1,0 +1,46 @@
+export { HSizer } from "./HSizer.ts";
+export type { HSizerConfig } from "./HSizer.ts";
+
+export { VSizer } from "./VSizer.ts";
+export type { VSizerConfig } from "./VSizer.ts";
+
+export { GridSizer } from "./GridSizer.ts";
+export type { GridSizerConfig } from "./GridSizer.ts";
+
+export { FixWidthSizer } from "./FixWidthSizer.ts";
+export type { FixWidthSizerConfig } from "./FixWidthSizer.ts";
+
+export { Anchor } from "./Anchor.ts";
+export type { AnchorConfig } from "./Anchor.ts";
+
+export { ResizeHost, useResize } from "./ResizeHost.ts";
+
+export type {
+  AnchorFill,
+  AnchorPosition,
+  GridChildOptions,
+  HAlign,
+  Insets,
+  Justify,
+  Resizable,
+  SizerChildOptions,
+  VAlign,
+} from "./types.ts";
+
+// Pure math helpers (also re-exported for advanced use / testing).
+export { computeFlex, alignCross } from "./flexMath.ts";
+export type { FlexInput, FlexResult } from "./flexMath.ts";
+
+export { placeGrid, trackOffset, spanSize } from "./gridMath.ts";
+export type {
+  GridChildSpec,
+  GridInput,
+  GridResult,
+  GridCellPlacement,
+} from "./gridMath.ts";
+
+export { computeWrap } from "./wrapMath.ts";
+export type { WrapChildSpec, WrapInput, WrapResult } from "./wrapMath.ts";
+
+export { computeAnchor } from "./anchorMath.ts";
+export type { AnchorComputeInput, AnchorComputeResult } from "./anchorMath.ts";

--- a/packages/spacebiz-ui/src/layout/sizerBase.ts
+++ b/packages/spacebiz-ui/src/layout/sizerBase.ts
@@ -1,0 +1,51 @@
+// Internal base for HSizer/VSizer/GridSizer/FixWidthSizer. Centralizes the
+// child-positioning helpers that need access to Phaser display objects.
+
+import * as Phaser from "phaser";
+
+export interface SizedDisplayObject extends Phaser.GameObjects.GameObject {
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+  setSize?: (width: number, height: number) => unknown;
+  setDisplaySize?: (width: number, height: number) => unknown;
+  setOrigin?: (x: number, y?: number) => unknown;
+  displayOriginX?: number;
+  displayOriginY?: number;
+}
+
+export function readChildSize(child: Phaser.GameObjects.GameObject): {
+  width: number;
+  height: number;
+} {
+  const c = child as SizedDisplayObject;
+  return { width: c.width ?? 0, height: c.height ?? 0 };
+}
+
+export function applyChildSize(
+  child: Phaser.GameObjects.GameObject,
+  width: number,
+  height: number,
+): void {
+  const c = child as SizedDisplayObject;
+  if (typeof c.setSize === "function") {
+    c.setSize(width, height);
+  } else {
+    c.width = width;
+    c.height = height;
+  }
+}
+
+export function placeChild(
+  child: Phaser.GameObjects.GameObject,
+  x: number,
+  y: number,
+): void {
+  const c = child as SizedDisplayObject;
+  // Honour displayOrigin when present (Sprites/Images default to 0.5).
+  const ox = c.displayOriginX ?? 0;
+  const oy = c.displayOriginY ?? 0;
+  c.x = x + ox;
+  c.y = y + oy;
+}

--- a/packages/spacebiz-ui/src/layout/types.ts
+++ b/packages/spacebiz-ui/src/layout/types.ts
@@ -1,0 +1,78 @@
+// Shared types for layout primitives. Pure types — safe to import from tests
+// without dragging in Phaser.
+
+import type { LayoutMetrics } from "../Layout.ts";
+
+export type HAlign = "left" | "center" | "right" | "stretch";
+export type VAlign = "top" | "center" | "bottom" | "stretch";
+export type Justify =
+  | "start"
+  | "center"
+  | "end"
+  | "space-between"
+  | "space-around";
+
+export type AnchorPosition =
+  | "topLeft"
+  | "top"
+  | "topRight"
+  | "left"
+  | "center"
+  | "right"
+  | "bottomLeft"
+  | "bottom"
+  | "bottomRight";
+
+export type AnchorFill = "horizontal" | "vertical" | "both";
+
+export interface Insets {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+export interface Resizable {
+  onLayout(metrics: LayoutMetrics): void;
+}
+
+export interface SizerChildOptions {
+  /**
+   * Flex weight. When > 0 along the main axis, the child grows to share
+   * remaining free space proportionally to its weight.
+   */
+  flex?: number;
+  /** Cross-axis alignment override for this child. */
+  align?: HAlign | VAlign;
+  /** Per-side padding around this child within the cell. */
+  padding?: number | Partial<Insets>;
+}
+
+export interface GridChildOptions {
+  colspan?: number;
+  rowspan?: number;
+  /** Per-cell horizontal alignment override. */
+  hAlign?: HAlign;
+  /** Per-cell vertical alignment override. */
+  vAlign?: VAlign;
+}
+
+export interface MeasuredChild {
+  /** Natural (display) width. */
+  width: number;
+  /** Natural (display) height. */
+  height: number;
+  flex?: number;
+}
+
+export function normalizeInsets(value: number | Partial<Insets>): Insets {
+  if (typeof value === "number") {
+    return { top: value, right: value, bottom: value, left: value };
+  }
+  return {
+    top: value.top ?? 0,
+    right: value.right ?? 0,
+    bottom: value.bottom ?? 0,
+    left: value.left ?? 0,
+  };
+}

--- a/packages/spacebiz-ui/src/layout/wrapMath.ts
+++ b/packages/spacebiz-ui/src/layout/wrapMath.ts
@@ -1,0 +1,93 @@
+// Pure wrap layout math for FixWidthSizer.
+
+export interface WrapChildSpec {
+  width: number;
+  height: number;
+}
+
+export interface WrapInput {
+  containerWidth: number;
+  columnGap: number;
+  rowGap: number;
+  children: WrapChildSpec[];
+  /** Horizontal alignment of each row's content. */
+  hAlign?: "start" | "center" | "end";
+}
+
+export interface WrapResult {
+  positions: Array<{ x: number; y: number }>;
+  totalWidth: number;
+  totalHeight: number;
+  /** Index ranges per row, useful for tests/debugging. */
+  rows: Array<{ start: number; end: number; width: number; height: number }>;
+}
+
+export function computeWrap(input: WrapInput): WrapResult {
+  const {
+    containerWidth,
+    columnGap,
+    rowGap,
+    children,
+    hAlign = "start",
+  } = input;
+
+  const positions: Array<{ x: number; y: number }> = [];
+  const rows: WrapResult["rows"] = [];
+
+  if (children.length === 0) {
+    return { positions, totalWidth: 0, totalHeight: 0, rows };
+  }
+
+  let rowStart = 0;
+  let rowWidth = 0;
+  let rowHeight = 0;
+  let cursorY = 0;
+  let widestRow = 0;
+
+  function flushRow(end: number): void {
+    const rowItemCount = end - rowStart;
+    const totalGap = columnGap * Math.max(0, rowItemCount - 1);
+    const contentWidth = rowWidth + totalGap;
+    let xOffset = 0;
+    if (hAlign === "center") {
+      xOffset = Math.max(0, (containerWidth - contentWidth) / 2);
+    } else if (hAlign === "end") {
+      xOffset = Math.max(0, containerWidth - contentWidth);
+    }
+
+    let cursorX = xOffset;
+    for (let i = rowStart; i < end; i++) {
+      positions[i] = { x: cursorX, y: cursorY };
+      cursorX += children[i].width + columnGap;
+    }
+    rows.push({
+      start: rowStart,
+      end,
+      width: contentWidth,
+      height: rowHeight,
+    });
+    if (contentWidth > widestRow) widestRow = contentWidth;
+    cursorY += rowHeight + rowGap;
+    rowStart = end;
+    rowWidth = 0;
+    rowHeight = 0;
+  }
+
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    const itemsInRow = i - rowStart;
+    const projected = rowWidth + child.width + (itemsInRow > 0 ? columnGap : 0);
+
+    if (itemsInRow > 0 && projected > containerWidth) {
+      flushRow(i);
+    }
+
+    rowWidth += child.width;
+    if (child.height > rowHeight) rowHeight = child.height;
+  }
+  flushRow(children.length);
+
+  // cursorY now sits one rowGap past the last row's bottom edge.
+  const totalHeight = Math.max(0, cursorY - rowGap);
+  return { positions, totalWidth: widestRow, totalHeight, rows };
+}

--- a/styleguide/scenes/StyleguideScene.ts
+++ b/styleguide/scenes/StyleguideScene.ts
@@ -25,6 +25,11 @@ import {
   InfoCard,
   IconButton,
   StatusBadge,
+  HSizer,
+  VSizer,
+  GridSizer,
+  FixWidthSizer,
+  Anchor,
   // Layout constants
   SIDEBAR_WIDTH,
   CONTENT_GAP,
@@ -119,6 +124,7 @@ export class StyleguideScene extends Phaser.Scene {
     y = this.addInfoCardSection(y);
     y = this.addIconButtonSection(y);
     y = this.addStatusBadgeSection(y);
+    y = this.addLayoutPrimitivesSection(y);
     y += 60;
 
     this.maxScroll = Math.max(0, y - GAME_HEIGHT);
@@ -2148,5 +2154,167 @@ export class StyleguideScene extends Phaser.Scene {
     }
 
     return y + 40;
+  }
+
+  /* ── Layout primitives (HSizer / VSizer / GridSizer / FixWidthSizer / Anchor) ─ */
+
+  private addLayoutPrimitivesSection(y: number): number {
+    y = this.addSubheading(y, "LAYOUT PRIMITIVES");
+
+    const swatch = (
+      w: number,
+      h: number,
+      color = this.theme.colors.accent,
+    ): Phaser.GameObjects.Rectangle => {
+      const r = this.add.rectangle(0, 0, w, h, color, 0.85).setOrigin(0, 0);
+      r.setStrokeStyle(1, this.theme.colors.panelBorder, 0.8);
+      return r;
+    };
+
+    // ── HSizer ──
+    this.scrollContainer.add(
+      new Label(this, {
+        x: 60,
+        y,
+        text: "HSizer (gap=8, justify=space-between, align=center)",
+        style: "caption",
+        color: this.theme.colors.textDim,
+      }),
+    );
+    y += 22;
+    const hSizer = new HSizer(this, {
+      x: 60,
+      y,
+      width: 600,
+      height: 40,
+      gap: 8,
+      justify: "space-between",
+      align: "center",
+    });
+    hSizer.add([swatch(80, 30), swatch(120, 30), swatch(60, 30)]);
+    this.children.remove(hSizer);
+    this.scrollContainer.add(hSizer);
+    y += 60;
+
+    // ── VSizer with flex ──
+    this.scrollContainer.add(
+      new Label(this, {
+        x: 60,
+        y,
+        text: "VSizer (gap=6, align=stretch, child flex weights)",
+        style: "caption",
+        color: this.theme.colors.textDim,
+      }),
+    );
+    y += 22;
+    const vSizer = new VSizer(this, {
+      x: 60,
+      y,
+      width: 200,
+      height: 180,
+      gap: 6,
+      align: "stretch",
+    });
+    vSizer.add(swatch(0, 30), { flex: 0 });
+    vSizer.add(swatch(0, 30, this.theme.colors.profit), { flex: 1 });
+    vSizer.add(swatch(0, 30, this.theme.colors.warning), { flex: 2 });
+    this.children.remove(vSizer);
+    this.scrollContainer.add(vSizer);
+
+    // ── GridSizer beside the VSizer ──
+    this.scrollContainer.add(
+      new Label(this, {
+        x: 290,
+        y: y - 22,
+        text: "GridSizer (3 cols, colspan)",
+        style: "caption",
+        color: this.theme.colors.textDim,
+      }),
+    );
+    const grid = new GridSizer(this, {
+      x: 290,
+      y,
+      columns: 3,
+      columnGap: 6,
+      rowGap: 6,
+    });
+    grid.add(swatch(60, 40));
+    grid.add(swatch(60, 40));
+    grid.add(swatch(60, 40));
+    grid.add(swatch(126, 40), { colspan: 2 });
+    grid.add(swatch(60, 40));
+    this.children.remove(grid);
+    this.scrollContainer.add(grid);
+
+    y += 200;
+
+    // ── FixWidthSizer ──
+    this.scrollContainer.add(
+      new Label(this, {
+        x: 60,
+        y,
+        text: "FixWidthSizer (wraps when overflowing the container)",
+        style: "caption",
+        color: this.theme.colors.textDim,
+      }),
+    );
+    y += 22;
+    const fix = new FixWidthSizer(this, {
+      x: 60,
+      y,
+      width: 600,
+      columnGap: 6,
+      rowGap: 6,
+    });
+    for (let i = 0; i < 12; i++) {
+      const w = 60 + ((i * 17) % 80);
+      fix.add(
+        swatch(
+          w,
+          24,
+          i % 2 === 0
+            ? this.theme.colors.accent
+            : this.theme.colors.accentHover,
+        ),
+      );
+    }
+    this.children.remove(fix);
+    this.scrollContainer.add(fix);
+    y += fix.getContentSize().height + 20;
+
+    // ── Anchor ──
+    this.scrollContainer.add(
+      new Label(this, {
+        x: 60,
+        y,
+        text: "Anchor (pin a child to a corner of a 600x120 frame, fill=horizontal)",
+        style: "caption",
+        color: this.theme.colors.textDim,
+      }),
+    );
+    y += 22;
+
+    const frame = this.add
+      .rectangle(60, y, 600, 120, this.theme.colors.panelBg, 0.4)
+      .setOrigin(0, 0);
+    frame.setStrokeStyle(1, this.theme.colors.panelBorder, 0.7);
+    this.scrollContainer.add(frame);
+
+    const anchored = swatch(0, 24, this.theme.colors.profit);
+    const anchor = new Anchor(this, {
+      to: "bottom",
+      fill: "horizontal",
+      insets: 8,
+      parentWidth: 600,
+      parentHeight: 120,
+    });
+    anchor.x = 60;
+    anchor.y = y;
+    anchor.add(anchored);
+    this.children.remove(anchor);
+    this.scrollContainer.add(anchor);
+
+    y += 140;
+    return y;
   }
 }


### PR DESCRIPTION
## Summary
- Adds `packages/spacebiz-ui/src/layout/` with Rex-inspired flex containers (`HSizer`, `VSizer`, `GridSizer`, `FixWidthSizer`), an `Anchor` component for edge/corner pinning, and a `ResizeHost` + `useResize()` helper that owns `scale.on('resize')` and broadcasts to anything implementing the new `Resizable` interface (`onLayout(metrics)`).
- Layout math (`flexMath`, `gridMath`, `wrapMath`, `anchorMath`) is split out as pure functions so 36 unit tests cover the algorithms in node env without booting Phaser. ResizeHost is exercised through a tiny scene stub.
- Re-exports the new module from `@spacebiz/ui` and adds a "LAYOUT PRIMITIVES" section to the styleguide demoing each primitive.

This is unit 1 of 21 in the 3-tier UI library plan (`vivid-knitting-lagoon.md`).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run test` (932 tests, 36 new for layout)
- [x] `npm run build` (main + styleguide bundles)
- [x] `npm run test:e2e` (8/8 pass)
- [x] Manual: `npm run dev`, visit `/` and `/styleguide/`, confirm new section renders without console errors