### PR TITLE
fix(ui-tests): add getBounds to mock Phaser game object

### DIFF
--- a/packages/spacebiz-ui/src/__tests__/feedback/_phaserMock.ts
+++ b/packages/spacebiz-ui/src/__tests__/feedback/_phaserMock.ts
@@ -171,6 +171,14 @@ export class MockGameObject extends MiniEmitter {
   setColor(_c: string): this {
     return this;
   }
+  getBounds(): { x: number; y: number; width: number; height: number } {
+    return {
+      x: this.x,
+      y: this.y,
+      width: this.width,
+      height: this.height,
+    };
+  }
   destroy(_fromScene?: boolean): void {
     if (this.destroyed) return;
     this.destroyed = true;


### PR DESCRIPTION
Modal close glyph calls `closeText.getBounds()` (added in #234 for the focus ring) but the Phaser mock from #232 didn't implement it. Tests were green individually at each merge, but the combination on main breaks every Modal test with `closeText.getBounds is not a function`. This unblocks the rebased PRs (#223, #229, #235, #237, #238).