### PR TITLE
fix(ci): apply prettier formatting to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - phase 6 — interaction overhaul (#15)
 - upgrade caretaker-github to 0.19.2, switch to PyPI install (#18)
-- window.__sft console API, Playwright e2e, MCP server, prod opt-in, lint rule (#21)
+- window.\_\_sft console API, Playwright e2e, MCP server, prod opt-in, lint rule (#21)
 - prevent silent BGM play failure on prod (iOS Safari autoplay compat) (#22)
 - add checks:write and security_events:read to Caretaker workflow (#23)
 - add Claude Code workflow to handle @claude review handoffs (#24)


### PR DESCRIPTION
## Summary

- CHANGELOG.md had a Prettier formatting violation that was blocking the Azure Deploy workflow at the `format:check` step
- Prettier escapes `__sft` → `\_\_sft` in Markdown to avoid ambiguous emphasis parsing
- No content changes — pure formatting fix

## Root Cause

`npm run check` (used by `deploy-azure.yml`) chains `typecheck → lint → format:check → test → build`. The `format:check` step was exiting 1 on CHANGELOG.md.

## Verification

- `npm run format:check` ✅ All matched files use Prettier code style
- `npm run check` ✅ Exit code 0 (typecheck, lint, format:check, 1283 tests, build all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)