### PR TITLE
feat(styleguide): registry-driven sections, theme switcher, interactive knobs

### DIFF
--- a/packages/spacebiz-ui/src/Button.styleguide.ts
+++ b/packages/spacebiz-ui/src/Button.styleguide.ts
@@ -1,0 +1,71 @@
+/**
+ * Styleguide section for `Button`.
+ *
+ * This adjacent `*.styleguide.ts` file is the convention for declaring
+ * a component's styleguide entry. The styleguide app's `registry.ts`
+ * imports these sections so each component owns its own demo.
+ *
+ * Section type lives in `styleguide/registry.ts`; we type the export
+ * loosely here to avoid a circular dependency between the package and
+ * the styleguide app.
+ */
+import * as Phaser from "phaser";
+import { Button } from "./Button.ts";
+import { Label } from "./Label.ts";
+import { FloatingText } from "./FloatingText.ts";
+import { getTheme } from "./Theme.ts";
+
+export interface ButtonStyleguide {
+  id: string;
+  title: string;
+  category: string;
+  knobs: ReadonlyArray<{
+    type: "boolean" | "string";
+    id: string;
+    label: string;
+    default: boolean | string;
+  }>;
+  render: (
+    scene: Phaser.Scene,
+    container: Phaser.GameObjects.Container,
+    knobs: Record<string, boolean | number | string>,
+  ) => void;
+}
+
+export const buttonStyleguide: ButtonStyleguide = {
+  id: "button",
+  title: "Button",
+  category: "Primitives",
+  knobs: [
+    { type: "string", id: "label", label: "Label text", default: "Click me" },
+    { type: "boolean", id: "disabled", label: "Disabled", default: false },
+  ],
+  render: (scene, root, knobs) => {
+    const theme = getTheme();
+    const label = String(knobs["label"] ?? "Click me");
+    const disabled = Boolean(knobs["disabled"]);
+    root.add(
+      new Label(scene, {
+        x: 0,
+        y: 0,
+        text: "Knob-driven button:",
+        style: "caption",
+      }),
+    );
+    const btn = new Button(scene, {
+      x: 0,
+      y: 24,
+      label,
+      disabled,
+      onClick: () =>
+        new FloatingText(
+          scene,
+          root.x + 60,
+          root.y + 50,
+          "Click!",
+          theme.colors.profit,
+        ),
+    });
+    root.add(btn);
+  },
+};

--- a/styleguide/__tests__/registry.test.ts
+++ b/styleguide/__tests__/registry.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { groupByCategory, type StyleguideSection } from "../sectionGrouping.ts";
+import { buildDefaultKnobValues, type KnobDef } from "../knobs/index.ts";
+
+/**
+ * Note: importing the real `legacySections` would transitively load
+ * `@spacebiz/ui` which touches `window` at module load and crashes
+ * Vitest's node environment. The registry's responsibility (grouping,
+ * defaults) is pure data and is fully exercised by these synthetic
+ * fixtures.
+ */
+const fixture = (
+  id: string,
+  category: string,
+  title = id,
+  knobs?: ReadonlyArray<KnobDef>,
+): StyleguideSection => ({
+  id,
+  title,
+  category,
+  knobs,
+  render: () => {},
+});
+
+describe("groupByCategory", () => {
+  it("returns empty list for empty input", () => {
+    expect(groupByCategory([])).toEqual([]);
+  });
+
+  it("preserves the order categories were first seen", () => {
+    const sections = [
+      fixture("a", "Tokens"),
+      fixture("b", "Primitives"),
+      fixture("c", "Tokens"),
+      fixture("d", "Composites"),
+    ];
+    const groups = groupByCategory(sections);
+    expect(groups.map((g) => g.category)).toEqual([
+      "Tokens",
+      "Primitives",
+      "Composites",
+    ]);
+  });
+
+  it("returns sections in original registration order within each group", () => {
+    const sections = [
+      fixture("z", "Tokens"),
+      fixture("y", "Primitives"),
+      fixture("x", "Tokens"),
+      fixture("w", "Tokens"),
+    ];
+    const groups = groupByCategory(sections);
+    const tokens = groups.find((g) => g.category === "Tokens");
+    expect(tokens?.sections.map((s) => s.id)).toEqual(["z", "x", "w"]);
+  });
+
+  it("preserves total section count across grouping", () => {
+    const sections = [
+      fixture("a", "Tokens"),
+      fixture("b", "Primitives"),
+      fixture("c", "Tokens"),
+      fixture("d", "Composites"),
+      fixture("e", "Primitives"),
+    ];
+    const groups = groupByCategory(sections);
+    const total = groups.reduce((acc, g) => acc + g.sections.length, 0);
+    expect(total).toBe(sections.length);
+  });
+});
+
+describe("buildDefaultKnobValues", () => {
+  it("returns empty object when no knobs supplied", () => {
+    expect(buildDefaultKnobValues(undefined)).toEqual({});
+    expect(buildDefaultKnobValues([])).toEqual({});
+  });
+
+  it("populates from each knob's `default`", () => {
+    const knobs: KnobDef[] = [
+      { type: "boolean", id: "b", label: "B", default: true },
+      { type: "number", id: "n", label: "N", default: 7 },
+      { type: "string", id: "s", label: "S", default: "hi" },
+      {
+        type: "select",
+        id: "sel",
+        label: "Sel",
+        default: "two",
+        options: [
+          { value: "one", label: "One" },
+          { value: "two", label: "Two" },
+        ],
+      },
+      { type: "color", id: "c", label: "C", default: "#ff00aa" },
+    ];
+    expect(buildDefaultKnobValues(knobs)).toEqual({
+      b: true,
+      n: 7,
+      s: "hi",
+      sel: "two",
+      c: "#ff00aa",
+    });
+  });
+
+  it("preserves knob order in the returned record", () => {
+    const knobs: KnobDef[] = [
+      { type: "number", id: "first", label: "1", default: 1 },
+      { type: "number", id: "second", label: "2", default: 2 },
+      { type: "number", id: "third", label: "3", default: 3 },
+    ];
+    const values = buildDefaultKnobValues(knobs);
+    expect(Object.keys(values)).toEqual(["first", "second", "third"]);
+  });
+});

--- a/styleguide/knobs/index.ts
+++ b/styleguide/knobs/index.ts
@@ -1,0 +1,12 @@
+export type {
+  KnobDef,
+  KnobValue,
+  KnobValues,
+  BooleanKnob,
+  NumberKnob,
+  StringKnob,
+  SelectKnob,
+  ColorKnob,
+} from "./types.ts";
+export { buildDefaultKnobValues } from "./types.ts";
+export { renderKnobs } from "./render.ts";

--- a/styleguide/knobs/render.ts
+++ b/styleguide/knobs/render.ts
@@ -1,0 +1,222 @@
+import type { KnobDef, KnobValue, KnobValues } from "./types.ts";
+
+/**
+ * Render a stack of knob controls into a DOM container. Returns a teardown
+ * callback that removes the controls and event listeners.
+ *
+ * DOM overlays are used (rather than Phaser-native controls) because the knob
+ * panel sits *outside* the game canvas and needs to interact with native
+ * keyboard/text input affordances. The styleguide canvas is centred, leaving
+ * room on the right for a fixed-position panel.
+ */
+export function renderKnobs(
+  parent: HTMLElement,
+  knobs: ReadonlyArray<KnobDef>,
+  values: KnobValues,
+  onChange: (id: string, value: KnobValue) => void,
+): () => void {
+  // Clear existing
+  while (parent.firstChild) parent.removeChild(parent.firstChild);
+
+  if (knobs.length === 0) {
+    const empty = document.createElement("div");
+    empty.textContent = "No knobs for this section.";
+    empty.style.opacity = "0.5";
+    empty.style.fontStyle = "italic";
+    parent.appendChild(empty);
+    return () => {
+      while (parent.firstChild) parent.removeChild(parent.firstChild);
+    };
+  }
+
+  const cleanups: Array<() => void> = [];
+
+  for (const knob of knobs) {
+    const row = document.createElement("div");
+    row.className = "sg-knob-row";
+    row.style.marginBottom = "12px";
+    row.style.display = "flex";
+    row.style.flexDirection = "column";
+    row.style.gap = "4px";
+
+    const label = document.createElement("label");
+    label.textContent = knob.label;
+    label.style.fontSize = "11px";
+    label.style.opacity = "0.85";
+    label.style.textTransform = "uppercase";
+    label.style.letterSpacing = "0.5px";
+    row.appendChild(label);
+
+    const current = values[knob.id] ?? knob.default;
+    const control = renderControl(knob, current, (v) => onChange(knob.id, v));
+    row.appendChild(control.el);
+    cleanups.push(control.dispose);
+
+    parent.appendChild(row);
+  }
+
+  return () => {
+    for (const fn of cleanups) fn();
+    while (parent.firstChild) parent.removeChild(parent.firstChild);
+  };
+}
+
+interface Control {
+  el: HTMLElement;
+  dispose: () => void;
+}
+
+function renderControl(
+  knob: KnobDef,
+  current: KnobValue,
+  emit: (v: KnobValue) => void,
+): Control {
+  switch (knob.type) {
+    case "boolean":
+      return renderBoolean(Boolean(current), emit);
+    case "number":
+      return renderNumber(knob, Number(current), emit);
+    case "select":
+      return renderSelect(knob, String(current), emit);
+    case "color":
+      return renderColor(String(current), emit);
+    case "string":
+    default:
+      return renderString(String(current), emit);
+  }
+}
+
+function renderBoolean(
+  current: boolean,
+  emit: (v: KnobValue) => void,
+): Control {
+  const wrap = document.createElement("label");
+  wrap.style.display = "inline-flex";
+  wrap.style.alignItems = "center";
+  wrap.style.gap = "6px";
+  wrap.style.cursor = "pointer";
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  input.checked = current;
+  const txt = document.createElement("span");
+  txt.textContent = current ? "On" : "Off";
+  const handler = () => {
+    txt.textContent = input.checked ? "On" : "Off";
+    emit(input.checked);
+  };
+  input.addEventListener("change", handler);
+  wrap.appendChild(input);
+  wrap.appendChild(txt);
+  return {
+    el: wrap,
+    dispose: () => input.removeEventListener("change", handler),
+  };
+}
+
+function renderNumber(
+  knob: { min?: number; max?: number; step?: number },
+  current: number,
+  emit: (v: KnobValue) => void,
+): Control {
+  const wrap = document.createElement("div");
+  wrap.style.display = "flex";
+  wrap.style.alignItems = "center";
+  wrap.style.gap = "8px";
+
+  const slider = document.createElement("input");
+  slider.type = "range";
+  slider.min = String(knob.min ?? 0);
+  slider.max = String(knob.max ?? 100);
+  slider.step = String(knob.step ?? 1);
+  slider.value = String(current);
+  slider.style.flex = "1";
+
+  const readout = document.createElement("span");
+  readout.style.minWidth = "44px";
+  readout.style.textAlign = "right";
+  readout.style.fontVariantNumeric = "tabular-nums";
+  readout.textContent = String(current);
+
+  const handler = () => {
+    const v = Number(slider.value);
+    readout.textContent = String(v);
+    emit(v);
+  };
+  slider.addEventListener("input", handler);
+
+  wrap.appendChild(slider);
+  wrap.appendChild(readout);
+  return {
+    el: wrap,
+    dispose: () => slider.removeEventListener("input", handler),
+  };
+}
+
+function renderSelect(
+  knob: { options: ReadonlyArray<{ value: string; label: string }> },
+  current: string,
+  emit: (v: KnobValue) => void,
+): Control {
+  const select = document.createElement("select");
+  select.style.width = "100%";
+  for (const opt of knob.options) {
+    const o = document.createElement("option");
+    o.value = opt.value;
+    o.textContent = opt.label;
+    if (opt.value === current) o.selected = true;
+    select.appendChild(o);
+  }
+  const handler = () => emit(select.value);
+  select.addEventListener("change", handler);
+  return {
+    el: select,
+    dispose: () => select.removeEventListener("change", handler),
+  };
+}
+
+function renderString(current: string, emit: (v: KnobValue) => void): Control {
+  const input = document.createElement("input");
+  input.type = "text";
+  input.value = current;
+  input.style.width = "100%";
+  const handler = () => emit(input.value);
+  input.addEventListener("input", handler);
+  return {
+    el: input,
+    dispose: () => input.removeEventListener("input", handler),
+  };
+}
+
+function renderColor(current: string, emit: (v: KnobValue) => void): Control {
+  const wrap = document.createElement("div");
+  wrap.style.display = "flex";
+  wrap.style.alignItems = "center";
+  wrap.style.gap = "8px";
+
+  const swatch = document.createElement("input");
+  swatch.type = "color";
+  swatch.value = normaliseColor(current);
+
+  const readout = document.createElement("span");
+  readout.style.fontFamily = "monospace";
+  readout.textContent = swatch.value;
+
+  const handler = () => {
+    readout.textContent = swatch.value;
+    emit(swatch.value);
+  };
+  swatch.addEventListener("input", handler);
+
+  wrap.appendChild(swatch);
+  wrap.appendChild(readout);
+  return {
+    el: wrap,
+    dispose: () => swatch.removeEventListener("input", handler),
+  };
+}
+
+function normaliseColor(input: string): string {
+  if (input.startsWith("#") && input.length === 7) return input.toLowerCase();
+  if (/^[0-9a-fA-F]{6}$/.test(input)) return `#${input.toLowerCase()}`;
+  return "#000000";
+}

--- a/styleguide/knobs/types.ts
+++ b/styleguide/knobs/types.ts
@@ -1,0 +1,68 @@
+/**
+ * Knob system for the styleguide.
+ *
+ * A `KnobDef` declares a single interactive control rendered in the right-hand
+ * "knobs" panel of the styleguide. Each section can declare its knobs and read
+ * back the current values via the `KnobValues` map passed to `render`.
+ */
+
+export interface BooleanKnob {
+  type: "boolean";
+  id: string;
+  label: string;
+  default: boolean;
+}
+
+export interface NumberKnob {
+  type: "number";
+  id: string;
+  label: string;
+  default: number;
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+export interface StringKnob {
+  type: "string";
+  id: string;
+  label: string;
+  default: string;
+}
+
+export interface SelectKnob {
+  type: "select";
+  id: string;
+  label: string;
+  default: string;
+  options: ReadonlyArray<{ value: string; label: string }>;
+}
+
+export interface ColorKnob {
+  type: "color";
+  id: string;
+  label: string;
+  /** Default colour as `#rrggbb`. */
+  default: string;
+}
+
+export type KnobDef =
+  | BooleanKnob
+  | NumberKnob
+  | StringKnob
+  | SelectKnob
+  | ColorKnob;
+
+export type KnobValue = boolean | number | string;
+
+export type KnobValues = Record<string, KnobValue>;
+
+/** Build a `KnobValues` map from a list of `KnobDef`s using each knob's default. */
+export function buildDefaultKnobValues(
+  knobs: ReadonlyArray<KnobDef> | undefined,
+): KnobValues {
+  const out: KnobValues = {};
+  if (!knobs) return out;
+  for (const k of knobs) out[k.id] = k.default;
+  return out;
+}

--- a/styleguide/registry.ts
+++ b/styleguide/registry.ts
@@ -1,0 +1,18 @@
+import { legacySections } from "./sections/legacy.ts";
+import type { StyleguideSection } from "./sectionGrouping.ts";
+
+export type { StyleguideSection } from "./sectionGrouping.ts";
+export { groupByCategory } from "./sectionGrouping.ts";
+
+/**
+ * Ordered list of all sections shown in the styleguide. Sections are grouped
+ * in the side-panel by their `category` field (preserving first-seen order).
+ *
+ * To add a new section either:
+ *  1. Append a `StyleguideSection` to this array directly, or
+ *  2. Author a `*.styleguide.ts` adjacent to a component in
+ *     `packages/spacebiz-ui/src/...` and import its `section` export here.
+ */
+export const styleguideSections: ReadonlyArray<StyleguideSection> = [
+  ...legacySections,
+];

--- a/styleguide/scenes/StyleguideScene.ts
+++ b/styleguide/scenes/StyleguideScene.ts
@@ -1,2152 +1,358 @@
 import * as Phaser from "phaser";
 import {
   getTheme,
+  setTheme,
   colorToString,
   GAME_WIDTH,
   GAME_HEIGHT,
-  Panel,
-  Button,
   Label,
-  Modal,
-  Tooltip,
-  ProgressBar,
-  ScrollableList,
-  TabGroup,
-  DataTable,
-  createStarfield,
-  addPulseTween,
-  addTwinkleTween,
-  addFloatTween,
-  registerAmbientCleanup,
-  flashScreen,
-  FloatingText,
-  MilestoneOverlay,
-  StatRow,
-  InfoCard,
-  IconButton,
-  StatusBadge,
-  // Layout constants
-  SIDEBAR_WIDTH,
-  CONTENT_GAP,
-  HUD_TOP_BAR_HEIGHT,
-  HUD_BOTTOM_BAR_HEIGHT,
-  NAV_SIDEBAR_WIDTH,
-  CONTENT_TOP,
-  CONTENT_HEIGHT,
-  CONTENT_LEFT,
-  MAX_CONTENT_WIDTH,
-  SIDEBAR_LEFT,
-  MAIN_CONTENT_LEFT,
-  MAIN_CONTENT_WIDTH,
-  FULL_CONTENT_LEFT,
-  FULL_CONTENT_WIDTH,
-  // Depth layers
-  DEPTH_STARFIELD,
-  DEPTH_AMBIENT_MID,
-  DEPTH_CONTENT,
-  DEPTH_UI,
-  DEPTH_MODAL,
-  DEPTH_HUD,
+  Dropdown,
 } from "@spacebiz/ui";
-import type { ThemeConfig, ColumnDef, BadgeVariant } from "@spacebiz/ui";
+import type { ThemeConfig } from "@spacebiz/ui";
+import { darkTheme, lightTheme, highContrastTheme } from "../themes.ts";
 import {
-  CARGO_TYPE_LIST,
-  getCargoIconKey,
-  getCargoColor,
-  getCargoLabel,
-} from "@spacebiz/ui";
+  styleguideSections,
+  groupByCategory,
+  type StyleguideSection,
+} from "../registry.ts";
 import {
-  drawRexPortrait,
-  getMoodAccentColor,
-} from "../../src/ui/AdviserPortrait.ts";
-import { drawPortrait } from "../../src/ui/PortraitGenerator.ts";
-import type {
-  PortraitData,
-  AlienRole,
-} from "../../src/ui/PortraitGenerator.ts";
-import type { AdviserMood } from "../../src/data/types.ts";
+  buildDefaultKnobValues,
+  renderKnobs,
+  type KnobValue,
+  type KnobValues,
+} from "../knobs/index.ts";
+
+/* ── Layout constants for the styleguide chrome ──────────────────── */
+const TOP_BAR_HEIGHT = 56;
+const SIDE_PANEL_WIDTH = 200;
+const KNOBS_PANEL_WIDTH = 280;
+const PANEL_PADDING = 12;
 
 /**
- * Interactive style guide showcasing all @spacebiz/ui components.
- * Organised into vertical sections that scroll via mouse wheel.
+ * Registry-driven styleguide scene.
+ *
+ * Layout:
+ *   ┌──────────────────────────────────────────────────────┐
+ *   │ top bar — title + theme switcher                     │
+ *   ├──────────┬──────────────────────────────┬────────────┤
+ *   │ sections │ active section content       │ knobs      │
+ *   │ side nav │ (re-rendered on knob/theme   │ (DOM       │
+ *   │          │  change)                     │  overlay)  │
+ *   └──────────┴──────────────────────────────┴────────────┘
  */
 export class StyleguideScene extends Phaser.Scene {
-  private scrollContainer!: Phaser.GameObjects.Container;
-  private scrollY = 0;
-  private maxScroll = 0;
-  private theme!: ThemeConfig;
+  private activeId: string;
+  private knobValuesById: Map<string, KnobValues> = new Map();
+  private contentRoot!: Phaser.GameObjects.Container;
+  private contentTitle!: Label;
+  private sidePanelRoot!: Phaser.GameObjects.Container;
+  private topBarRoot!: Phaser.GameObjects.Container;
+
+  private knobsHost: HTMLDivElement | null = null;
+  private knobsTeardown: (() => void) | null = null;
 
   constructor() {
     super({ key: "StyleguideScene" });
+    this.activeId =
+      styleguideSections[0]?.id ??
+      // Defensive: if registry is empty we still need a string.
+      "missing";
   }
 
   create(): void {
-    this.theme = getTheme();
+    // Pre-populate knob values for every section.
+    for (const s of styleguideSections) {
+      this.knobValuesById.set(s.id, buildDefaultKnobValues(s.knobs));
+    }
 
-    // ── Starfield background ──
-    createStarfield(this, { count: 80, twinkle: true, shimmer: true });
+    this.drawBackground();
+    this.buildTopBar();
+    this.buildSidePanel();
+    this.buildContentArea();
+    this.mountKnobsHost();
+    this.renderActiveSection();
 
-    // ── Scrollable container for all sections ──
-    this.scrollContainer = this.add.container(0, 0);
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => this.cleanup());
+    this.events.once(Phaser.Scenes.Events.DESTROY, () => this.cleanup());
+  }
 
-    let y = 30;
-    y = this.addSectionTitle(y, "◆ STAR FREIGHT TYCOON — UI STYLE GUIDE");
-    y = this.addColorPaletteSection(y);
-    y = this.addTypographySection(y);
-    y = this.addButtonSection(y);
-    y = this.addPanelSection(y);
-    y = this.addProgressBarSection(y);
-    y = this.addScrollableListSection(y);
-    y = this.addTabGroupSection(y);
-    y = this.addDataTableSection(y);
-    y = this.addTooltipSection(y);
-    y = this.addFloatingTextSection(y);
-    y = this.addAmbientFxSection(y);
-    y = this.addMilestoneSection(y);
-    y = this.addModalSection(y);
+  /* ── Chrome ────────────────────────────────────────────────── */
 
-    // ── Game-specific & extended sections ──
-    y = this.addIconGallerySection(y);
-    y = this.addCargoIconSection(y);
-    y = this.addHudBarSection(y);
-    y = this.addAdviserPortraitSection(y);
-    y = this.addPortraitGallerySection(y);
-    y = this.addSpacingLayoutSection(y);
-    y = this.addDepthLayersSection(y);
-    y = this.addGlassEffectSection(y);
-    y = this.addAnimationTimingSection(y);
-    y = this.addStatRowSection(y);
-    y = this.addInfoCardSection(y);
-    y = this.addIconButtonSection(y);
-    y = this.addStatusBadgeSection(y);
-    y += 60;
+  private drawBackground(): void {
+    const theme = getTheme();
+    this.add
+      .rectangle(0, 0, GAME_WIDTH, GAME_HEIGHT, theme.colors.background)
+      .setOrigin(0, 0);
+  }
 
-    this.maxScroll = Math.max(0, y - GAME_HEIGHT);
+  private buildTopBar(): void {
+    const theme = getTheme();
+    this.topBarRoot = this.add.container(0, 0);
+    const bg = this.add
+      .rectangle(0, 0, GAME_WIDTH, TOP_BAR_HEIGHT, theme.colors.headerBg)
+      .setOrigin(0, 0)
+      .setStrokeStyle(1, theme.colors.panelBorder, 0.6);
+    this.topBarRoot.add(bg);
+    const title = new Label(this, {
+      x: PANEL_PADDING,
+      y: TOP_BAR_HEIGHT / 2 - 12,
+      text: "STAR FREIGHT TYCOON — UI STYLE GUIDE",
+      style: "heading",
+      color: theme.colors.accent,
+      glow: true,
+    });
+    this.topBarRoot.add(title);
 
-    // ── Mouse wheel scrolling ──
-    this.input.on(
-      "wheel",
-      (
-        _pointer: unknown,
-        over: Phaser.GameObjects.GameObject[],
-        _deltaX: number,
-        deltaY: number,
-      ) => {
-        // Don't scroll the page when over a child that handles its own scroll
-        if (
-          over.some(
-            (obj) =>
-              "getData" in obj &&
-              (obj as Phaser.GameObjects.GameObject).getData("consumesWheel"),
-          )
-        ) {
-          return;
-        }
-        this.scrollY = Phaser.Math.Clamp(
-          this.scrollY + deltaY * 0.5,
-          0,
-          this.maxScroll,
-        );
-        this.scrollContainer.y = -this.scrollY;
-      },
-    );
+    // Place the theme switcher to the left of the reserved DOM knobs
+    // overlay so it stays visible regardless of FIT scaling.
+    const themeLabelX = GAME_WIDTH - KNOBS_PANEL_WIDTH - 260;
+    const themeLabel = new Label(this, {
+      x: themeLabelX,
+      y: TOP_BAR_HEIGHT / 2 - 6,
+      text: "Theme:",
+      style: "caption",
+      color: theme.colors.textDim,
+    });
+    this.topBarRoot.add(themeLabel);
 
-    // Scroll hint
-    const hint = this.add
-      .text(GAME_WIDTH - 20, GAME_HEIGHT - 20, "↕ Scroll to explore", {
-        fontFamily: this.theme.fonts.caption.family,
-        fontSize: `${this.theme.fonts.caption.size}px`,
-        color: colorToString(this.theme.colors.textDim),
+    const dropdown = new Dropdown(this, {
+      x: themeLabelX + 60,
+      y: TOP_BAR_HEIGHT / 2 - 16,
+      width: 180,
+      height: 32,
+      defaultIndex: 0,
+      options: [
+        { label: "Default (Dark)", value: "dark" },
+        { label: "Light", value: "light" },
+        { label: "High Contrast", value: "high-contrast" },
+      ],
+      onChange: (value) => this.applyTheme(value),
+    });
+    this.topBarRoot.add(dropdown);
+  }
+
+  private buildSidePanel(): void {
+    const theme = getTheme();
+    this.sidePanelRoot = this.add.container(0, TOP_BAR_HEIGHT);
+
+    const bg = this.add
+      .rectangle(
+        0,
+        0,
+        SIDE_PANEL_WIDTH,
+        GAME_HEIGHT - TOP_BAR_HEIGHT,
+        theme.colors.panelBg,
+        0.7,
+      )
+      .setOrigin(0, 0)
+      .setStrokeStyle(1, theme.colors.panelBorder, 0.4);
+    this.sidePanelRoot.add(bg);
+
+    let y = PANEL_PADDING;
+    for (const group of groupByCategory(styleguideSections)) {
+      this.sidePanelRoot.add(
+        new Label(this, {
+          x: PANEL_PADDING,
+          y,
+          text: group.category.toUpperCase(),
+          style: "caption",
+          color: theme.colors.accent,
+        }),
+      );
+      y += 18;
+      for (const section of group.sections) {
+        const isActive = section.id === this.activeId;
+        const item = this.buildNavItem(section, isActive);
+        item.setPosition(PANEL_PADDING, y);
+        this.sidePanelRoot.add(item);
+        y += 22;
+      }
+      y += 8;
+    }
+  }
+
+  private buildNavItem(
+    section: StyleguideSection,
+    isActive: boolean,
+  ): Phaser.GameObjects.Container {
+    const theme = getTheme();
+    const c = this.add.container(0, 0);
+    const txt = this.add
+      .text(0, 0, `${isActive ? "▶ " : "  "}${section.title}`, {
+        fontFamily: theme.fonts.body.family,
+        fontSize: "13px",
+        color: colorToString(
+          isActive ? theme.colors.accent : theme.colors.text,
+        ),
       })
-      .setOrigin(1, 1);
-    addPulseTween(this, hint, {
-      minAlpha: 0.3,
-      maxAlpha: 0.8,
-      duration: this.theme.ambient.panelIdlePulseDuration,
+      .setOrigin(0, 0)
+      .setInteractive({ useHandCursor: true });
+    txt.on("pointerover", () => {
+      if (!isActive) txt.setColor(colorToString(theme.colors.accentHover));
     });
+    txt.on("pointerout", () => {
+      if (!isActive) txt.setColor(colorToString(theme.colors.text));
+    });
+    txt.on("pointerdown", () => this.setActiveSection(section.id));
+    c.add(txt);
+    return c;
   }
 
-  /* ── Section helpers ──────────────────────────────────────── */
+  private buildContentArea(): void {
+    const theme = getTheme();
+    const x = SIDE_PANEL_WIDTH;
+    const y = TOP_BAR_HEIGHT;
+    const w = GAME_WIDTH - SIDE_PANEL_WIDTH - KNOBS_PANEL_WIDTH;
+    const h = GAME_HEIGHT - TOP_BAR_HEIGHT;
 
-  private addSectionTitle(y: number, text: string): number {
-    const label = new Label(this, {
-      x: GAME_WIDTH / 2,
-      y,
-      text,
+    this.add.rectangle(x, y, w, h, theme.colors.background).setOrigin(0, 0);
+
+    this.contentTitle = new Label(this, {
+      x: x + PANEL_PADDING,
+      y: y + PANEL_PADDING,
+      text: "",
       style: "heading",
-      color: this.theme.colors.accent,
-      glow: true,
-    }).setOrigin(0.5, 0);
-    this.scrollContainer.add(label);
-    return y + 50;
-  }
-
-  private addSubheading(y: number, text: string): number {
-    const label = new Label(this, {
-      x: 40,
-      y,
-      text,
-      style: "heading",
-      color: this.theme.colors.text,
+      color: theme.colors.accent,
     });
-    this.scrollContainer.add(label);
 
-    // Accent divider
-    const line = this.add
-      .rectangle(40, y + 28, 200, 2, this.theme.colors.accent, 0.4)
-      .setOrigin(0, 0.5);
-    this.scrollContainer.add(line);
-    return y + 44;
+    // Container that owns the active section's children. Positioned
+    // below the title so render functions can use (0,0) coordinates
+    // relative to the content area.
+    this.contentRoot = this.add.container(x + PANEL_PADDING, y + 50);
   }
 
-  /* ── 1. Color Palette ─────────────────────────────────────── */
+  /* ── Knobs panel (DOM overlay) ─────────────────────────────── */
 
-  private addColorPaletteSection(y: number): number {
-    y = this.addSubheading(y, "COLOR PALETTE");
-
-    const colors = this.theme.colors;
-    const swatches: [string, number][] = [
-      ["background", colors.background],
-      ["headerBg", colors.headerBg],
-      ["panelBg", colors.panelBg],
-      ["panelBorder", colors.panelBorder],
-      ["accent", colors.accent],
-      ["accentHover", colors.accentHover],
-      ["text", colors.text],
-      ["textDim", colors.textDim],
-      ["profit", colors.profit],
-      ["loss", colors.loss],
-      ["warning", colors.warning],
-      ["buttonBg", colors.buttonBg],
-      ["buttonHover", colors.buttonHover],
-      ["buttonPressed", colors.buttonPressed],
-      ["buttonDisabled", colors.buttonDisabled],
-      ["scrollbarTrack", colors.scrollbarTrack],
-      ["scrollbarThumb", colors.scrollbarThumb],
-      ["rowEven", colors.rowEven],
-      ["rowOdd", colors.rowOdd],
-      ["rowHover", colors.rowHover],
-      ["modalOverlay", colors.modalOverlay],
-    ];
-
-    const cols = 7;
-    const swatchW = 140;
-    const swatchH = 50;
-    const gap = 10;
-    const startX = 40;
-
-    for (let i = 0; i < swatches.length; i++) {
-      const [name, value] = swatches[i];
-      const col = i % cols;
-      const row = Math.floor(i / cols);
-      const sx = startX + col * (swatchW + gap);
-      const sy = y + row * (swatchH + 24 + gap);
-
-      const rect = this.add
-        .rectangle(sx, sy, swatchW, swatchH, value, 1)
-        .setOrigin(0, 0);
-      rect.setStrokeStyle(1, this.theme.colors.panelBorder, 0.6);
-      this.scrollContainer.add(rect);
-
-      const lbl = this.add
-        .text(sx, sy + swatchH + 4, `${name}\n${colorToString(value)}`, {
-          fontFamily: this.theme.fonts.caption.family,
-          fontSize: `${this.theme.fonts.caption.size}px`,
-          color: colorToString(this.theme.colors.textDim),
-        })
-        .setOrigin(0, 0);
-      this.scrollContainer.add(lbl);
+  private mountKnobsHost(): void {
+    // The styleguide canvas sits inside a Phaser scaled wrapper. The DOM
+    // overlay is appended to `document.body` and positioned absolutely.
+    // It does NOT scale with the canvas — it lives in screen pixels — so
+    // it remains usable regardless of FIT scaling.
+    const existing = document.getElementById("sg-knobs-panel");
+    if (existing && existing.parentNode) {
+      existing.parentNode.removeChild(existing);
     }
+    const host = document.createElement("div");
+    host.id = "sg-knobs-panel";
+    host.style.position = "fixed";
+    host.style.top = "12px";
+    host.style.right = "12px";
+    host.style.width = "260px";
+    host.style.maxHeight = "calc(100vh - 24px)";
+    host.style.overflow = "auto";
+    host.style.background = "rgba(10, 10, 24, 0.92)";
+    host.style.color = "#e0e0ff";
+    host.style.fontFamily = "monospace";
+    host.style.fontSize = "12px";
+    host.style.padding = "12px";
+    host.style.border = "1px solid #2a2a5a";
+    host.style.borderRadius = "4px";
+    host.style.zIndex = "1000";
 
-    const totalRows = Math.ceil(swatches.length / cols);
-    return y + totalRows * (swatchH + 24 + gap) + 20;
+    const heading = document.createElement("div");
+    heading.textContent = "KNOBS";
+    heading.style.fontSize = "11px";
+    heading.style.opacity = "0.7";
+    heading.style.letterSpacing = "1px";
+    heading.style.marginBottom = "10px";
+    heading.style.borderBottom = "1px solid #2a2a5a";
+    heading.style.paddingBottom = "6px";
+    host.appendChild(heading);
+
+    const body = document.createElement("div");
+    body.id = "sg-knobs-body";
+    host.appendChild(body);
+
+    document.body.appendChild(host);
+    this.knobsHost = host;
   }
 
-  /* ── 2. Typography ────────────────────────────────────────── */
-
-  private addTypographySection(y: number): number {
-    y = this.addSubheading(y, "TYPOGRAPHY");
-
-    const styles: Array<{
-      style: "heading" | "body" | "caption" | "value";
-      sample: string;
-    }> = [
-      { style: "heading", sample: "Heading – Orbitron 20px Bold" },
-      { style: "body", sample: "Body – Share Tech Mono 16px Regular" },
-      { style: "caption", sample: "Caption – Share Tech Mono 12px (dimmed)" },
-      { style: "value", sample: "Value – Orbitron 18px Bold (accent)" },
-    ];
-
-    for (const { style, sample } of styles) {
-      const label = new Label(this, { x: 60, y, text: sample, style });
-      this.scrollContainer.add(label);
-      y += 36;
+  private renderKnobsForActive(): void {
+    if (!this.knobsHost) return;
+    const body = this.knobsHost.querySelector<HTMLDivElement>("#sg-knobs-body");
+    if (!body) return;
+    if (this.knobsTeardown) {
+      this.knobsTeardown();
+      this.knobsTeardown = null;
     }
-
-    // Glow example
-    const glowLabel = new Label(this, {
-      x: 60,
-      y,
-      text: "Label with glow: true",
-      style: "heading",
-      color: this.theme.colors.accent,
-      glow: true,
-    });
-    this.scrollContainer.add(glowLabel);
-    y += 36;
-
-    // Colored labels
-    const colorExamples: [string, number][] = [
-      ["Profit label", this.theme.colors.profit],
-      ["Loss label", this.theme.colors.loss],
-      ["Warning label", this.theme.colors.warning],
-    ];
-    for (const [text, color] of colorExamples) {
-      const lbl = new Label(this, { x: 60, y, text, style: "body", color });
-      this.scrollContainer.add(lbl);
-      y += 28;
-    }
-
-    return y + 20;
-  }
-
-  /* ── 3. Buttons ───────────────────────────────────────────── */
-
-  private addButtonSection(y: number): number {
-    y = this.addSubheading(y, "BUTTONS");
-
-    const configs: Array<{ label: string; disabled?: boolean }> = [
-      { label: "Primary Action" },
-      { label: "Hover Me" },
-      { label: "Disabled", disabled: true },
-    ];
-
-    let x = 60;
-    for (const cfg of configs) {
-      const btn = new Button(this, {
-        x,
-        y: y + 20,
-        label: cfg.label,
-        disabled: cfg.disabled,
-        onClick: () => {
-          new FloatingText(this, x, y, "Clicked!", this.theme.colors.profit);
-        },
-      });
-      this.scrollContainer.add(btn);
-      x += btn.width + 20;
-    }
-
-    // Size variants on a second row — autoWidth sizes to content
-    const sizeConfigs: Array<{ label: string }> = [
-      { label: "Short" },
-      { label: "A Much Longer Label Here" },
-    ];
-
-    x = 60;
-    for (const cfg of sizeConfigs) {
-      const btn = new Button(this, {
-        x,
-        y: y + 70,
-        label: cfg.label,
-        autoWidth: true,
-        onClick: () => {
-          new FloatingText(
-            this,
-            x,
-            y + 50,
-            "Clicked!",
-            this.theme.colors.profit,
-          );
-        },
-      });
-      this.scrollContainer.add(btn);
-      x += btn.width + 20;
-    }
-
-    return y + 130;
-  }
-
-  /* ── 4. Panels ────────────────────────────────────────────── */
-
-  private addPanelSection(y: number): number {
-    y = this.addSubheading(y, "PANELS");
-
-    // Standard panel
-    const panel1 = new Panel(this, {
-      x: 40,
-      y,
-      width: 300,
-      height: 160,
-      title: "Standard Panel",
-    });
-    this.scrollContainer.add(panel1);
-
-    const panelBody = new Label(this, {
-      x: 55,
-      y: y + panel1.getContentY() + 10,
-      text: "Panel with title bar,\nchamfered border, and\nglowing idle animation.",
-      style: "body",
-    });
-    this.scrollContainer.add(panelBody);
-
-    // Panel without title
-    const panel2 = new Panel(this, {
-      x: 370,
-      y,
-      width: 280,
-      height: 160,
-    });
-    this.scrollContainer.add(panel2);
-
-    const p2Body = new Label(this, {
-      x: 385,
-      y: y + 20,
-      text: "Panel without title.\nNo drag, just display.",
-      style: "body",
-    });
-    this.scrollContainer.add(p2Body);
-
-    // Active panel
-    const panel3 = new Panel(this, {
-      x: 680,
-      y,
-      width: 280,
-      height: 160,
-      title: "Active Panel",
-    });
-    panel3.setActive(true);
-    this.scrollContainer.add(panel3);
-
-    const p3Body = new Label(this, {
-      x: 695,
-      y: y + panel3.getContentY() + 10,
-      text: "setActive(true) —\nbrighter glow for focus.",
-      style: "body",
-    });
-    this.scrollContainer.add(p3Body);
-
-    return y + 190;
-  }
-
-  /* ── 5. Progress Bars ─────────────────────────────────────── */
-
-  private addProgressBarSection(y: number): number {
-    y = this.addSubheading(y, "PROGRESS BARS");
-
-    const configs: Array<{
-      label: string;
-      value: number;
-      maxValue: number;
-      fillColor?: number;
-    }> = [
-      { label: "Default (70/100)", value: 70, maxValue: 100 },
-      {
-        label: "Profit (45/50)",
-        value: 45,
-        maxValue: 50,
-        fillColor: this.theme.colors.profit,
-      },
-      {
-        label: "Warning (20/100)",
-        value: 20,
-        maxValue: 100,
-        fillColor: this.theme.colors.warning,
-      },
-      {
-        label: "Loss (8/100)",
-        value: 8,
-        maxValue: 100,
-        fillColor: this.theme.colors.loss,
-      },
-      { label: "Full (100/100)", value: 100, maxValue: 100 },
-      { label: "Empty (0/100)", value: 0, maxValue: 100 },
-    ];
-
-    for (const cfg of configs) {
-      const lbl = new Label(this, {
-        x: 60,
-        y,
-        text: cfg.label,
-        style: "caption",
-      });
-      this.scrollContainer.add(lbl);
-
-      const bar = new ProgressBar(this, {
-        x: 60,
-        y: y + 18,
-        width: 400,
-        height: 18,
-        value: cfg.value,
-        maxValue: cfg.maxValue,
-        fillColor: cfg.fillColor,
-      });
-      this.scrollContainer.add(bar);
-      y += 52;
-    }
-
-    // Animated bar
-    const animLabel = new Label(this, {
-      x: 560,
-      y: y - 300,
-      text: "Animated fill:",
-      style: "caption",
-    });
-    this.scrollContainer.add(animLabel);
-    const animBar = new ProgressBar(this, {
-      x: 560,
-      y: y - 282,
-      width: 400,
-      height: 22,
-      value: 0,
-      maxValue: 100,
-    });
-    this.scrollContainer.add(animBar);
-
-    // Cycle animation
-    let animVal = 0;
-    let animDir = 1;
-    this.time.addEvent({
-      delay: 800,
-      loop: true,
-      callback: () => {
-        animVal += animDir * 15;
-        if (animVal >= 100) {
-          animVal = 100;
-          animDir = -1;
-        }
-        if (animVal <= 0) {
-          animVal = 0;
-          animDir = 1;
-        }
-        animBar.setValue(animVal, true);
-      },
-    });
-
-    return y + 20;
-  }
-
-  /* ── 6. Scrollable List ───────────────────────────────────── */
-
-  private addScrollableListSection(y: number): number {
-    y = this.addSubheading(y, "SCROLLABLE LIST");
-
-    const list = new ScrollableList(this, {
-      x: 60,
-      y,
-      width: 400,
-      height: 200,
-      itemHeight: 36,
-      onSelect: (idx) => {
-        new FloatingText(
-          this,
-          480,
-          y + 40,
-          `Selected #${idx}`,
-          this.theme.colors.accent,
-        );
-      },
-    });
-    this.scrollContainer.add(list);
-
-    // Populate with sample data
-    for (let i = 0; i < 20; i++) {
-      const row = this.add.container(0, 0);
-      const txt = new Label(this, {
-        x: 16,
-        y: 8,
-        text: `Item ${i + 1} — Sample list entry`,
-        style: "body",
-      });
-      row.add(txt);
-      list.addItem(row);
-    }
-
-    const desc = new Label(this, {
-      x: 500,
-      y: y + 10,
-      text: "ScrollableList\n• Mouse wheel scroll\n• Click to select\n• Keyboard nav (arrows/enter)\n• Geometry mask clipping",
-      style: "caption",
-      maxWidth: 300,
-    });
-    this.scrollContainer.add(desc);
-
-    return y + 230;
-  }
-
-  /* ── 7. Tab Group ─────────────────────────────────────────── */
-
-  private addTabGroupSection(y: number): number {
-    y = this.addSubheading(y, "TAB GROUP");
-
-    const tab1Content = this.add.container(0, 0);
-    tab1Content.add(
-      new Label(this, {
-        x: 16,
-        y: 16,
-        text: "Content for Tab 1\nThis is the first panel.",
-        style: "body",
-      }),
+    const section = this.getActiveSection();
+    if (!section) return;
+    const values = this.knobValuesById.get(section.id) ?? {};
+    this.knobsTeardown = renderKnobs(
+      body,
+      section.knobs ?? [],
+      values,
+      (id, value) => this.onKnobChange(id, value),
     );
-
-    const tab2Content = this.add.container(0, 0);
-    tab2Content.add(
-      new Label(this, {
-        x: 16,
-        y: 16,
-        text: "Content for Tab 2\nDifferent content here.",
-        style: "body",
-      }),
-    );
-
-    const tab3Content = this.add.container(0, 0);
-    tab3Content.add(
-      new Label(this, {
-        x: 16,
-        y: 16,
-        text: "Content for Tab 3\nYet another tab.",
-        style: "body",
-      }),
-    );
-
-    const tabGroup = new TabGroup(this, {
-      x: 60,
-      y,
-      width: 600,
-      tabs: [
-        { label: "Overview", content: tab1Content },
-        { label: "Details", content: tab2Content },
-        { label: "Settings", content: tab3Content },
-      ],
-    });
-    this.scrollContainer.add(tabGroup);
-
-    return y + 140;
   }
 
-  /* ── 8. Data Table ────────────────────────────────────────── */
-
-  private addDataTableSection(y: number): number {
-    y = this.addSubheading(y, "DATA TABLE");
-
-    const columns: ColumnDef[] = [
-      { key: "name", label: "Planet", width: 150, sortable: true },
-      { key: "commodity", label: "Commodity", width: 120, sortable: true },
-      {
-        key: "price",
-        label: "Price",
-        width: 80,
-        align: "right",
-        sortable: true,
-        format: (v: unknown) => `$${v}`,
-      },
-      {
-        key: "trend",
-        label: "Trend",
-        width: 80,
-        align: "right",
-        sortable: true,
-        format: (v: unknown) => `${Number(v) > 0 ? "+" : ""}${v}%`,
-        colorFn: (v: unknown) => {
-          const n = Number(v);
-          return n > 0
-            ? this.theme.colors.profit
-            : n < 0
-              ? this.theme.colors.loss
-              : this.theme.colors.textDim;
-        },
-      },
-      {
-        key: "supply",
-        label: "Supply",
-        width: 80,
-        align: "right",
-        sortable: true,
-      },
-    ];
-
-    const rows = [
-      {
-        name: "Solara Prime",
-        commodity: "Fuel Cells",
-        price: 124,
-        trend: 12,
-        supply: 450,
-      },
-      {
-        name: "Nova Station",
-        commodity: "Ore",
-        price: 89,
-        trend: -5,
-        supply: 1200,
-      },
-      {
-        name: "Zenith IV",
-        commodity: "Electronics",
-        price: 342,
-        trend: 3,
-        supply: 88,
-      },
-      {
-        name: "Dustfall",
-        commodity: "Food",
-        price: 45,
-        trend: -18,
-        supply: 3400,
-      },
-      {
-        name: "Helix Ring",
-        commodity: "Luxury Goods",
-        price: 780,
-        trend: 25,
-        supply: 22,
-      },
-      {
-        name: "Frost Haven",
-        commodity: "Water",
-        price: 32,
-        trend: 0,
-        supply: 5600,
-      },
-      {
-        name: "Ember Gate",
-        commodity: "Rare Metals",
-        price: 567,
-        trend: 8,
-        supply: 75,
-      },
-      {
-        name: "Drift Colony",
-        commodity: "Passengers",
-        price: 210,
-        trend: -2,
-        supply: 150,
-      },
-    ];
-
-    const table = new DataTable(this, {
-      x: 60,
-      y,
-      width: 560,
-      height: 260,
-      columns,
-      onRowSelect: (_rowIndex, rowData) => {
-        new FloatingText(
-          this,
-          640,
-          y + 40,
-          String(rowData["name"]),
-          this.theme.colors.accent,
-        );
-      },
-    });
-    table.setRows(rows);
-    this.scrollContainer.add(table);
-
-    const desc = new Label(this, {
-      x: 660,
-      y: y + 10,
-      text: "DataTable\n• Click headers to sort\n• Click rows to select\n• Scroll with mouse wheel\n• Color functions for cells\n• Custom formatters",
-      style: "caption",
-      maxWidth: 300,
-    });
-    this.scrollContainer.add(desc);
-
-    return y + 290;
+  private onKnobChange(id: string, value: KnobValue): void {
+    const section = this.getActiveSection();
+    if (!section) return;
+    const current = this.knobValuesById.get(section.id) ?? {};
+    this.knobValuesById.set(section.id, { ...current, [id]: value });
+    this.renderActiveSection();
   }
 
-  /* ── 9. Tooltips ──────────────────────────────────────────── */
+  /* ── Theme switching ────────────────────────────────────────── */
 
-  private addTooltipSection(y: number): number {
-    y = this.addSubheading(y, "TOOLTIPS");
-
-    const tooltip = new Tooltip(this);
-    this.scrollContainer.add(tooltip);
-
-    const targets: Array<{ label: string; tip: string }> = [
-      {
-        label: "Hover for info",
-        tip: "This is a standard tooltip.\nIt auto-positions near the cursor.",
-      },
-      {
-        label: "Another tooltip",
-        tip: "Tooltips support multi-line text\nand configurable delay + width.",
-      },
-      { label: "Short tip", tip: "Quick info." },
-    ];
-
-    let x = 60;
-    for (const { label, tip } of targets) {
-      const btn = new Button(this, {
-        x,
-        y: y + 10,
-        label,
-        autoWidth: true,
-        onClick: () => {},
-      });
-      this.scrollContainer.add(btn);
-      tooltip.attachTo(btn, tip);
-      x += btn.width + 24;
-    }
-
-    return y + 80;
+  private applyTheme(value: string): void {
+    const next = themeFromValue(value);
+    setTheme(next);
+    // Components read the theme on construction, so a full re-render
+    // of all chrome + active section is needed.
+    this.scene.restart();
   }
 
-  /* ── 10. Floating Text ────────────────────────────────────── */
+  /* ── Section switching / rendering ──────────────────────────── */
 
-  private addFloatingTextSection(y: number): number {
-    y = this.addSubheading(y, "FLOATING TEXT");
-
-    const sizes: Array<"small" | "medium" | "large" | "huge"> = [
-      "small",
-      "medium",
-      "large",
-      "huge",
-    ];
-    let x = 60;
-
-    for (const size of sizes) {
-      const btn = new Button(this, {
-        x,
-        y: y + 10,
-        label: size,
-        onClick: () => {
-          new FloatingText(
-            this,
-            x + 40,
-            y - 10 - this.scrollY,
-            `+$${Math.floor(Math.random() * 999)}`,
-            this.theme.colors.profit,
-            { size },
-          );
-        },
-      });
-      this.scrollContainer.add(btn);
-      x += 140;
-    }
-
-    // Bounce vs no-bounce
-    const btnBounce = new Button(this, {
-      x: x + 20,
-      y: y + 10,
-      label: "bounce: true",
-      autoWidth: true,
-      onClick: () => {
-        new FloatingText(
-          this,
-          x + 60,
-          y - 10 - this.scrollY,
-          "Bouncy!",
-          this.theme.colors.warning,
-          { bounce: true },
-        );
-      },
-    });
-    this.scrollContainer.add(btnBounce);
-
-    const btnNoBounce = new Button(this, {
-      x: x + btnBounce.width + 20,
-      y: y + 10,
-      label: "bounce: false",
-      autoWidth: true,
-      onClick: () => {
-        new FloatingText(
-          this,
-          x + 240,
-          y - 10 - this.scrollY,
-          "Smooth",
-          this.theme.colors.accent,
-          { bounce: false },
-        );
-      },
-    });
-    this.scrollContainer.add(btnNoBounce);
-
-    return y + 80;
+  private setActiveSection(id: string): void {
+    if (this.activeId === id) return;
+    this.activeId = id;
+    // Repaint side panel so the active marker moves.
+    this.sidePanelRoot.removeAll(true);
+    this.buildSidePanel();
+    this.renderActiveSection();
   }
 
-  /* ── 11. Ambient FX ───────────────────────────────────────── */
-
-  private addAmbientFxSection(y: number): number {
-    y = this.addSubheading(y, "AMBIENT FX");
-
-    const tweens: Phaser.Tweens.Tween[] = [];
-
-    // Pulse
-    const pulseTarget = this.add.circle(
-      100,
-      y + 40,
-      16,
-      this.theme.colors.accent,
-      0.8,
-    );
-    this.scrollContainer.add(pulseTarget);
-    tweens.push(
-      addPulseTween(this, pulseTarget, {
-        minAlpha: 0.3,
-        maxAlpha: 1.0,
-        duration: this.theme.ambient.panelIdlePulseDuration,
-      }),
-    );
-    const pulseLbl = new Label(this, {
-      x: 130,
-      y: y + 32,
-      text: "addPulseTween",
-      style: "caption",
-    });
-    this.scrollContainer.add(pulseLbl);
-
-    // Twinkle
-    const twinkleTarget = this.add.circle(
-      300,
-      y + 40,
-      16,
-      this.theme.colors.profit,
-      0.8,
-    );
-    this.scrollContainer.add(twinkleTarget);
-    tweens.push(
-      addTwinkleTween(this, twinkleTarget, {
-        minAlpha: 0.3,
-        maxAlpha: 1.0,
-        minDuration: this.theme.ambient.starTwinkleDurationMin,
-        maxDuration: this.theme.ambient.starTwinkleDurationMax,
-      }),
-    );
-    const twinkleLbl = new Label(this, {
-      x: 330,
-      y: y + 32,
-      text: "addTwinkleTween",
-      style: "caption",
-    });
-    this.scrollContainer.add(twinkleLbl);
-
-    // Float
-    const floatTarget = this.add.circle(
-      520,
-      y + 40,
-      16,
-      this.theme.colors.warning,
-      0.8,
-    );
-    this.scrollContainer.add(floatTarget);
-    tweens.push(
-      addFloatTween(this, floatTarget, { dx: 5, dy: -8, duration: 4000 }),
-    );
-    const floatLbl = new Label(this, {
-      x: 550,
-      y: y + 32,
-      text: "addFloatTween",
-      style: "caption",
-    });
-    this.scrollContainer.add(floatLbl);
-
-    registerAmbientCleanup(this, tweens);
-
-    // Flash screen button
-    const flashBtn = new Button(this, {
-      x: 720,
-      y: y + 28,
-      label: "flashScreen()",
-      onClick: () => flashScreen(this, 0xffffff),
-    });
-    this.scrollContainer.add(flashBtn);
-
-    return y + 90;
+  private getActiveSection(): StyleguideSection | undefined {
+    return styleguideSections.find((s) => s.id === this.activeId);
   }
 
-  /* ── 12. Milestones ───────────────────────────────────────── */
-
-  private addMilestoneSection(y: number): number {
-    y = this.addSubheading(y, "MILESTONE OVERLAYS");
-
-    const types: Array<{
-      type: Parameters<typeof MilestoneOverlay.show>[1];
-      label: string;
-    }> = [
-      { type: "big_profit", label: "Big Profit" },
-      { type: "profit_streak", label: "Profit Streak" },
-      { type: "record_profit", label: "Record Profit" },
-      { type: "loss_warning", label: "Loss Warning" },
-      { type: "bankruptcy_warning", label: "Bankruptcy" },
-      { type: "event_opportunity", label: "Opportunity" },
-      { type: "event_hazard", label: "Hazard" },
-      { type: "sim_complete", label: "Sim Complete" },
-    ];
-
-    let x = 60;
-    for (const { type, label } of types) {
-      const btn = new Button(this, {
-        x,
-        y: y + 10,
-        label,
-        onClick: () => {
-          MilestoneOverlay.show(
-            this,
-            type,
-            label,
-            "Subtitle text shown below",
-            undefined,
-            { holdDuration: 4000 },
-          );
-        },
-      });
-      this.scrollContainer.add(btn);
-      x += btn.width + 12;
-      if (x > GAME_WIDTH - 160) {
-        x = 60;
-        y += 50;
-      }
+  private renderActiveSection(): void {
+    const section = this.getActiveSection();
+    if (!section) return;
+    if (this.contentTitle) {
+      this.contentTitle.setText(section.title);
     }
-
-    return y + 80;
+    this.contentRoot.removeAll(true);
+    const values = this.knobValuesById.get(section.id) ?? {};
+    section.render(this, this.contentRoot, values);
+    this.renderKnobsForActive();
   }
 
-  /* ── 13. Modal ────────────────────────────────────────────── */
+  /* ── Cleanup ────────────────────────────────────────────────── */
 
-  private addModalSection(y: number): number {
-    y = this.addSubheading(y, "MODALS");
-
-    const btnModal = new Button(this, {
-      x: 60,
-      y: y + 10,
-      autoWidth: true,
-      label: "Open Confirm Modal",
-      onClick: () => {
-        new Modal(this, {
-          title: "Confirm Action",
-          body: "Are you sure you want to proceed?\nThis action cannot be undone.",
-          okText: "Confirm",
-          cancelText: "Cancel",
-          onOk: () =>
-            new FloatingText(
-              this,
-              GAME_WIDTH / 2,
-              300,
-              "Confirmed!",
-              this.theme.colors.profit,
-            ),
-          onCancel: () =>
-            new FloatingText(
-              this,
-              GAME_WIDTH / 2,
-              300,
-              "Cancelled",
-              this.theme.colors.loss,
-            ),
-        }).show();
-      },
-    });
-    this.scrollContainer.add(btnModal);
-
-    const btnInfo = new Button(this, {
-      x: 280,
-      y: y + 10,
-      autoWidth: true,
-      label: "Open Info Modal",
-      onClick: () => {
-        new Modal(this, {
-          title: "Information",
-          body: "This is an informational modal\nwith only an OK button.",
-          okText: "Got it",
-        }).show();
-      },
-    });
-    this.scrollContainer.add(btnInfo);
-
-    return y + 80;
+  private cleanup(): void {
+    if (this.knobsTeardown) {
+      this.knobsTeardown();
+      this.knobsTeardown = null;
+    }
+    if (this.knobsHost && this.knobsHost.parentNode) {
+      this.knobsHost.parentNode.removeChild(this.knobsHost);
+    }
+    this.knobsHost = null;
   }
-
-  /* ── 14. Icon Gallery ─────────────────────────────────────── */
-
-  private addIconGallerySection(y: number): number {
-    y = this.addSubheading(y, "ICON GALLERY");
-
-    const icons = [
-      { key: "icon-map", label: "Map" },
-      { key: "icon-fleet", label: "Fleet" },
-      { key: "icon-routes", label: "Routes" },
-      { key: "icon-finance", label: "Finance" },
-      { key: "icon-market", label: "Market" },
-      { key: "icon-audio", label: "Audio" },
-      { key: "icon-end-turn", label: "End Turn" },
-      { key: "icon-adviser", label: "Adviser" },
-    ];
-
-    let x = 60;
-    for (const { key, label } of icons) {
-      // Icon against a subtle bg
-      const bg = this.add
-        .rectangle(x, y, 56, 56, this.theme.colors.panelBg, 0.5)
-        .setOrigin(0, 0)
-        .setStrokeStyle(1, this.theme.colors.panelBorder, 0.4);
-      this.scrollContainer.add(bg);
-
-      const img = this.add
-        .image(x + 28, y + 28, key)
-        .setOrigin(0.5)
-        .setTint(this.theme.colors.accent);
-      this.scrollContainer.add(img);
-
-      const lbl = new Label(this, {
-        x: x + 28,
-        y: y + 62,
-        text: label,
-        style: "caption",
-        color: this.theme.colors.textDim,
-      }).setOrigin(0.5, 0);
-      this.scrollContainer.add(lbl);
-
-      x += 80;
-    }
-
-    // Hovered variants on second row
-    x = 60;
-    const hoverY = y + 90;
-    const hoverNote = new Label(this, {
-      x,
-      y: hoverY,
-      text: "Hover tint variants:",
-      style: "caption",
-      color: this.theme.colors.textDim,
-    });
-    this.scrollContainer.add(hoverNote);
-
-    x = 250;
-    const tints = [
-      { label: "accent", color: this.theme.colors.accent },
-      { label: "text", color: this.theme.colors.text },
-      { label: "profit", color: this.theme.colors.profit },
-      { label: "warning", color: this.theme.colors.warning },
-      { label: "loss", color: this.theme.colors.loss },
-    ];
-    for (const { label, color } of tints) {
-      const img = this.add
-        .image(x + 14, hoverY + 8, "icon-map")
-        .setOrigin(0.5)
-        .setTint(color);
-      this.scrollContainer.add(img);
-
-      const lbl = new Label(this, {
-        x: x + 32,
-        y: hoverY + 2,
-        text: label,
-        style: "caption",
-        color,
-      });
-      this.scrollContainer.add(lbl);
-      x += 100;
-    }
-
-    return hoverY + 40;
-  }
-
-  /* ── 14b. Cargo Icons ─────────────────────────────────────── */
-
-  private addCargoIconSection(y: number): number {
-    y = this.addSubheading(y, "CARGO ICONS");
-
-    let x = 60;
-    for (const ct of CARGO_TYPE_LIST) {
-      const color = getCargoColor(ct);
-      const label = getCargoLabel(ct);
-      const key = getCargoIconKey(ct);
-
-      const bg = this.add
-        .rectangle(x, y, 56, 56, this.theme.colors.panelBg, 0.5)
-        .setOrigin(0, 0)
-        .setStrokeStyle(1, this.theme.colors.panelBorder, 0.4);
-      this.scrollContainer.add(bg);
-
-      const img = this.add
-        .image(x + 28, y + 28, key)
-        .setOrigin(0.5)
-        .setTint(color);
-      this.scrollContainer.add(img);
-
-      const lbl = new Label(this, {
-        x: x + 28,
-        y: y + 62,
-        text: label,
-        style: "caption",
-        color,
-      }).setOrigin(0.5, 0);
-      this.scrollContainer.add(lbl);
-
-      x += 90;
-    }
-
-    return y + 90;
-  }
-
-  /* ── 15. HUD Bar ──────────────────────────────────────────── */
-
-  private addHudBarSection(y: number): number {
-    y = this.addSubheading(y, "HUD BAR & DIVIDERS");
-
-    // Show nine-slice HUD bar texture
-    const barW = 600;
-    const bar = this.add
-      .nineslice(60, y, "hud-bar-bg", undefined, barW, 48, 10, 10, 10, 10)
-      .setOrigin(0, 0);
-    this.scrollContainer.add(bar);
-
-    const barLbl = new Label(this, {
-      x: 70 + barW / 2,
-      y: y + 14,
-      text: "hud-bar-bg (NineSlice)",
-      style: "caption",
-      color: this.theme.colors.textDim,
-    }).setOrigin(0.5, 0);
-    this.scrollContainer.add(barLbl);
-
-    y += 60;
-
-    // Divider
-    const divW = 400;
-    const div = this.add
-      .nineslice(60, y, "divider-h", undefined, divW, 4, 2, 2, 0, 0)
-      .setOrigin(0, 0);
-    this.scrollContainer.add(div);
-
-    const divLbl = new Label(this, {
-      x: 60 + divW + 16,
-      y: y - 4,
-      text: "divider-h",
-      style: "caption",
-      color: this.theme.colors.textDim,
-    });
-    this.scrollContainer.add(divLbl);
-
-    y += 24;
-
-    // Layout reference
-    const layoutInfo = [
-      `HUD_TOP_BAR_HEIGHT: ${HUD_TOP_BAR_HEIGHT}`,
-      `HUD_BOTTOM_BAR_HEIGHT: ${HUD_BOTTOM_BAR_HEIGHT}`,
-      `NAV_SIDEBAR_WIDTH: ${NAV_SIDEBAR_WIDTH}`,
-    ];
-    for (const info of layoutInfo) {
-      const lbl = new Label(this, {
-        x: 60,
-        y,
-        text: info,
-        style: "caption",
-        color: this.theme.colors.textDim,
-      });
-      this.scrollContainer.add(lbl);
-      y += 18;
-    }
-
-    return y + 20;
-  }
-
-  /* ── 16. Adviser Portrait ─────────────────────────────────── */
-
-  private addAdviserPortraitSection(y: number): number {
-    y = this.addSubheading(y, "ADVISER PORTRAIT — REX K9-CORP");
-
-    const moods: AdviserMood[] = ["standby", "analyzing", "alert", "success"];
-    const portraitSize = 128;
-    let x = 60;
-
-    for (const mood of moods) {
-      // Portrait graphics
-      const g = this.add.graphics();
-      g.setPosition(x, y);
-      drawRexPortrait(g, portraitSize, portraitSize, mood);
-      this.scrollContainer.add(g);
-
-      // Accent border matching mood
-      const accentColor = getMoodAccentColor(mood);
-      const border = this.add
-        .rectangle(x, y, portraitSize, portraitSize)
-        .setOrigin(0, 0)
-        .setStrokeStyle(2, accentColor, 0.6);
-      border.isFilled = false;
-      this.scrollContainer.add(border);
-
-      // Mood label
-      const lbl = new Label(this, {
-        x: x + portraitSize / 2,
-        y: y + portraitSize + 6,
-        text: mood,
-        style: "caption",
-        color: accentColor,
-      }).setOrigin(0.5, 0);
-      this.scrollContainer.add(lbl);
-
-      // Accent color hex
-      const hex = new Label(this, {
-        x: x + portraitSize / 2,
-        y: y + portraitSize + 22,
-        text: colorToString(accentColor),
-        style: "caption",
-        color: this.theme.colors.textDim,
-      }).setOrigin(0.5, 0);
-      this.scrollContainer.add(hex);
-
-      x += portraitSize + 24;
-    }
-
-    // Description
-    const descX = x + 30;
-    const desc = new Label(this, {
-      x: descX,
-      y: y + 10,
-      text: "Rex — K9-Corp Advisor\n32×32 pixel grid\n4 mood states\nProcedural pixel art\nwith mood-specific\naccents and expressions",
-      style: "caption",
-      color: this.theme.colors.textDim,
-      maxWidth: 200,
-    });
-    this.scrollContainer.add(desc);
-
-    return y + portraitSize + 50;
-  }
-
-  /* ── 17. Portrait Gallery ─────────────────────────────────── */
-
-  private addPortraitGallerySection(y: number): number {
-    y = this.addSubheading(y, "PORTRAIT GALLERY — PROCEDURAL PIXEL ART");
-
-    const size = 96;
-    const gap = 16;
-
-    // ── Planet types ──
-    const planetsLabel = new Label(this, {
-      x: 60,
-      y,
-      text: "Planets",
-      style: "body",
-      color: this.theme.colors.text,
-    });
-    this.scrollContainer.add(planetsLabel);
-    y += 24;
-
-    const planetTypes: Array<{
-      label: string;
-      planetType: string;
-    }> = [
-      { label: "Terran", planetType: "terran" },
-      { label: "Mining", planetType: "mining" },
-      { label: "Agricultural", planetType: "agricultural" },
-      { label: "Industrial", planetType: "industrial" },
-      { label: "Hub Station", planetType: "hubStation" },
-      { label: "Resort", planetType: "resort" },
-      { label: "Research", planetType: "research" },
-    ];
-
-    let x = 60;
-    for (const { label, planetType } of planetTypes) {
-      const g = this.add.graphics();
-      g.setPosition(x, y);
-      drawPortrait(g, "planet", size, size, 42, {
-        planetType: planetType as "terran",
-      });
-      this.scrollContainer.add(g);
-
-      const border = this.add
-        .rectangle(x, y, size, size)
-        .setOrigin(0, 0)
-        .setStrokeStyle(1, this.theme.colors.panelBorder, 0.4);
-      border.isFilled = false;
-      this.scrollContainer.add(border);
-
-      const lbl = new Label(this, {
-        x: x + size / 2,
-        y: y + size + 4,
-        text: label,
-        style: "caption",
-        color: this.theme.colors.textDim,
-      }).setOrigin(0.5, 0);
-      this.scrollContainer.add(lbl);
-
-      x += size + gap;
-    }
-
-    y += size + 34;
-
-    // ── Ships, Systems, Events ──
-    const otherLabel = new Label(this, {
-      x: 60,
-      y,
-      text: "Ships / Systems / Events",
-      style: "body",
-      color: this.theme.colors.text,
-    });
-    this.scrollContainer.add(otherLabel);
-    y += 24;
-
-    const otherTypes: Array<{
-      label: string;
-      type: "ship" | "system" | "event";
-      data?: PortraitData;
-    }> = [
-      {
-        label: "Ship (shuttle)",
-        type: "ship",
-        data: { shipClass: "cargoShuttle" },
-      },
-      {
-        label: "Ship (freighter)",
-        type: "ship",
-        data: { shipClass: "bulkFreighter" },
-      },
-      {
-        label: "Ship (hauler)",
-        type: "ship",
-        data: { shipClass: "mixedHauler" },
-      },
-      {
-        label: "System",
-        type: "system",
-        data: { starColor: 0xffd700, planetCount: 5 },
-      },
-      {
-        label: "Event (market)",
-        type: "event",
-        data: { eventCategory: "market" },
-      },
-      {
-        label: "Event (hazard)",
-        type: "event",
-        data: { eventCategory: "hazard" },
-      },
-    ];
-
-    x = 60;
-    for (const item of otherTypes) {
-      const g = this.add.graphics();
-      g.setPosition(x, y);
-      drawPortrait(g, item.type, size, size, 123, item.data);
-      this.scrollContainer.add(g);
-
-      const border = this.add
-        .rectangle(x, y, size, size)
-        .setOrigin(0, 0)
-        .setStrokeStyle(1, this.theme.colors.panelBorder, 0.4);
-      border.isFilled = false;
-      this.scrollContainer.add(border);
-
-      const lbl = new Label(this, {
-        x: x + size / 2,
-        y: y + size + 4,
-        text: item.label,
-        style: "caption",
-        color: this.theme.colors.textDim,
-      }).setOrigin(0.5, 0);
-      this.scrollContainer.add(lbl);
-
-      x += size + gap;
-    }
-
-    y += size + 34;
-
-    // ── Aliens ──
-    const alienLabel = new Label(this, {
-      x: 60,
-      y,
-      text: "Aliens",
-      style: "body",
-      color: this.theme.colors.text,
-    });
-    this.scrollContainer.add(alienLabel);
-    y += 24;
-
-    const alienRoles: AlienRole[] = [
-      "broker",
-      "miner",
-      "researcher",
-      "concierge",
-      "enforcer",
-    ];
-
-    x = 60;
-    for (const role of alienRoles) {
-      const g = this.add.graphics();
-      g.setPosition(x, y);
-      drawPortrait(g, "alien", size, size, 77, { alienRole: role });
-      this.scrollContainer.add(g);
-
-      const border = this.add
-        .rectangle(x, y, size, size)
-        .setOrigin(0, 0)
-        .setStrokeStyle(1, this.theme.colors.panelBorder, 0.4);
-      border.isFilled = false;
-      this.scrollContainer.add(border);
-
-      const lbl = new Label(this, {
-        x: x + size / 2,
-        y: y + size + 4,
-        text: role,
-        style: "caption",
-        color: this.theme.colors.textDim,
-      }).setOrigin(0.5, 0);
-      this.scrollContainer.add(lbl);
-
-      x += size + gap;
-    }
-
-    y += size + 34;
-
-    // ── Seed variation ──
-    const seedLabel = new Label(this, {
-      x: 60,
-      y,
-      text: "Seed variation (same type, different seeds)",
-      style: "body",
-      color: this.theme.colors.text,
-    });
-    this.scrollContainer.add(seedLabel);
-    y += 24;
-
-    x = 60;
-    for (let seed = 1; seed <= 8; seed++) {
-      const g = this.add.graphics();
-      g.setPosition(x, y);
-      drawPortrait(g, "planet", size, size, seed * 17, {
-        planetType: "terran",
-      });
-      this.scrollContainer.add(g);
-
-      const lbl = new Label(this, {
-        x: x + size / 2,
-        y: y + size + 4,
-        text: `seed ${seed * 17}`,
-        style: "caption",
-        color: this.theme.colors.textDim,
-      }).setOrigin(0.5, 0);
-      this.scrollContainer.add(lbl);
-
-      x += size + gap;
-    }
-
-    return y + size + 34;
-  }
-
-  /* ── 18. Spacing & Layout Guide ───────────────────────────── */
-
-  private addSpacingLayoutSection(y: number): number {
-    y = this.addSubheading(y, "SPACING & LAYOUT TOKENS");
-
-    const spacing = this.theme.spacing;
-    const spacingTokens: Array<{ name: string; value: number }> = [
-      { name: "xs", value: spacing.xs },
-      { name: "sm", value: spacing.sm },
-      { name: "md", value: spacing.md },
-      { name: "lg", value: spacing.lg },
-      { name: "xl", value: spacing.xl },
-    ];
-
-    let x = 60;
-    for (const { name, value } of spacingTokens) {
-      // Visual size block
-      const block = this.add
-        .rectangle(x, y, value, value, this.theme.colors.accent, 0.5)
-        .setOrigin(0, 0)
-        .setStrokeStyle(1, this.theme.colors.accent, 0.8);
-      this.scrollContainer.add(block);
-
-      const lbl = new Label(this, {
-        x: x + Math.max(value, 20) / 2,
-        y: y + Math.max(value, 4) + 8,
-        text: `${name}\n${value}px`,
-        style: "caption",
-        color: this.theme.colors.textDim,
-      }).setOrigin(0.5, 0);
-      this.scrollContainer.add(lbl);
-
-      x += Math.max(value, 30) + 30;
-    }
-
-    y += 70;
-
-    // Layout constants table
-    const layoutConstants: Array<{ name: string; value: number }> = [
-      { name: "GAME_WIDTH", value: GAME_WIDTH },
-      { name: "GAME_HEIGHT", value: GAME_HEIGHT },
-      { name: "MAX_CONTENT_WIDTH", value: MAX_CONTENT_WIDTH },
-      { name: "SIDEBAR_WIDTH", value: SIDEBAR_WIDTH },
-      { name: "CONTENT_GAP", value: CONTENT_GAP },
-      { name: "NAV_SIDEBAR_WIDTH", value: NAV_SIDEBAR_WIDTH },
-      { name: "CONTENT_TOP", value: CONTENT_TOP },
-      { name: "CONTENT_HEIGHT", value: CONTENT_HEIGHT },
-      { name: "CONTENT_LEFT", value: CONTENT_LEFT },
-      { name: "SIDEBAR_LEFT", value: SIDEBAR_LEFT },
-      { name: "MAIN_CONTENT_LEFT", value: MAIN_CONTENT_LEFT },
-      { name: "MAIN_CONTENT_WIDTH", value: MAIN_CONTENT_WIDTH },
-      { name: "FULL_CONTENT_LEFT", value: FULL_CONTENT_LEFT },
-      { name: "FULL_CONTENT_WIDTH", value: FULL_CONTENT_WIDTH },
-    ];
-
-    const colWidth = 260;
-    let col = 0;
-    const startY = y;
-    for (const { name, value } of layoutConstants) {
-      const cx = 60 + col * colWidth;
-      const lbl = new Label(this, {
-        x: cx,
-        y,
-        text: `${name}: ${value}`,
-        style: "caption",
-        color: this.theme.colors.textDim,
-      });
-      this.scrollContainer.add(lbl);
-      y += 18;
-
-      // Wrap to next column after 7 items
-      if ((layoutConstants.indexOf({ name, value }) + 1) % 7 === 0) {
-        col++;
-        y = startY;
-      }
-    }
-
-    // Two-column layout — reset y to below longest column
-    y = startY + Math.ceil(layoutConstants.length / 2) * 18;
-
-    return y + 20;
-  }
-
-  /* ── 19. Depth Layers Reference ───────────────────────────── */
-
-  private addDepthLayersSection(y: number): number {
-    y = this.addSubheading(y, "DEPTH LAYERS");
-
-    const layers: Array<{ name: string; value: number; color: number }> = [
-      {
-        name: "DEPTH_STARFIELD",
-        value: DEPTH_STARFIELD,
-        color: 0x335577,
-      },
-      {
-        name: "DEPTH_AMBIENT_MID",
-        value: DEPTH_AMBIENT_MID,
-        color: 0x557799,
-      },
-      {
-        name: "DEPTH_CONTENT",
-        value: DEPTH_CONTENT,
-        color: this.theme.colors.text,
-      },
-      { name: "DEPTH_UI", value: DEPTH_UI, color: this.theme.colors.accent },
-      {
-        name: "DEPTH_MODAL",
-        value: DEPTH_MODAL,
-        color: this.theme.colors.warning,
-      },
-      { name: "DEPTH_HUD", value: DEPTH_HUD, color: this.theme.colors.profit },
-    ];
-
-    const barMaxW = 500;
-    const barH = 24;
-    const maxDepth = DEPTH_HUD;
-
-    for (const { name, value, color } of layers) {
-      // Depth bar (log-scale visual)
-      const normalised =
-        value <= 0
-          ? 20
-          : Math.max(
-              20,
-              (Math.log10(value + 1) / Math.log10(maxDepth + 1)) * barMaxW,
-            );
-      const bar = this.add
-        .rectangle(60, y, normalised, barH, color, 0.5)
-        .setOrigin(0, 0)
-        .setStrokeStyle(1, color, 0.7);
-      this.scrollContainer.add(bar);
-
-      const lbl = new Label(this, {
-        x: 70 + normalised,
-        y: y + 4,
-        text: `${name} = ${value}`,
-        style: "caption",
-        color,
-      });
-      this.scrollContainer.add(lbl);
-
-      y += barH + 8;
-    }
-
-    return y + 20;
-  }
-
-  /* ── 20. Glass Effect Showcase ────────────────────────────── */
-
-  private addGlassEffectSection(y: number): number {
-    y = this.addSubheading(y, "GLASS EFFECT & CHAMFER");
-
-    const { glass, chamfer, panel } = this.theme;
-
-    // Visual demo — panel with labelled effects
-    const demoPanel = new Panel(this, {
-      x: 60,
-      y,
-      width: 350,
-      height: 180,
-      title: "Glass Effect Demo",
-    });
-    this.scrollContainer.add(demoPanel);
-
-    // Annotate config values
-    const configLabels = [
-      `glass.bgAlpha: ${glass.bgAlpha}`,
-      `glass.topTint: ${colorToString(glass.topTint)}`,
-      `glass.bottomTint: ${colorToString(glass.bottomTint)}`,
-      `glass.innerBorderAlpha: ${glass.innerBorderAlpha}`,
-      `chamfer.size: ${chamfer.size}`,
-      `panel.borderWidth: ${panel.borderWidth}`,
-    ];
-
-    let configY = y + 10;
-    for (const text of configLabels) {
-      const lbl = new Label(this, {
-        x: 440,
-        y: configY,
-        text,
-        style: "caption",
-        color: this.theme.colors.textDim,
-      });
-      this.scrollContainer.add(lbl);
-      configY += 18;
-    }
-
-    // Chamfer size comparison
-    const chamferSizes = [0, 4, 8, 12, 16];
-    let cx = 60;
-    const chamferY = y + 200;
-
-    const chamferTitle = new Label(this, {
-      x: 60,
-      y: chamferY - 20,
-      text: "Chamfer size comparison (visual approximation):",
-      style: "caption",
-      color: this.theme.colors.textDim,
-    });
-    this.scrollContainer.add(chamferTitle);
-
-    for (const size of chamferSizes) {
-      const rect = this.add
-        .rectangle(cx, chamferY, 80, 60, this.theme.colors.panelBg, 0.6)
-        .setOrigin(0, 0)
-        .setStrokeStyle(1, this.theme.colors.panelBorder, 0.6);
-      this.scrollContainer.add(rect);
-
-      const lbl = new Label(this, {
-        x: cx + 40,
-        y: chamferY + 66,
-        text: `${size}px`,
-        style: "caption",
-        color: this.theme.colors.textDim,
-      }).setOrigin(0.5, 0);
-      this.scrollContainer.add(lbl);
-
-      cx += 100;
-    }
-
-    return chamferY + 90;
-  }
-
-  /* ── 21. Animation Timing Guide ───────────────────────────── */
-
-  private addAnimationTimingSection(y: number): number {
-    y = this.addSubheading(y, "ANIMATION / AMBIENT TIMING");
-
-    const ambient = this.theme.ambient;
-    const timings: Array<{ name: string; value: number; unit?: string }> = [
-      {
-        name: "starTwinkleDurationMin",
-        value: ambient.starTwinkleDurationMin,
-        unit: "ms",
-      },
-      {
-        name: "starTwinkleDurationMax",
-        value: ambient.starTwinkleDurationMax,
-        unit: "ms",
-      },
-      {
-        name: "starShimmerDuration",
-        value: ambient.starShimmerDuration,
-        unit: "ms",
-      },
-      {
-        name: "routePulseDuration",
-        value: ambient.routePulseDuration,
-        unit: "ms",
-      },
-      {
-        name: "routePulseAlphaMin",
-        value: ambient.routePulseAlphaMin,
-      },
-      {
-        name: "routePulseAlphaMax",
-        value: ambient.routePulseAlphaMax,
-      },
-      {
-        name: "routeFlowDuration",
-        value: ambient.routeFlowDuration,
-        unit: "ms",
-      },
-      {
-        name: "panelIdlePulseDuration",
-        value: ambient.panelIdlePulseDuration,
-        unit: "ms",
-      },
-      {
-        name: "buttonIdleShimmerDuration",
-        value: ambient.buttonIdleShimmerDuration,
-        unit: "ms",
-      },
-      {
-        name: "orbitalRotationDuration",
-        value: ambient.orbitalRotationDuration,
-        unit: "ms",
-      },
-    ];
-
-    const colWidth = 360;
-    let col = 0;
-    const startY = y;
-    let currentY = y;
-    let maxY = y;
-
-    for (let i = 0; i < timings.length; i++) {
-      const { name, value, unit } = timings[i];
-      const cx = 60 + col * colWidth;
-      const display = unit ? `${value}${unit}` : `${value}`;
-
-      const lbl = new Label(this, {
-        x: cx,
-        y: currentY,
-        text: `${name}: ${display}`,
-        style: "caption",
-        color: this.theme.colors.textDim,
-      });
-      this.scrollContainer.add(lbl);
-
-      currentY += 20;
-      if (currentY > maxY) maxY = currentY;
-
-      // Split into two columns
-      if (i === 4) {
-        col = 1;
-        currentY = startY;
-      }
-    }
-
-    return maxY + 20;
-  }
-
-  /* ── 22. StatRow Widget ───────────────────────────────────── */
-
-  private addStatRowSection(y: number): number {
-    y = this.addSubheading(y, "STAT ROW WIDGET");
-
-    const rows: Array<{
-      label: string;
-      value: string;
-      valueColor?: number;
-      compact?: boolean;
-    }> = [
-      { label: "Credits", value: "$12,450" },
-      {
-        label: "Fuel Level",
-        value: "85%",
-        valueColor: this.theme.colors.profit,
-      },
-      {
-        label: "Risk Factor",
-        value: "HIGH",
-        valueColor: this.theme.colors.loss,
-      },
-      { label: "Distance", value: "42 LY", compact: true },
-      {
-        label: "Profit Margin",
-        value: "+18.5%",
-        valueColor: this.theme.colors.profit,
-        compact: true,
-      },
-    ];
-
-    for (const cfg of rows) {
-      const row = new StatRow(this, {
-        x: 60,
-        y,
-        width: 400,
-        ...cfg,
-      });
-      // Re-parent into scroll container
-      this.children.remove(row);
-      this.scrollContainer.add(row);
-      y += row.rowHeight + 4;
-    }
-
-    const desc = new Label(this, {
-      x: 500,
-      y: y - 80,
-      text: "StatRow\n• Key→value with leader line\n• Optional color override\n• Compact mode for dense layouts\n• Used in InfoCard, HUD, and\n  detail panels",
-      style: "caption",
-      color: this.theme.colors.textDim,
-      maxWidth: 300,
-    });
-    this.scrollContainer.add(desc);
-
-    return y + 20;
-  }
-
-  /* ── 23. InfoCard Widget ──────────────────────────────────── */
-
-  private addInfoCardSection(y: number): number {
-    y = this.addSubheading(y, "INFO CARD WIDGET");
-
-    // Standard card
-    const card1 = new InfoCard(this, {
-      x: 60,
-      y,
-      width: 280,
-      title: "Solara Prime",
-      stats: [
-        { label: "Population", value: "2.4M" },
-        { label: "Economy", value: "Industrial" },
-        {
-          label: "Trade Volume",
-          value: "$450K",
-          valueColor: this.theme.colors.profit,
-        },
-        { label: "Tax Rate", value: "12%" },
-      ],
-      description:
-        "A thriving industrial world with significant mining operations and growing trade networks.",
-    });
-    this.children.remove(card1);
-    this.scrollContainer.add(card1);
-
-    // Compact card
-    const card2 = new InfoCard(this, {
-      x: 380,
-      y,
-      width: 240,
-      title: "Ship Status",
-      stats: [
-        { label: "Hull", value: "92%", valueColor: this.theme.colors.profit },
-        { label: "Fuel", value: "45%", valueColor: this.theme.colors.warning },
-        { label: "Cargo", value: "8/12" },
-        { label: "Speed", value: "3.2 LY/turn" },
-      ],
-      compact: true,
-    });
-    this.children.remove(card2);
-    this.scrollContainer.add(card2);
-
-    // Danger-themed card
-    const card3 = new InfoCard(this, {
-      x: 660,
-      y,
-      width: 260,
-      title: "⚠ Risk Alert",
-      stats: [
-        {
-          label: "Pirate Threat",
-          value: "HIGH",
-          valueColor: this.theme.colors.loss,
-        },
-        {
-          label: "Hull Damage",
-          value: "34%",
-          valueColor: this.theme.colors.loss,
-        },
-        {
-          label: "Escape Route",
-          value: "Available",
-          valueColor: this.theme.colors.profit,
-        },
-      ],
-      description: "Hostile territory ahead. Proceed with caution.",
-    });
-    this.children.remove(card3);
-    this.scrollContainer.add(card3);
-
-    const maxH = Math.max(card1.cardHeight, card2.cardHeight, card3.cardHeight);
-    return y + maxH + 20;
-  }
-
-  /* ── 24. IconButton Widget ────────────────────────────────── */
-
-  private addIconButtonSection(y: number): number {
-    y = this.addSubheading(y, "ICON BUTTON WIDGET");
-
-    const icons = [
-      { icon: "icon-map", label: "Map" },
-      { icon: "icon-fleet", label: "Fleet" },
-      { icon: "icon-routes", label: "Routes" },
-      { icon: "icon-finance", label: "Finance" },
-      { icon: "icon-market", label: "Market" },
-    ];
-
-    // Row 1: Icon-only buttons
-    let x = 60;
-    const row1Label = new Label(this, {
-      x,
-      y: y - 2,
-      text: "Icon-only:",
-      style: "caption",
-      color: this.theme.colors.textDim,
-    });
-    this.scrollContainer.add(row1Label);
-    x = 160;
-
-    for (let i = 0; i < icons.length; i++) {
-      const btn = new IconButton(this, {
-        x,
-        y,
-        icon: icons[i].icon,
-        active: i === 0,
-        onClick: () => {
-          new FloatingText(
-            this,
-            x + 20,
-            y - 10 - this.scrollY,
-            icons[i].label,
-            this.theme.colors.accent,
-          );
-        },
-      });
-      this.children.remove(btn);
-      this.scrollContainer.add(btn);
-      x += 50;
-    }
-
-    y += 50;
-
-    // Row 2: Icon + label buttons
-    x = 60;
-    const row2Label = new Label(this, {
-      x,
-      y: y - 2,
-      text: "With labels:",
-      style: "caption",
-      color: this.theme.colors.textDim,
-    });
-    this.scrollContainer.add(row2Label);
-    x = 160;
-
-    for (let i = 0; i < 3; i++) {
-      const btn = new IconButton(this, {
-        x,
-        y,
-        icon: icons[i].icon,
-        label: icons[i].label,
-        active: i === 1,
-        onClick: () => {},
-      });
-      this.children.remove(btn);
-      this.scrollContainer.add(btn);
-      x += 140;
-    }
-
-    y += 50;
-
-    // Row 3: Disabled
-    x = 60;
-    const row3Label = new Label(this, {
-      x,
-      y: y - 2,
-      text: "Disabled:",
-      style: "caption",
-      color: this.theme.colors.textDim,
-    });
-    this.scrollContainer.add(row3Label);
-
-    const disabledBtn = new IconButton(this, {
-      x: 160,
-      y,
-      icon: "icon-end-turn",
-      label: "End Turn",
-      disabled: true,
-      onClick: () => {},
-    });
-    this.children.remove(disabledBtn);
-    this.scrollContainer.add(disabledBtn);
-
-    return y + 50;
-  }
-
-  /* ── 25. Status Badge Widget ──────────────────────────────── */
-
-  private addStatusBadgeSection(y: number): number {
-    y = this.addSubheading(y, "STATUS BADGE WIDGET");
-
-    const variants: Array<{
-      text: string;
-      variant: BadgeVariant;
-      pulse?: boolean;
-    }> = [
-      { text: "Online", variant: "success" },
-      { text: "In Transit", variant: "info" },
-      { text: "Low Fuel", variant: "warning" },
-      { text: "Critical", variant: "danger", pulse: true },
-      { text: "Idle", variant: "neutral" },
-    ];
-
-    let x = 60;
-    for (const cfg of variants) {
-      const badge = new StatusBadge(this, {
-        x,
-        y,
-        ...cfg,
-      });
-      this.children.remove(badge);
-      this.scrollContainer.add(badge);
-
-      const lbl = new Label(this, {
-        x: x + badge.badgeWidth / 2,
-        y: y + badge.badgeHeight + 6,
-        text: cfg.variant,
-        style: "caption",
-        color: this.theme.colors.textDim,
-      }).setOrigin(0.5, 0);
-      this.scrollContainer.add(lbl);
-
-      x += badge.badgeWidth + 20;
-    }
-
-    y += 50;
-
-    // Contextual usage examples
-    const usageLabel = new Label(this, {
-      x: 60,
-      y,
-      text: "Contextual usage examples:",
-      style: "caption",
-      color: this.theme.colors.textDim,
-    });
-    this.scrollContainer.add(usageLabel);
-    y += 20;
-
-    const contextBadges: Array<{
-      text: string;
-      variant: BadgeVariant;
-    }> = [
-      { text: "Profit Streak", variant: "success" },
-      { text: "Market Crash", variant: "danger" },
-      { text: "Trade Route Active", variant: "info" },
-      { text: "Fuel Warning", variant: "warning" },
-      { text: "Docked", variant: "neutral" },
-      { text: "Bonus Active", variant: "success" },
-    ];
-
-    x = 60;
-    for (const cfg of contextBadges) {
-      const badge = new StatusBadge(this, { x, y, ...cfg });
-      this.children.remove(badge);
-      this.scrollContainer.add(badge);
-      x += badge.badgeWidth + 12;
-
-      if (x > GAME_WIDTH - 200) {
-        x = 60;
-        y += 30;
-      }
-    }
-
-    return y + 40;
+}
+
+function themeFromValue(value: string): ThemeConfig {
+  switch (value) {
+    case "light":
+      return lightTheme;
+    case "high-contrast":
+      return highContrastTheme;
+    case "dark":
+    default:
+      return darkTheme;
   }
 }

--- a/styleguide/sectionGrouping.ts
+++ b/styleguide/sectionGrouping.ts
@@ -1,0 +1,50 @@
+import type * as Phaser from "phaser";
+import type { KnobDef, KnobValues } from "./knobs/index.ts";
+
+/**
+ * A renderable styleguide section.
+ *
+ * `render` is given a clean container — anything it adds will be cleaned up
+ * by the scene when the section changes. The render is re-invoked when the
+ * theme is changed or any knob value changes, so it MUST be idempotent and
+ * MUST NOT keep singleton state outside the supplied container.
+ */
+export interface StyleguideSection {
+  id: string;
+  title: string;
+  category: string;
+  knobs?: ReadonlyArray<KnobDef>;
+  render: (
+    scene: Phaser.Scene,
+    container: Phaser.GameObjects.Container,
+    knobs: KnobValues,
+  ) => void;
+}
+
+/**
+ * Group sections by their `category`, preserving insertion order.
+ *
+ * Lives in its own module (separate from `registry.ts`) so unit tests can
+ * import the grouping logic without transitively pulling in Phaser-bound
+ * section renderers.
+ */
+export function groupByCategory(
+  sections: ReadonlyArray<StyleguideSection>,
+): ReadonlyArray<{
+  category: string;
+  sections: ReadonlyArray<StyleguideSection>;
+}> {
+  const ordered: string[] = [];
+  const buckets = new Map<string, StyleguideSection[]>();
+  for (const s of sections) {
+    if (!buckets.has(s.category)) {
+      buckets.set(s.category, []);
+      ordered.push(s.category);
+    }
+    buckets.get(s.category)!.push(s);
+  }
+  return ordered.map((category) => ({
+    category,
+    sections: buckets.get(category)!,
+  }));
+}

--- a/styleguide/sections/legacy.ts
+++ b/styleguide/sections/legacy.ts
@@ -1,0 +1,1399 @@
+import * as Phaser from "phaser";
+import {
+  getTheme,
+  colorToString,
+  Panel,
+  Button,
+  Label,
+  Modal,
+  Tooltip,
+  ProgressBar,
+  ScrollableList,
+  TabGroup,
+  DataTable,
+  addPulseTween,
+  addTwinkleTween,
+  addFloatTween,
+  registerAmbientCleanup,
+  flashScreen,
+  FloatingText,
+  MilestoneOverlay,
+  StatRow,
+  InfoCard,
+  IconButton,
+  StatusBadge,
+  HUD_TOP_BAR_HEIGHT,
+  HUD_BOTTOM_BAR_HEIGHT,
+  NAV_SIDEBAR_WIDTH,
+  GAME_WIDTH,
+  GAME_HEIGHT,
+  MAX_CONTENT_WIDTH,
+  SIDEBAR_WIDTH,
+  CONTENT_GAP,
+  CONTENT_TOP,
+  CONTENT_HEIGHT,
+  CONTENT_LEFT,
+  SIDEBAR_LEFT,
+  MAIN_CONTENT_LEFT,
+  MAIN_CONTENT_WIDTH,
+  FULL_CONTENT_LEFT,
+  FULL_CONTENT_WIDTH,
+  DEPTH_STARFIELD,
+  DEPTH_AMBIENT_MID,
+  DEPTH_CONTENT,
+  DEPTH_UI,
+  DEPTH_MODAL,
+  DEPTH_HUD,
+  CARGO_TYPE_LIST,
+  getCargoIconKey,
+  getCargoColor,
+  getCargoLabel,
+} from "@spacebiz/ui";
+import type { ColumnDef, BadgeVariant } from "@spacebiz/ui";
+import type { StyleguideSection } from "../sectionGrouping.ts";
+import type { KnobValues } from "../knobs/index.ts";
+import {
+  drawRexPortrait,
+  getMoodAccentColor,
+} from "../../src/ui/AdviserPortrait.ts";
+import { drawPortrait } from "../../src/ui/PortraitGenerator.ts";
+import type {
+  PortraitData,
+  AlienRole,
+} from "../../src/ui/PortraitGenerator.ts";
+import type { AdviserMood } from "../../src/data/types.ts";
+
+/* ------------------------------------------------------------------ */
+/* Sections                                                            */
+/* ------------------------------------------------------------------ */
+
+const colorPalette: StyleguideSection = {
+  id: "color-palette",
+  title: "Color Palette",
+  category: "Tokens",
+  render: (scene, root) => {
+    const theme = getTheme();
+    const colors = theme.colors;
+    const swatches: Array<[string, number]> = [
+      ["background", colors.background],
+      ["headerBg", colors.headerBg],
+      ["panelBg", colors.panelBg],
+      ["panelBorder", colors.panelBorder],
+      ["accent", colors.accent],
+      ["accentHover", colors.accentHover],
+      ["text", colors.text],
+      ["textDim", colors.textDim],
+      ["profit", colors.profit],
+      ["loss", colors.loss],
+      ["warning", colors.warning],
+      ["buttonBg", colors.buttonBg],
+      ["buttonHover", colors.buttonHover],
+      ["buttonPressed", colors.buttonPressed],
+      ["buttonDisabled", colors.buttonDisabled],
+      ["scrollbarTrack", colors.scrollbarTrack],
+      ["scrollbarThumb", colors.scrollbarThumb],
+      ["rowEven", colors.rowEven],
+      ["rowOdd", colors.rowOdd],
+      ["rowHover", colors.rowHover],
+      ["modalOverlay", colors.modalOverlay],
+    ];
+
+    const cols = 5;
+    const swatchW = 140;
+    const swatchH = 50;
+    const gap = 10;
+
+    for (let i = 0; i < swatches.length; i++) {
+      const [name, value] = swatches[i];
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+      const sx = col * (swatchW + gap);
+      const sy = row * (swatchH + 24 + gap);
+      const rect = scene.add
+        .rectangle(sx, sy, swatchW, swatchH, value, 1)
+        .setOrigin(0, 0)
+        .setStrokeStyle(1, theme.colors.panelBorder, 0.6);
+      root.add(rect);
+      const lbl = scene.add
+        .text(sx, sy + swatchH + 4, `${name}\n${colorToString(value)}`, {
+          fontFamily: theme.fonts.caption.family,
+          fontSize: `${theme.fonts.caption.size}px`,
+          color: colorToString(theme.colors.textDim),
+        })
+        .setOrigin(0, 0);
+      root.add(lbl);
+    }
+  },
+};
+
+const typography: StyleguideSection = {
+  id: "typography",
+  title: "Typography",
+  category: "Tokens",
+  knobs: [
+    {
+      type: "boolean",
+      id: "glow",
+      label: "Glow heading",
+      default: true,
+    },
+  ],
+  render: (scene, root, knobs) => {
+    const theme = getTheme();
+    let y = 0;
+    const styles: Array<{
+      style: "heading" | "body" | "caption" | "value";
+      sample: string;
+    }> = [
+      { style: "heading", sample: "Heading – 24px Bold" },
+      { style: "body", sample: "Body – 16px Regular" },
+      { style: "caption", sample: "Caption – 12px (dimmed)" },
+      { style: "value", sample: "Value – 18px Bold (accent)" },
+    ];
+    for (const { style, sample } of styles) {
+      root.add(new Label(scene, { x: 0, y, text: sample, style }));
+      y += 36;
+    }
+    root.add(
+      new Label(scene, {
+        x: 0,
+        y,
+        text: "Heading with knob-controlled glow",
+        style: "heading",
+        color: theme.colors.accent,
+        glow: Boolean(knobs["glow"]),
+      }),
+    );
+    y += 36;
+    const colorExamples: Array<[string, number]> = [
+      ["Profit label", theme.colors.profit],
+      ["Loss label", theme.colors.loss],
+      ["Warning label", theme.colors.warning],
+    ];
+    for (const [text, color] of colorExamples) {
+      root.add(new Label(scene, { x: 0, y, text, style: "body", color }));
+      y += 28;
+    }
+  },
+};
+
+const buttons: StyleguideSection = {
+  id: "buttons",
+  title: "Buttons",
+  category: "Primitives",
+  knobs: [
+    {
+      type: "boolean",
+      id: "disabled",
+      label: "Disable second button",
+      default: false,
+    },
+  ],
+  render: (scene, root, knobs) => {
+    const theme = getTheme();
+    const configs: Array<{ label: string; disabled?: boolean }> = [
+      { label: "Primary Action" },
+      { label: "Hover Me", disabled: Boolean(knobs["disabled"]) },
+      { label: "Always Disabled", disabled: true },
+    ];
+    let x = 0;
+    for (const cfg of configs) {
+      const btn = new Button(scene, {
+        x,
+        y: 0,
+        label: cfg.label,
+        disabled: cfg.disabled,
+        onClick: () => {
+          new FloatingText(scene, x + 20, 0, "Click!", theme.colors.profit);
+        },
+      });
+      root.add(btn);
+      x += btn.width + 20;
+    }
+    const sizeConfigs = ["Short", "A Much Longer Label Here"];
+    x = 0;
+    for (const label of sizeConfigs) {
+      const btn = new Button(scene, {
+        x,
+        y: 60,
+        label,
+        autoWidth: true,
+        onClick: () => {},
+      });
+      root.add(btn);
+      x += btn.width + 20;
+    }
+  },
+};
+
+const panels: StyleguideSection = {
+  id: "panels",
+  title: "Panels",
+  category: "Primitives",
+  knobs: [
+    {
+      type: "boolean",
+      id: "active",
+      label: "Activate centre panel",
+      default: false,
+    },
+  ],
+  render: (scene, root, knobs) => {
+    const p1 = new Panel(scene, {
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 160,
+      title: "Standard Panel",
+    });
+    root.add(p1);
+    root.add(
+      new Label(scene, {
+        x: 16,
+        y: p1.getContentY() + 10,
+        text: "Panel with title bar,\nchamfered border, and\nidle pulse glow.",
+        style: "body",
+      }),
+    );
+
+    const p2 = new Panel(scene, {
+      x: 320,
+      y: 0,
+      width: 280,
+      height: 160,
+    });
+    root.add(p2);
+    root.add(
+      new Label(scene, {
+        x: 336,
+        y: 20,
+        text: "Panel without title.",
+        style: "body",
+      }),
+    );
+
+    const p3 = new Panel(scene, {
+      x: 620,
+      y: 0,
+      width: 280,
+      height: 160,
+      title: "Active Panel",
+    });
+    p3.setActive(Boolean(knobs["active"]));
+    root.add(p3);
+    root.add(
+      new Label(scene, {
+        x: 636,
+        y: p3.getContentY() + 10,
+        text: "Toggle 'active'\nin the knobs panel.",
+        style: "body",
+      }),
+    );
+  },
+};
+
+const progressBars: StyleguideSection = {
+  id: "progress-bars",
+  title: "Progress Bars",
+  category: "Primitives",
+  knobs: [
+    {
+      type: "number",
+      id: "value",
+      label: "Animated value",
+      default: 60,
+      min: 0,
+      max: 100,
+      step: 1,
+    },
+  ],
+  render: (scene, root, knobs) => {
+    const theme = getTheme();
+    const configs: Array<{
+      label: string;
+      value: number;
+      maxValue: number;
+      fillColor?: number;
+    }> = [
+      { label: "Default (70/100)", value: 70, maxValue: 100 },
+      {
+        label: "Profit (45/50)",
+        value: 45,
+        maxValue: 50,
+        fillColor: theme.colors.profit,
+      },
+      {
+        label: "Warning (20/100)",
+        value: 20,
+        maxValue: 100,
+        fillColor: theme.colors.warning,
+      },
+      {
+        label: "Loss (8/100)",
+        value: 8,
+        maxValue: 100,
+        fillColor: theme.colors.loss,
+      },
+    ];
+    let y = 0;
+    for (const cfg of configs) {
+      root.add(
+        new Label(scene, {
+          x: 0,
+          y,
+          text: cfg.label,
+          style: "caption",
+        }),
+      );
+      root.add(
+        new ProgressBar(scene, {
+          x: 0,
+          y: y + 18,
+          width: 400,
+          height: 18,
+          value: cfg.value,
+          maxValue: cfg.maxValue,
+          fillColor: cfg.fillColor,
+        }),
+      );
+      y += 52;
+    }
+
+    root.add(
+      new Label(scene, {
+        x: 0,
+        y,
+        text: "Knob-driven value:",
+        style: "caption",
+      }),
+    );
+    root.add(
+      new ProgressBar(scene, {
+        x: 0,
+        y: y + 18,
+        width: 400,
+        height: 22,
+        value: Number(knobs["value"]),
+        maxValue: 100,
+      }),
+    );
+  },
+};
+
+const scrollableList: StyleguideSection = {
+  id: "scrollable-list",
+  title: "Scrollable List",
+  category: "Composites",
+  render: (scene, root) => {
+    const list = new ScrollableList(scene, {
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 200,
+      itemHeight: 36,
+    });
+    root.add(list);
+    for (let i = 0; i < 20; i++) {
+      const row = scene.add.container(0, 0);
+      row.add(
+        new Label(scene, {
+          x: 16,
+          y: 8,
+          text: `Item ${i + 1} — Sample list entry`,
+          style: "body",
+        }),
+      );
+      list.addItem(row);
+    }
+    root.add(
+      new Label(scene, {
+        x: 420,
+        y: 10,
+        text: "ScrollableList\n• Wheel scroll\n• Click to select\n• Keyboard nav\n• Geometry mask",
+        style: "caption",
+        maxWidth: 280,
+      }),
+    );
+  },
+};
+
+const tabGroup: StyleguideSection = {
+  id: "tab-group",
+  title: "Tab Group",
+  category: "Composites",
+  render: (scene, root) => {
+    const buildTab = (text: string): Phaser.GameObjects.Container => {
+      const c = scene.add.container(0, 0);
+      c.add(new Label(scene, { x: 16, y: 16, text, style: "body" }));
+      return c;
+    };
+    root.add(
+      new TabGroup(scene, {
+        x: 0,
+        y: 0,
+        width: 600,
+        tabs: [
+          { label: "Overview", content: buildTab("Content for Tab 1") },
+          { label: "Details", content: buildTab("Content for Tab 2") },
+          { label: "Settings", content: buildTab("Content for Tab 3") },
+        ],
+      }),
+    );
+  },
+};
+
+const dataTable: StyleguideSection = {
+  id: "data-table",
+  title: "Data Table",
+  category: "Composites",
+  render: (scene, root) => {
+    const theme = getTheme();
+    const columns: ColumnDef[] = [
+      { key: "name", label: "Planet", width: 150, sortable: true },
+      { key: "commodity", label: "Commodity", width: 120, sortable: true },
+      {
+        key: "price",
+        label: "Price",
+        width: 80,
+        align: "right",
+        sortable: true,
+        format: (v: unknown) => `$${v}`,
+      },
+      {
+        key: "trend",
+        label: "Trend",
+        width: 80,
+        align: "right",
+        sortable: true,
+        format: (v: unknown) => `${Number(v) > 0 ? "+" : ""}${v}%`,
+        colorFn: (v: unknown) => {
+          const n = Number(v);
+          return n > 0
+            ? theme.colors.profit
+            : n < 0
+              ? theme.colors.loss
+              : theme.colors.textDim;
+        },
+      },
+      {
+        key: "supply",
+        label: "Supply",
+        width: 80,
+        align: "right",
+        sortable: true,
+      },
+    ];
+    const rows = [
+      {
+        name: "Solara Prime",
+        commodity: "Fuel",
+        price: 124,
+        trend: 12,
+        supply: 450,
+      },
+      {
+        name: "Nova Station",
+        commodity: "Ore",
+        price: 89,
+        trend: -5,
+        supply: 1200,
+      },
+      {
+        name: "Zenith IV",
+        commodity: "Electronics",
+        price: 342,
+        trend: 3,
+        supply: 88,
+      },
+      {
+        name: "Dustfall",
+        commodity: "Food",
+        price: 45,
+        trend: -18,
+        supply: 3400,
+      },
+      {
+        name: "Helix Ring",
+        commodity: "Luxury",
+        price: 780,
+        trend: 25,
+        supply: 22,
+      },
+      {
+        name: "Frost Haven",
+        commodity: "Water",
+        price: 32,
+        trend: 0,
+        supply: 5600,
+      },
+      {
+        name: "Ember Gate",
+        commodity: "Metals",
+        price: 567,
+        trend: 8,
+        supply: 75,
+      },
+      {
+        name: "Drift Colony",
+        commodity: "Passengers",
+        price: 210,
+        trend: -2,
+        supply: 150,
+      },
+    ];
+    const table = new DataTable(scene, {
+      x: 0,
+      y: 0,
+      width: 560,
+      height: 260,
+      columns,
+    });
+    table.setRows(rows);
+    root.add(table);
+  },
+};
+
+const tooltips: StyleguideSection = {
+  id: "tooltips",
+  title: "Tooltips",
+  category: "Composites",
+  render: (scene, root) => {
+    const tooltip = new Tooltip(scene);
+    root.add(tooltip);
+    const targets: Array<{ label: string; tip: string }> = [
+      { label: "Hover for info", tip: "Standard tooltip.\nAuto-positions." },
+      { label: "Another tooltip", tip: "Multi-line text\nand delay support." },
+      { label: "Short tip", tip: "Quick info." },
+    ];
+    let x = 0;
+    for (const { label, tip } of targets) {
+      const btn = new Button(scene, {
+        x,
+        y: 0,
+        label,
+        autoWidth: true,
+        onClick: () => {},
+      });
+      root.add(btn);
+      tooltip.attachTo(btn, tip);
+      x += btn.width + 24;
+    }
+  },
+};
+
+const floatingText: StyleguideSection = {
+  id: "floating-text",
+  title: "Floating Text",
+  category: "Feedback",
+  render: (scene, root) => {
+    const theme = getTheme();
+    const sizes: Array<"small" | "medium" | "large" | "huge"> = [
+      "small",
+      "medium",
+      "large",
+      "huge",
+    ];
+    let x = 0;
+    for (const size of sizes) {
+      const btn = new Button(scene, {
+        x,
+        y: 0,
+        label: size,
+        onClick: () => {
+          new FloatingText(
+            scene,
+            root.x + x + 40,
+            root.y + 20,
+            `+$${Math.floor(Math.random() * 999)}`,
+            theme.colors.profit,
+            { size },
+          );
+        },
+      });
+      root.add(btn);
+      x += 140;
+    }
+  },
+};
+
+const ambientFx: StyleguideSection = {
+  id: "ambient-fx",
+  title: "Ambient FX",
+  category: "Feedback",
+  render: (scene, root) => {
+    const theme = getTheme();
+    const tweens: Phaser.Tweens.Tween[] = [];
+    const pulse = scene.add.circle(0, 20, 16, theme.colors.accent, 0.8);
+    root.add(pulse);
+    tweens.push(
+      addPulseTween(scene, pulse, {
+        minAlpha: 0.3,
+        maxAlpha: 1,
+        duration: theme.ambient.panelIdlePulseDuration,
+      }),
+    );
+    root.add(
+      new Label(scene, {
+        x: 30,
+        y: 10,
+        text: "addPulseTween",
+        style: "caption",
+      }),
+    );
+
+    const twinkle = scene.add.circle(200, 20, 16, theme.colors.profit, 0.8);
+    root.add(twinkle);
+    tweens.push(
+      addTwinkleTween(scene, twinkle, {
+        minAlpha: 0.3,
+        maxAlpha: 1,
+        minDuration: theme.ambient.starTwinkleDurationMin,
+        maxDuration: theme.ambient.starTwinkleDurationMax,
+      }),
+    );
+    root.add(
+      new Label(scene, {
+        x: 230,
+        y: 10,
+        text: "addTwinkleTween",
+        style: "caption",
+      }),
+    );
+
+    const float = scene.add.circle(420, 20, 16, theme.colors.warning, 0.8);
+    root.add(float);
+    tweens.push(addFloatTween(scene, float, { dx: 5, dy: -8, duration: 4000 }));
+    root.add(
+      new Label(scene, {
+        x: 450,
+        y: 10,
+        text: "addFloatTween",
+        style: "caption",
+      }),
+    );
+
+    registerAmbientCleanup(scene, tweens);
+
+    const flashBtn = new Button(scene, {
+      x: 620,
+      y: 8,
+      label: "flashScreen()",
+      onClick: () => flashScreen(scene, 0xffffff),
+    });
+    root.add(flashBtn);
+  },
+};
+
+const milestones: StyleguideSection = {
+  id: "milestones",
+  title: "Milestones",
+  category: "Feedback",
+  render: (scene, root) => {
+    const types: Array<{
+      type: Parameters<typeof MilestoneOverlay.show>[1];
+      label: string;
+    }> = [
+      { type: "big_profit", label: "Big Profit" },
+      { type: "profit_streak", label: "Profit Streak" },
+      { type: "record_profit", label: "Record Profit" },
+      { type: "loss_warning", label: "Loss Warning" },
+      { type: "bankruptcy_warning", label: "Bankruptcy" },
+      { type: "event_opportunity", label: "Opportunity" },
+      { type: "event_hazard", label: "Hazard" },
+      { type: "sim_complete", label: "Sim Complete" },
+    ];
+    let x = 0;
+    let y = 0;
+    for (const { type, label } of types) {
+      const btn = new Button(scene, {
+        x,
+        y,
+        label,
+        onClick: () => {
+          MilestoneOverlay.show(
+            scene,
+            type,
+            label,
+            "Subtitle text",
+            undefined,
+            {
+              holdDuration: 4000,
+            },
+          );
+        },
+      });
+      root.add(btn);
+      x += btn.width + 12;
+      if (x > 600) {
+        x = 0;
+        y += 50;
+      }
+    }
+  },
+};
+
+const modals: StyleguideSection = {
+  id: "modals",
+  title: "Modals",
+  category: "Feedback",
+  render: (scene, root) => {
+    const theme = getTheme();
+    root.add(
+      new Button(scene, {
+        x: 0,
+        y: 0,
+        autoWidth: true,
+        label: "Open Confirm Modal",
+        onClick: () => {
+          new Modal(scene, {
+            title: "Confirm Action",
+            body: "Are you sure?\nThis cannot be undone.",
+            okText: "Confirm",
+            cancelText: "Cancel",
+            onOk: () =>
+              new FloatingText(
+                scene,
+                GAME_WIDTH / 2,
+                GAME_HEIGHT / 2,
+                "Confirmed!",
+                theme.colors.profit,
+              ),
+          }).show();
+        },
+      }),
+    );
+    root.add(
+      new Button(scene, {
+        x: 220,
+        y: 0,
+        autoWidth: true,
+        label: "Open Info Modal",
+        onClick: () => {
+          new Modal(scene, {
+            title: "Information",
+            body: "Informational modal\nwith only OK.",
+            okText: "Got it",
+          }).show();
+        },
+      }),
+    );
+  },
+};
+
+const iconGallery: StyleguideSection = {
+  id: "icons",
+  title: "Icon Gallery",
+  category: "Assets",
+  render: (scene, root) => {
+    const theme = getTheme();
+    const icons = [
+      { key: "icon-map", label: "Map" },
+      { key: "icon-fleet", label: "Fleet" },
+      { key: "icon-routes", label: "Routes" },
+      { key: "icon-finance", label: "Finance" },
+      { key: "icon-market", label: "Market" },
+      { key: "icon-audio", label: "Audio" },
+      { key: "icon-end-turn", label: "End Turn" },
+      { key: "icon-adviser", label: "Adviser" },
+    ];
+    let x = 0;
+    for (const { key, label } of icons) {
+      const bg = scene.add
+        .rectangle(x, 0, 56, 56, theme.colors.panelBg, 0.5)
+        .setOrigin(0, 0)
+        .setStrokeStyle(1, theme.colors.panelBorder, 0.4);
+      root.add(bg);
+      const img = scene.add
+        .image(x + 28, 28, key)
+        .setOrigin(0.5)
+        .setTint(theme.colors.accent);
+      root.add(img);
+      root.add(
+        new Label(scene, {
+          x: x + 28,
+          y: 62,
+          text: label,
+          style: "caption",
+          color: theme.colors.textDim,
+        }).setOrigin(0.5, 0),
+      );
+      x += 80;
+    }
+  },
+};
+
+const cargoIcons: StyleguideSection = {
+  id: "cargo-icons",
+  title: "Cargo Icons",
+  category: "Assets",
+  render: (scene, root) => {
+    const theme = getTheme();
+    let x = 0;
+    for (const ct of CARGO_TYPE_LIST) {
+      const color = getCargoColor(ct);
+      const label = getCargoLabel(ct);
+      const key = getCargoIconKey(ct);
+      const bg = scene.add
+        .rectangle(x, 0, 56, 56, theme.colors.panelBg, 0.5)
+        .setOrigin(0, 0)
+        .setStrokeStyle(1, theme.colors.panelBorder, 0.4);
+      root.add(bg);
+      const img = scene.add
+        .image(x + 28, 28, key)
+        .setOrigin(0.5)
+        .setTint(color);
+      root.add(img);
+      root.add(
+        new Label(scene, {
+          x: x + 28,
+          y: 62,
+          text: label,
+          style: "caption",
+          color,
+        }).setOrigin(0.5, 0),
+      );
+      x += 90;
+    }
+  },
+};
+
+const hudBar: StyleguideSection = {
+  id: "hud-bar",
+  title: "HUD Bar & Dividers",
+  category: "Assets",
+  render: (scene, root) => {
+    const theme = getTheme();
+    const barW = 600;
+    root.add(
+      scene.add
+        .nineslice(0, 0, "hud-bar-bg", undefined, barW, 48, 10, 10, 10, 10)
+        .setOrigin(0, 0),
+    );
+    root.add(
+      new Label(scene, {
+        x: barW / 2,
+        y: 14,
+        text: "hud-bar-bg (NineSlice)",
+        style: "caption",
+        color: theme.colors.textDim,
+      }).setOrigin(0.5, 0),
+    );
+    root.add(
+      scene.add
+        .nineslice(0, 60, "divider-h", undefined, 400, 4, 2, 2, 0, 0)
+        .setOrigin(0, 0),
+    );
+    const layoutInfo = [
+      `HUD_TOP_BAR_HEIGHT: ${HUD_TOP_BAR_HEIGHT}`,
+      `HUD_BOTTOM_BAR_HEIGHT: ${HUD_BOTTOM_BAR_HEIGHT}`,
+      `NAV_SIDEBAR_WIDTH: ${NAV_SIDEBAR_WIDTH}`,
+    ];
+    let y = 80;
+    for (const info of layoutInfo) {
+      root.add(
+        new Label(scene, {
+          x: 0,
+          y,
+          text: info,
+          style: "caption",
+          color: theme.colors.textDim,
+        }),
+      );
+      y += 18;
+    }
+  },
+};
+
+const adviserPortrait: StyleguideSection = {
+  id: "adviser-portrait",
+  title: "Adviser Portrait",
+  category: "Game UI",
+  knobs: [
+    {
+      type: "select",
+      id: "mood",
+      label: "Highlight mood",
+      default: "standby",
+      options: [
+        { value: "standby", label: "Standby" },
+        { value: "analyzing", label: "Analyzing" },
+        { value: "alert", label: "Alert" },
+        { value: "success", label: "Success" },
+      ],
+    },
+  ],
+  render: (scene, root, knobs) => {
+    const theme = getTheme();
+    const moods: AdviserMood[] = ["standby", "analyzing", "alert", "success"];
+    const portraitSize = 128;
+    const highlight = String(knobs["mood"]);
+    let x = 0;
+    for (const mood of moods) {
+      const g = scene.add.graphics();
+      g.setPosition(x, 0);
+      drawRexPortrait(g, portraitSize, portraitSize, mood);
+      root.add(g);
+      const accentColor = getMoodAccentColor(mood);
+      const isHighlighted = mood === highlight;
+      const border = scene.add
+        .rectangle(x, 0, portraitSize, portraitSize)
+        .setOrigin(0, 0)
+        .setStrokeStyle(
+          isHighlighted ? 4 : 2,
+          accentColor,
+          isHighlighted ? 1 : 0.6,
+        );
+      border.isFilled = false;
+      root.add(border);
+      root.add(
+        new Label(scene, {
+          x: x + portraitSize / 2,
+          y: portraitSize + 6,
+          text: mood,
+          style: "caption",
+          color: accentColor,
+        }).setOrigin(0.5, 0),
+      );
+      root.add(
+        new Label(scene, {
+          x: x + portraitSize / 2,
+          y: portraitSize + 22,
+          text: colorToString(accentColor),
+          style: "caption",
+          color: theme.colors.textDim,
+        }).setOrigin(0.5, 0),
+      );
+      x += portraitSize + 24;
+    }
+  },
+};
+
+const portraitGallery: StyleguideSection = {
+  id: "portrait-gallery",
+  title: "Portrait Gallery",
+  category: "Game UI",
+  knobs: [
+    {
+      type: "number",
+      id: "seed",
+      label: "Seed",
+      default: 42,
+      min: 1,
+      max: 200,
+      step: 1,
+    },
+  ],
+  render: (scene, root, knobs) => {
+    const theme = getTheme();
+    const size = 96;
+    const gap = 16;
+    const seed = Number(knobs["seed"]);
+    let y = 0;
+
+    root.add(
+      new Label(scene, {
+        x: 0,
+        y,
+        text: "Planets",
+        style: "body",
+        color: theme.colors.text,
+      }),
+    );
+    y += 24;
+    const planetTypes: Array<{ label: string; planetType: string }> = [
+      { label: "Terran", planetType: "terran" },
+      { label: "Mining", planetType: "mining" },
+      { label: "Agri", planetType: "agricultural" },
+      { label: "Industrial", planetType: "industrial" },
+      { label: "Hub", planetType: "hubStation" },
+      { label: "Resort", planetType: "resort" },
+      { label: "Research", planetType: "research" },
+    ];
+    let x = 0;
+    for (const { label, planetType } of planetTypes) {
+      const g = scene.add.graphics();
+      g.setPosition(x, y);
+      drawPortrait(g, "planet", size, size, seed, {
+        planetType: planetType as "terran",
+      });
+      root.add(g);
+      root.add(
+        new Label(scene, {
+          x: x + size / 2,
+          y: y + size + 4,
+          text: label,
+          style: "caption",
+          color: theme.colors.textDim,
+        }).setOrigin(0.5, 0),
+      );
+      x += size + gap;
+    }
+    y += size + 34;
+
+    root.add(
+      new Label(scene, {
+        x: 0,
+        y,
+        text: "Ships / Systems / Events",
+        style: "body",
+        color: theme.colors.text,
+      }),
+    );
+    y += 24;
+    const otherTypes: Array<{
+      label: string;
+      type: "ship" | "system" | "event";
+      data?: PortraitData;
+    }> = [
+      { label: "Shuttle", type: "ship", data: { shipClass: "cargoShuttle" } },
+      {
+        label: "Freighter",
+        type: "ship",
+        data: { shipClass: "bulkFreighter" },
+      },
+      { label: "Hauler", type: "ship", data: { shipClass: "mixedHauler" } },
+      {
+        label: "System",
+        type: "system",
+        data: { starColor: 0xffd700, planetCount: 5 },
+      },
+      { label: "Market evt", type: "event", data: { eventCategory: "market" } },
+      { label: "Hazard evt", type: "event", data: { eventCategory: "hazard" } },
+    ];
+    x = 0;
+    for (const item of otherTypes) {
+      const g = scene.add.graphics();
+      g.setPosition(x, y);
+      drawPortrait(g, item.type, size, size, seed, item.data);
+      root.add(g);
+      root.add(
+        new Label(scene, {
+          x: x + size / 2,
+          y: y + size + 4,
+          text: item.label,
+          style: "caption",
+          color: theme.colors.textDim,
+        }).setOrigin(0.5, 0),
+      );
+      x += size + gap;
+    }
+    y += size + 34;
+
+    root.add(
+      new Label(scene, {
+        x: 0,
+        y,
+        text: "Aliens",
+        style: "body",
+        color: theme.colors.text,
+      }),
+    );
+    y += 24;
+    const alienRoles: AlienRole[] = [
+      "broker",
+      "miner",
+      "researcher",
+      "concierge",
+      "enforcer",
+    ];
+    x = 0;
+    for (const role of alienRoles) {
+      const g = scene.add.graphics();
+      g.setPosition(x, y);
+      drawPortrait(g, "alien", size, size, seed, { alienRole: role });
+      root.add(g);
+      root.add(
+        new Label(scene, {
+          x: x + size / 2,
+          y: y + size + 4,
+          text: role,
+          style: "caption",
+          color: theme.colors.textDim,
+        }).setOrigin(0.5, 0),
+      );
+      x += size + gap;
+    }
+  },
+};
+
+const spacingLayout: StyleguideSection = {
+  id: "spacing-layout",
+  title: "Spacing & Layout",
+  category: "Tokens",
+  render: (scene, root) => {
+    const theme = getTheme();
+    const spacingTokens: Array<{ name: string; value: number }> = [
+      { name: "xs", value: theme.spacing.xs },
+      { name: "sm", value: theme.spacing.sm },
+      { name: "md", value: theme.spacing.md },
+      { name: "lg", value: theme.spacing.lg },
+      { name: "xl", value: theme.spacing.xl },
+    ];
+    let x = 0;
+    for (const { name, value } of spacingTokens) {
+      const block = scene.add
+        .rectangle(x, 0, value, value, theme.colors.accent, 0.5)
+        .setOrigin(0, 0)
+        .setStrokeStyle(1, theme.colors.accent, 0.8);
+      root.add(block);
+      root.add(
+        new Label(scene, {
+          x: x + Math.max(value, 20) / 2,
+          y: Math.max(value, 4) + 8,
+          text: `${name}\n${value}px`,
+          style: "caption",
+          color: theme.colors.textDim,
+        }).setOrigin(0.5, 0),
+      );
+      x += Math.max(value, 30) + 30;
+    }
+    let y = 70;
+    const layoutConstants: Array<[string, number]> = [
+      ["GAME_WIDTH", GAME_WIDTH],
+      ["GAME_HEIGHT", GAME_HEIGHT],
+      ["MAX_CONTENT_WIDTH", MAX_CONTENT_WIDTH],
+      ["SIDEBAR_WIDTH", SIDEBAR_WIDTH],
+      ["CONTENT_GAP", CONTENT_GAP],
+      ["NAV_SIDEBAR_WIDTH", NAV_SIDEBAR_WIDTH],
+      ["CONTENT_TOP", CONTENT_TOP],
+      ["CONTENT_HEIGHT", CONTENT_HEIGHT],
+      ["CONTENT_LEFT", CONTENT_LEFT],
+      ["SIDEBAR_LEFT", SIDEBAR_LEFT],
+      ["MAIN_CONTENT_LEFT", MAIN_CONTENT_LEFT],
+      ["MAIN_CONTENT_WIDTH", MAIN_CONTENT_WIDTH],
+      ["FULL_CONTENT_LEFT", FULL_CONTENT_LEFT],
+      ["FULL_CONTENT_WIDTH", FULL_CONTENT_WIDTH],
+    ];
+    const colW = 260;
+    for (let i = 0; i < layoutConstants.length; i++) {
+      const [name, value] = layoutConstants[i];
+      const col = Math.floor(i / 7);
+      const row = i % 7;
+      root.add(
+        new Label(scene, {
+          x: col * colW,
+          y: y + row * 18,
+          text: `${name}: ${value}`,
+          style: "caption",
+          color: theme.colors.textDim,
+        }),
+      );
+    }
+  },
+};
+
+const depthLayers: StyleguideSection = {
+  id: "depth-layers",
+  title: "Depth Layers",
+  category: "Tokens",
+  render: (scene, root) => {
+    const theme = getTheme();
+    const layers: Array<{ name: string; value: number; color: number }> = [
+      { name: "DEPTH_STARFIELD", value: DEPTH_STARFIELD, color: 0x335577 },
+      { name: "DEPTH_AMBIENT_MID", value: DEPTH_AMBIENT_MID, color: 0x557799 },
+      { name: "DEPTH_CONTENT", value: DEPTH_CONTENT, color: theme.colors.text },
+      { name: "DEPTH_UI", value: DEPTH_UI, color: theme.colors.accent },
+      { name: "DEPTH_MODAL", value: DEPTH_MODAL, color: theme.colors.warning },
+      { name: "DEPTH_HUD", value: DEPTH_HUD, color: theme.colors.profit },
+    ];
+    const barMaxW = 500;
+    const barH = 24;
+    const maxDepth = DEPTH_HUD;
+    let y = 0;
+    for (const { name, value, color } of layers) {
+      const normalised =
+        value <= 0
+          ? 20
+          : Math.max(
+              20,
+              (Math.log10(value + 1) / Math.log10(maxDepth + 1)) * barMaxW,
+            );
+      root.add(
+        scene.add
+          .rectangle(0, y, normalised, barH, color, 0.5)
+          .setOrigin(0, 0)
+          .setStrokeStyle(1, color, 0.7),
+      );
+      root.add(
+        new Label(scene, {
+          x: 10 + normalised,
+          y: y + 4,
+          text: `${name} = ${value}`,
+          style: "caption",
+          color,
+        }),
+      );
+      y += barH + 8;
+    }
+  },
+};
+
+const statRow: StyleguideSection = {
+  id: "stat-row",
+  title: "Stat Row",
+  category: "Composites",
+  render: (scene, root) => {
+    const theme = getTheme();
+    const rows: Array<{
+      label: string;
+      value: string;
+      valueColor?: number;
+      compact?: boolean;
+    }> = [
+      { label: "Credits", value: "$12,450" },
+      { label: "Fuel Level", value: "85%", valueColor: theme.colors.profit },
+      { label: "Risk Factor", value: "HIGH", valueColor: theme.colors.loss },
+      { label: "Distance", value: "42 LY", compact: true },
+      {
+        label: "Profit Margin",
+        value: "+18.5%",
+        valueColor: theme.colors.profit,
+        compact: true,
+      },
+    ];
+    let y = 0;
+    for (const cfg of rows) {
+      const row = new StatRow(scene, { x: 0, y, width: 400, ...cfg });
+      scene.children.remove(row);
+      root.add(row);
+      y += row.rowHeight + 4;
+    }
+  },
+};
+
+const infoCard: StyleguideSection = {
+  id: "info-card",
+  title: "Info Card",
+  category: "Composites",
+  render: (scene, root) => {
+    const theme = getTheme();
+    const c1 = new InfoCard(scene, {
+      x: 0,
+      y: 0,
+      width: 280,
+      title: "Solara Prime",
+      stats: [
+        { label: "Population", value: "2.4M" },
+        { label: "Economy", value: "Industrial" },
+        {
+          label: "Trade Volume",
+          value: "$450K",
+          valueColor: theme.colors.profit,
+        },
+      ],
+      description: "Industrial world with growing trade networks.",
+    });
+    scene.children.remove(c1);
+    root.add(c1);
+    const c2 = new InfoCard(scene, {
+      x: 320,
+      y: 0,
+      width: 240,
+      title: "Ship Status",
+      stats: [
+        { label: "Hull", value: "92%", valueColor: theme.colors.profit },
+        { label: "Fuel", value: "45%", valueColor: theme.colors.warning },
+      ],
+      compact: true,
+    });
+    scene.children.remove(c2);
+    root.add(c2);
+  },
+};
+
+const iconButton: StyleguideSection = {
+  id: "icon-button",
+  title: "Icon Button",
+  category: "Primitives",
+  render: (scene, root) => {
+    const icons = [
+      { icon: "icon-map", label: "Map" },
+      { icon: "icon-fleet", label: "Fleet" },
+      { icon: "icon-routes", label: "Routes" },
+      { icon: "icon-finance", label: "Finance" },
+    ];
+    let x = 0;
+    for (let i = 0; i < icons.length; i++) {
+      const btn = new IconButton(scene, {
+        x,
+        y: 0,
+        icon: icons[i].icon,
+        active: i === 0,
+        onClick: () => {},
+      });
+      scene.children.remove(btn);
+      root.add(btn);
+      x += 50;
+    }
+    x = 0;
+    for (let i = 0; i < 3; i++) {
+      const btn = new IconButton(scene, {
+        x,
+        y: 60,
+        icon: icons[i].icon,
+        label: icons[i].label,
+        active: i === 1,
+        onClick: () => {},
+      });
+      scene.children.remove(btn);
+      root.add(btn);
+      x += 140;
+    }
+  },
+};
+
+const statusBadge: StyleguideSection = {
+  id: "status-badge",
+  title: "Status Badge",
+  category: "Primitives",
+  render: (scene, root) => {
+    const variants: Array<{
+      text: string;
+      variant: BadgeVariant;
+      pulse?: boolean;
+    }> = [
+      { text: "Online", variant: "success" },
+      { text: "In Transit", variant: "info" },
+      { text: "Low Fuel", variant: "warning" },
+      { text: "Critical", variant: "danger", pulse: true },
+      { text: "Idle", variant: "neutral" },
+    ];
+    let x = 0;
+    for (const cfg of variants) {
+      const badge = new StatusBadge(scene, { x, y: 0, ...cfg });
+      scene.children.remove(badge);
+      root.add(badge);
+      x += badge.badgeWidth + 20;
+    }
+  },
+};
+
+export const legacySections: ReadonlyArray<StyleguideSection> = [
+  colorPalette,
+  typography,
+  spacingLayout,
+  depthLayers,
+  buttons,
+  panels,
+  progressBars,
+  iconButton,
+  statusBadge,
+  scrollableList,
+  tabGroup,
+  dataTable,
+  tooltips,
+  statRow,
+  infoCard,
+  floatingText,
+  ambientFx,
+  milestones,
+  modals,
+  iconGallery,
+  cargoIcons,
+  hudBar,
+  adviserPortrait,
+  portraitGallery,
+];
+
+// Mark `KnobValues` as referenced so unused-locals stays clean.
+export type _Touch = KnobValues;

--- a/styleguide/themes.ts
+++ b/styleguide/themes.ts
@@ -1,0 +1,75 @@
+import { DEFAULT_THEME } from "@spacebiz/ui";
+import type { ThemeConfig } from "@spacebiz/ui";
+
+/**
+ * Theme variants used by the styleguide's theme switcher.
+ *
+ * The semantic-token themes are still being defined in a parallel work unit;
+ * until they land in `@spacebiz/ui`, the styleguide ships its own minimal
+ * variants so the theme-switcher UX can be exercised in this PR.
+ */
+
+export const darkTheme: ThemeConfig = DEFAULT_THEME;
+
+export const lightTheme: ThemeConfig = {
+  ...DEFAULT_THEME,
+  colors: {
+    ...DEFAULT_THEME.colors,
+    background: 0xf2f2f7,
+    panelBg: 0xffffff,
+    panelBorder: 0xb8b8c8,
+    text: 0x16162a,
+    textDim: 0x55556a,
+    accent: 0x0066cc,
+    accentHover: 0x3388dd,
+    headerBg: 0xe8e8f0,
+    buttonBg: 0xe2e2ec,
+    buttonHover: 0xd0d0dc,
+    buttonPressed: 0xb8b8c8,
+    buttonDisabled: 0xeaeaf0,
+    rowEven: 0xffffff,
+    rowOdd: 0xf3f3f8,
+    rowHover: 0xdfe6f5,
+    modalOverlay: 0x000000,
+  },
+  glass: {
+    ...DEFAULT_THEME.glass,
+    bgAlpha: 0.95,
+    topTint: 0xffffff,
+    bottomTint: 0xe8e8f0,
+    innerBorderAlpha: 0.4,
+  },
+};
+
+export const highContrastTheme: ThemeConfig = {
+  ...DEFAULT_THEME,
+  colors: {
+    ...DEFAULT_THEME.colors,
+    background: 0x000000,
+    panelBg: 0x000000,
+    panelBorder: 0xffffff,
+    text: 0xffffff,
+    textDim: 0xcccccc,
+    accent: 0xffff00,
+    accentHover: 0xffff66,
+    profit: 0x00ff00,
+    loss: 0xff3333,
+    warning: 0xffaa00,
+    headerBg: 0x000000,
+    buttonBg: 0x000000,
+    buttonHover: 0x222222,
+    buttonPressed: 0xffff00,
+    buttonDisabled: 0x111111,
+  },
+  glass: {
+    ...DEFAULT_THEME.glass,
+    bgAlpha: 1,
+    topTint: 0x000000,
+    bottomTint: 0x000000,
+    innerBorderAlpha: 0,
+  },
+  panel: {
+    ...DEFAULT_THEME.panel,
+    borderWidth: 3,
+  },
+};


### PR DESCRIPTION
## Summary

Reorganises the styleguide app from a single ~2000-LOC scene with manual `addXSection()` calls into a registry-driven layout.

- **Top bar**: title + theme switcher dropdown (Default Dark / Light / High Contrast)
- **Left side panel**: sections grouped by category (Tokens, Primitives, Composites, Feedback, Assets, Game UI); click to navigate
- **Centre**: active section's render output, re-rendered on knob/theme change
- **Right (DOM overlay)**: interactive knobs panel with `boolean` / `number` / `select` / `string` / `color` controls

The registry (`styleguide/registry.ts`) imports section data; each section declares its `knobs` and a pure `render(scene, container, knobs)` function. Existing demos are ported as a single `legacySections` array in `styleguide/sections/legacy.ts`. A starter `Button.styleguide.ts` adjacent file demonstrates the convention for component-owned sections.

Knob rendering uses native DOM controls (`styleguide/knobs/render.ts`) because the right-side panel sits outside the canvas; native inputs give us proper keyboard / number / colour affordances for free.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (only pre-existing warnings)
- [x] `npm run format:check`
- [x] `npm run test` — including new `styleguide/__tests__/registry.test.ts` (7 tests covering `groupByCategory` and `buildDefaultKnobValues`)
- [x] `npm run build` — both main + styleguide bundles
- [x] `npm run dev` — visited `http://localhost:5173/styleguide/`, verified side panel renders all 6 categories, theme switcher swaps Dark → Light correctly, knobs panel updates as you switch sections, knob changes trigger live re-render.

## Notes for downstream units

- Other units adding sections should append to `styleguideSections` in `registry.ts`, ideally by importing a `*.styleguide.ts` adjacent to their component (see `packages/spacebiz-ui/src/Button.styleguide.ts`).
- The `darkTheme` / `lightTheme` / `highContrastTheme` exports here live in a local `styleguide/themes.ts` until unit 20 lands them in `@spacebiz/ui` proper; swap the import then.
- `groupByCategory` lives in `styleguide/sectionGrouping.ts` (separate from `registry.ts`) so unit tests can import the grouping logic without transitively pulling in Phaser-bound section renderers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)