### PR TITLE
fix(ui): stop scrolled DataTable from blocking dropdown clicks

### DIFF
--- a/packages/spacebiz-ui/src/DataTable.ts
+++ b/packages/spacebiz-ui/src/DataTable.ts
@@ -62,7 +62,6 @@ export class DataTable extends Phaser.GameObjects.Container {
   private sortAsc = true;
   private selectedRowIndex = -1;
   private selectedRowIndicator: Phaser.GameObjects.Rectangle | null = null;
-  private wheelHitArea: Phaser.GameObjects.Rectangle;
   private maskShape: Phaser.GameObjects.Graphics | null = null;
   private renderedRows: Record<string, unknown>[] = [];
   /**
@@ -73,12 +72,18 @@ export class DataTable extends Phaser.GameObjects.Container {
    * descendants in Phaser 4 (transform staleness across multiple parent
    * Containers, RT cache invalidation lag, etc.). Manual clipping is
    * unconditional and guarantees rows never render outside the table frame.
+   *
+   * In contentSized mode, `viewportActive` tracks whether the row's
+   * interactive hit area is currently enabled. Rows that have scrolled
+   * above/below the ScrollFrame viewport are disabled so their invisible
+   * rectangles can't block pointer events on UI elements outside the table.
    */
   private rowEntries: {
     top: number;
     height: number;
     bg: Phaser.GameObjects.Rectangle;
     children: Phaser.GameObjects.GameObject[];
+    viewportActive: boolean;
   }[] = [];
   private hasKeyboardFocus = false;
   private readonly keyboardNavigationEnabled: boolean;
@@ -114,18 +119,25 @@ export class DataTable extends Phaser.GameObjects.Container {
     this.headerContainer = scene.add.container(0, 0);
     this.add(this.headerContainer);
 
-    this.wheelHitArea = scene.add
-      .rectangle(0, 0, config.width, config.height, 0x000000, 0)
-      .setOrigin(0, 0)
-      .setInteractive(
-        new Phaser.Geom.Rectangle(0, 0, config.width, config.height),
-        Phaser.Geom.Rectangle.Contains,
-      );
-    this.wheelHitArea.on("pointerdown", () => {
-      this.focus();
-    });
-    this.addAt(this.wheelHitArea, 0);
-    this.wheelHitArea.setData("consumesWheel", true);
+    // In contentSized mode the parent ScrollFrame owns scrolling and the
+    // DataTable moves in world space as the frame scrolls. Creating an
+    // interactive hit-area here would let it drift above the table viewport
+    // and silently block pointer events on UI outside (e.g. dropdown filters).
+    // Row pointerdown handlers already call focus(), so we need no fallback.
+    if (!this.contentSized) {
+      const wheelHitArea = scene.add
+        .rectangle(0, 0, config.width, config.height, 0x000000, 0)
+        .setOrigin(0, 0)
+        .setInteractive(
+          new Phaser.Geom.Rectangle(0, 0, config.width, config.height),
+          Phaser.Geom.Rectangle.Contains,
+        );
+      wheelHitArea.on("pointerdown", () => {
+        this.focus();
+      });
+      this.addAt(wheelHitArea, 0);
+      wheelHitArea.setData("consumesWheel", true);
+    }
 
     // Mask + scroll indicator + canvas wheel are skipped in contentSized
     // mode — the parent ScrollFrame owns those concerns, and DataTable would
@@ -619,6 +631,7 @@ export class DataTable extends Phaser.GameObjects.Container {
         height: rowHeightPx,
         bg: rowBg,
         children: childList,
+        viewportActive: true,
       });
 
       yCursor += rowHeightPx;
@@ -650,6 +663,28 @@ export class DataTable extends Phaser.GameObjects.Container {
   setViewportScrollY(scrollY: number): void {
     if (!this.contentSized) return;
     this.headerContainer.setY(scrollY);
+
+    // Enable/disable each row's interactive hit area depending on whether it
+    // falls inside the visible body region [scrollY, scrollY + viewportBodyH].
+    // Rows outside the viewport move in world-space (the whole DataTable
+    // shifts as ScrollFrame scrolls) and their invisible rectangles would
+    // otherwise block pointer events on UI elements above or below the frame.
+    const viewportBodyH = this.tableConfig.height - this.headerHeight;
+    for (const entry of this.rowEntries) {
+      const inViewport =
+        entry.top + entry.height > scrollY &&
+        entry.top < scrollY + viewportBodyH;
+      if (inViewport && !entry.viewportActive) {
+        entry.bg.setInteractive(
+          new Phaser.Geom.Rectangle(0, 0, this.tableConfig.width, entry.height),
+          Phaser.Geom.Rectangle.Contains,
+        );
+        entry.viewportActive = true;
+      } else if (!inViewport && entry.viewportActive) {
+        entry.bg.disableInteractive();
+        entry.viewportActive = false;
+      }
+    }
   }
 
   private selectRow(


### PR DESCRIPTION
## Summary

- The route-finder dropdown filters became unclickable after even a small scroll of the route table.
- Root cause: in `contentSized` mode, `DataTable` created an invisible full-size `wheelHitArea` rectangle plus interactive row backgrounds. When `ScrollFrame` scrolled the table upward, those rectangles drifted into world-space *above* the viewport and silently swallowed pointer events on the filters above. Phaser's input system is purely spatial — it doesn't respect WebGL masks.
- Fix in [packages/spacebiz-ui/src/DataTable.ts](packages/spacebiz-ui/src/DataTable.ts):
  - Skip creating `wheelHitArea` in `contentSized` mode entirely. `ScrollFrame` owns scrolling and row `pointerdown` handlers already call `focus()`, so it serves no purpose there.
  - In `setViewportScrollY`, toggle each row's interactive hit area based on whether it overlaps the visible body region. A `viewportActive` boolean per `rowEntry` avoids redundant `setInteractive` / `disableInteractive` calls.

## Why this matters

The `wheelHitArea` overlapped the second row of dropdowns after just ~8px of scroll, and the first row after ~68px. Row backgrounds added a second wave of blocking after ~104px. With both addressed, the filters stay clickable regardless of table scroll position.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] `npm run test` — 1283 tests pass
- [x] `npm run build` succeeds
- [ ] Manual: open Routes scene → Route Finder tab → scroll the table → click each dropdown filter and confirm it opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)