### PR TITLE
fix(ui): keep scrolled table headers pinned

### DIFF
--- a/packages/spacebiz-ui/src/DataTable.ts
+++ b/packages/spacebiz-ui/src/DataTable.ts
@@ -108,11 +108,11 @@ export class DataTable extends Phaser.GameObjects.Container {
     this.keyboardNavigationEnabled = config.keyboardNavigation ?? false;
     this.contentSized = config.contentSized ?? false;
 
-    this.headerContainer = scene.add.container(0, 0);
-    this.add(this.headerContainer);
-
     this.bodyContainer = scene.add.container(0, this.headerHeight);
     this.add(this.bodyContainer);
+
+    this.headerContainer = scene.add.container(0, 0);
+    this.add(this.headerContainer);
 
     this.wheelHitArea = scene.add
       .rectangle(0, 0, config.width, config.height, 0x000000, 0)
@@ -640,6 +640,16 @@ export class DataTable extends Phaser.GameObjects.Container {
   /** Natural height of the rendered table (header + all rows). */
   get contentHeight(): number {
     return this._contentHeight;
+  }
+
+  /**
+   * Called by ScrollFrame in contentSized mode. The body scrolls with the
+   * frame, but the column header counter-scrolls so it remains pinned to the
+   * top of the viewport.
+   */
+  setViewportScrollY(scrollY: number): void {
+    if (!this.contentSized) return;
+    this.headerContainer.setY(scrollY);
   }
 
   private selectRow(

--- a/packages/spacebiz-ui/src/ScrollFrame.ts
+++ b/packages/spacebiz-ui/src/ScrollFrame.ts
@@ -23,7 +23,7 @@ export interface ScrollFrameConfig {
  *
  * Mask handling mirrors the path established in PR #213: filter mask via
  * `filters.internal.addMask(maskShape, false, undefined, "world")`, with the
- * mask shape repositioned each preupdate to the content layer's world
+ * mask shape repositioned each preupdate to the frame viewport's world
  * transform. No Phaser-3 `setMask`/`createGeometryMask` fallback needed since
  * we target Phaser 4 only.
  */
@@ -79,6 +79,7 @@ export class ScrollFrame extends Phaser.GameObjects.Container {
       this.viewportHeight - this.padding * 2,
     );
     applyClippingMask(this.contentLayer, this.maskShape);
+    this.syncMaskPosition();
 
     this.maskSyncBound = () => this.syncMaskPosition();
     this.scene.events.on("preupdate", this.maskSyncBound, this);
@@ -136,12 +137,16 @@ export class ScrollFrame extends Phaser.GameObjects.Container {
     if (this.scrollY > this.maxScroll) {
       this.scrollTo(this.maxScroll);
     }
+    this.syncContentScrollOffset();
+    this.syncMaskPosition();
   }
 
   /** Set scroll offset (clamped to [0, maxScroll]). */
   scrollTo(y: number): void {
     this.scrollY = Phaser.Math.Clamp(y, 0, this.maxScroll);
     this.contentLayer.y = this.padding - this.scrollY;
+    this.syncContentScrollOffset();
+    this.syncMaskPosition();
   }
 
   /**
@@ -183,10 +188,20 @@ export class ScrollFrame extends Phaser.GameObjects.Container {
     return bounds.height;
   }
 
+  private syncContentScrollOffset(): void {
+    const child = this.contentChild as unknown as {
+      setViewportScrollY?: (scrollY: number) => void;
+    } | null;
+    child?.setViewportScrollY?.(this.scrollY);
+  }
+
   private syncMaskPosition(): void {
     if (this.destroyed) return;
-    const matrix = this.contentLayer.getWorldTransformMatrix();
-    this.maskShape.setPosition(matrix.tx, matrix.ty);
+    const matrix = this.getWorldTransformMatrix();
+    this.maskShape.setPosition(
+      matrix.tx + this.padding,
+      matrix.ty + this.padding,
+    );
   }
 
   private isVisibleInWorld(): boolean {

--- a/packages/spacebiz-ui/src/__tests__/composites/DataTable.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/composites/DataTable.test.ts
@@ -5,6 +5,7 @@ import {
   rectangles,
   allTextStrings,
   asMock,
+  type MockContainerLike,
   type MockRectLike,
 } from "../_harness/inspect.ts";
 
@@ -292,14 +293,9 @@ function collectRowTexts(table: DataTable): string[] {
 }
 
 function getHeaderContainer(table: DataTable) {
-  return containers(table).find((container) =>
-    rectangles(container).some((r) => r.getData?.("consumesWheel") === true),
-  )!;
+  return asMock<{ headerContainer: MockContainerLike }>(table).headerContainer;
 }
 
 function getBodyContainer(table: DataTable) {
-  return containers(table).find(
-    (container) =>
-      !rectangles(container).some((r) => r.getData?.("consumesWheel") === true),
-  )!;
+  return asMock<{ bodyContainer: MockContainerLike }>(table).bodyContainer;
 }

--- a/packages/spacebiz-ui/src/__tests__/composites/DataTable.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/composites/DataTable.test.ts
@@ -93,7 +93,7 @@ describe("DataTable", () => {
       { name: "Bob", value: 20 },
     ]);
 
-    const headerContainer = containers(table)[0];
+    const headerContainer = getHeaderContainer(table);
     const hitAreas = rectangles(headerContainer).filter(
       (r) => r.getData?.("consumesWheel") === true,
     );
@@ -181,6 +181,24 @@ describe("DataTable", () => {
     expect(payload.height).toBeGreaterThan(0);
   });
 
+  it("contentSized mode counter-scrolls the header for fixed viewport headers", () => {
+    const table = new DataTable(scene as never, {
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 400,
+      columns: COLUMNS,
+      contentSized: true,
+    });
+
+    table.setViewportScrollY(96);
+
+    expect(getHeaderContainer(table).y).toBe(96);
+    expect(getBodyContainer(table).y).toBe(36);
+    const tableContainers = containers(table);
+    expect(tableContainers.at(-1)).toBe(getHeaderContainer(table));
+  });
+
   it("keyboard navigation moves selection with ArrowDown when focused", () => {
     const onRowSelect = vi.fn();
     const table = new DataTable(scene as never, {
@@ -249,13 +267,13 @@ describe("DataTable", () => {
 function findRowBackgrounds(table: DataTable): MockRectLike[] {
   const tableWidth = asMock<{ tableConfig?: { width: number } }>(table)
     .tableConfig?.width;
-  const body = containers(table)[1];
+  const body = getBodyContainer(table);
   return rectangles(body).filter((r) => r.width === tableWidth);
 }
 
 function collectRowTexts(table: DataTable): string[] {
   // Group same-Y texts into a single pipe-joined row signature.
-  const body = containers(table)[1];
+  const body = getBodyContainer(table);
   const out: string[] = [];
   let acc = "";
   let lastY = -Infinity;
@@ -271,4 +289,17 @@ function collectRowTexts(table: DataTable): string[] {
   }
   if (acc) out.push(acc);
   return out;
+}
+
+function getHeaderContainer(table: DataTable) {
+  return containers(table).find((container) =>
+    rectangles(container).some((r) => r.getData?.("consumesWheel") === true),
+  )!;
+}
+
+function getBodyContainer(table: DataTable) {
+  return containers(table).find(
+    (container) =>
+      !rectangles(container).some((r) => r.getData?.("consumesWheel") === true),
+  )!;
 }

--- a/packages/spacebiz-ui/src/__tests__/composites/ScrollFrame.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/composites/ScrollFrame.test.ts
@@ -251,4 +251,44 @@ describe("ScrollFrame", () => {
     expect(layer.x).toBe(8);
     expect(layer.y).toBe(8);
   });
+
+  it("keeps the mask anchored to the viewport when content scrolls", () => {
+    const frame = new ScrollFrame(scene as never, {
+      x: 20,
+      y: 30,
+      width: 300,
+      height: 200,
+      padding: 8,
+    });
+    frame.setContent(makeChildOfHeight(scene, 500) as unknown as never);
+
+    const mask = (frame as unknown as { maskShape: { x: number; y: number } })
+      .maskShape;
+
+    expect(mask.x).toBe(28);
+    expect(mask.y).toBe(38);
+
+    frame.scrollTo(100);
+
+    expect(mask.x).toBe(28);
+    expect(mask.y).toBe(38);
+  });
+
+  it("notifies content when the viewport scroll offset changes", () => {
+    const frame = new ScrollFrame(scene as never, {
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 200,
+    });
+    const child = makeChildOfHeight(scene, 500) as MockContainer & {
+      setViewportScrollY: ReturnType<typeof vi.fn>;
+    };
+    child.setViewportScrollY = vi.fn();
+
+    frame.setContent(child as unknown as never);
+    frame.scrollTo(100);
+
+    expect(child.setViewportScrollY).toHaveBeenLastCalledWith(100);
+  });
 });


### PR DESCRIPTION
## Summary
- Keep ScrollFrame masks anchored to the viewport while content scrolls.
- Add a DataTable viewport scroll hook so content-sized table headers remain pinned above scrolling rows.
- Cover the mask anchoring and fixed header behavior with unit tests.

## Verification
- npm run check
- Playwright visual validation on RoutesScene after heavy table scrolling