### PR TITLE
feat(diplomacy): Foreign Relations hub v1 — playable gift + surveil

### DIFF
--- a/src/scenes/DiplomacyScene.ts
+++ b/src/scenes/DiplomacyScene.ts
@@ -1,17 +1,41 @@
 import * as Phaser from "phaser";
-import type { GameState, QueuedDiplomacyAction } from "../data/types.ts";
+import { gameStore } from "../data/GameStore.ts";
+import type {
+  AICompany,
+  Empire,
+  GameState,
+  QueuedDiplomacyAction,
+} from "../data/types.ts";
 import { EMPTY_DIPLOMACY_STATE } from "../data/types.ts";
 import { cooldownKey, isOnCooldown } from "../game/diplomacy/Cooldowns.ts";
+import { getStandingTier } from "../game/diplomacy/StandingTiers.ts";
+import {
+  Button,
+  DataTable,
+  Label,
+  Panel,
+  ScrollFrame,
+  createStarfield,
+  getLayout,
+  getTheme,
+} from "../ui/index.ts";
+import {
+  buildQueuedAction,
+  evaluateActionState,
+  getActionsForEmpire,
+  getActionsForRival,
+  getPerTurnCap,
+  type HubActionDescriptor,
+} from "./diplomacyHubHelpers.ts";
 
 const REPUTATION_THROTTLE_THRESHOLD = 75;
 const THROTTLE_BASE = 2;
 const THROTTLE_HIGH = 3;
 
-function getPerTurnCap(state: GameState): number {
-  return (state.reputation ?? 0) >= REPUTATION_THROTTLE_THRESHOLD
-    ? THROTTLE_HIGH
-    : THROTTLE_BASE;
-}
+type Selection =
+  | { kind: "empire"; id: string }
+  | { kind: "rival"; id: string }
+  | null;
 
 /**
  * Pure helper: queue a diplomacy action onto the game state. Throws if the
@@ -27,46 +51,338 @@ export function queueDiplomacyAction(
   if (isOnCooldown(d.cooldowns, key, state.turn)) {
     throw new Error(`Action on cooldown: ${key}`);
   }
-  if (d.queuedActions.length >= getPerTurnCap(state)) {
+  const cap =
+    (state.reputation ?? 0) >= REPUTATION_THROTTLE_THRESHOLD
+      ? THROTTLE_HIGH
+      : THROTTLE_BASE;
+  if (d.queuedActions.length >= cap) {
     throw new Error("Per-turn diplomacy cap reached");
   }
   return {
     ...state,
-    diplomacy: {
-      ...d,
-      queuedActions: [...d.queuedActions, action],
-    },
+    diplomacy: { ...d, queuedActions: [...d.queuedActions, action] },
   };
 }
 
+interface TargetRow {
+  rowKind: "empire" | "rival";
+  id: string;
+  name: string;
+  tier: string;
+  standing: number;
+  empireRef?: string;
+}
+
 /**
- * Foreign Relations hub. Wave-1 ships a placeholder shell; the full hub UI
- * (left rail of empires/rivals + right pane with portrait + action buttons +
- * cooldown display) is wave-2 polish. In wave 1, players queue actions via
- * the upcoming wave-2 UI; the underlying queueDiplomacyAction helper is the
- * stable API for both the wave-1 placeholder and the wave-2 polish.
+ * Foreign Relations hub — v1.
+ *
+ * Player workflow:
+ *  - Pick a target (empire or rival) from the left table.
+ *  - Action buttons appear in the right pane with cost, cooldown, and cap
+ *    awareness; clicking queues the action via `queueDiplomacyAction`.
+ *  - The header counter shows queued/cap; once at the cap, all action
+ *    buttons disable.
+ *
+ * Verbs in v1: gift (empire/rival) + surveil (rival, three lens variants).
+ * Lobby and propose-non-compete need multi-target pickers and ship in v2.
  */
 export class DiplomacyScene extends Phaser.Scene {
+  private targetTable!: DataTable;
+  private actionPanel!: Panel;
+  private actionButtons: Button[] = [];
+  private actionStatusLabel!: Label;
+  private headerCounter!: Label;
+  private queuedSummary!: Label;
+  private selection: Selection = null;
+  private storeUnsub: (() => void) | null = null;
+
   constructor() {
     super({ key: "DiplomacyScene" });
   }
 
   create(): void {
-    const cx = this.scale.width / 2;
-    const cy = this.scale.height / 2;
-    this.add
-      .text(cx, cy - 16, "Foreign Relations", {
-        fontFamily: "sans-serif",
-        fontSize: "28px",
-        color: "#e8d8a8",
-      })
-      .setOrigin(0.5);
-    this.add
-      .text(cx, cy + 24, "(Hub UI ships in wave 2 polish)", {
-        fontFamily: "sans-serif",
-        fontSize: "16px",
-        color: "#a8a890",
-      })
-      .setOrigin(0.5);
+    const L = getLayout();
+    createStarfield(this);
+
+    this.buildHeader(L);
+    this.buildTargetTable(L);
+    this.buildActionPanel(L);
+    this.refreshFromState();
+
+    const onChange = (): void => this.refreshFromState();
+    gameStore.on("stateChanged", onChange);
+    this.storeUnsub = (): void => {
+      gameStore.off("stateChanged", onChange);
+    };
+    this.events.on(Phaser.Scenes.Events.SHUTDOWN, () => {
+      this.storeUnsub?.();
+      this.storeUnsub = null;
+    });
   }
+
+  // ─── Layout builders ────────────────────────────────────────────────────
+
+  private buildHeader(L: ReturnType<typeof getLayout>): void {
+    new Label(this, {
+      x: L.mainContentLeft,
+      y: L.contentTop - 28,
+      text: "Foreign Relations",
+      style: "heading",
+    });
+    this.headerCounter = new Label(this, {
+      x: L.mainContentLeft + L.mainContentWidth - 8,
+      y: L.contentTop - 28,
+      text: "Actions: 0/2",
+      style: "caption",
+    });
+    this.headerCounter.setOrigin(1, 0);
+  }
+
+  private buildTargetTable(L: ReturnType<typeof getLayout>): void {
+    const tableW = Math.floor(L.mainContentWidth * 0.55);
+    const tablePanel = new Panel(this, {
+      x: L.mainContentLeft,
+      y: L.contentTop,
+      width: tableW,
+      height: L.contentHeight,
+      title: "Targets",
+    });
+    const content = tablePanel.getContentArea();
+    const absX = L.mainContentLeft + content.x;
+    const absY = L.contentTop + content.y;
+
+    const frame = new ScrollFrame(this, {
+      x: absX,
+      y: absY,
+      width: content.width,
+      height: content.height - 16,
+    });
+    this.targetTable = new DataTable(this, {
+      x: 0,
+      y: 0,
+      width: content.width,
+      height: content.height - 16,
+      contentSized: true,
+      columns: [
+        { key: "type", label: "Type", width: 60 },
+        { key: "name", label: "Name", width: 180 },
+        { key: "tier", label: "Tier", width: 80 },
+        { key: "standing", label: "Standing", width: 80, align: "right" },
+      ],
+      onRowSelect: (_idx, row) => {
+        const kind = row["rowKind"] as "empire" | "rival";
+        const id = row["id"] as string;
+        this.selection = { kind, id };
+        this.refreshActionPanel();
+      },
+    });
+    frame.setContent(this.targetTable);
+  }
+
+  private buildActionPanel(L: ReturnType<typeof getLayout>): void {
+    const panelX =
+      L.mainContentLeft + Math.floor(L.mainContentWidth * 0.55) + 8;
+    const panelW =
+      L.mainContentWidth - Math.floor(L.mainContentWidth * 0.55) - 8;
+    this.actionPanel = new Panel(this, {
+      x: panelX,
+      y: L.contentTop,
+      width: panelW,
+      height: L.contentHeight,
+      title: "Actions",
+    });
+    const content = this.actionPanel.getContentArea();
+    const absX = panelX + content.x;
+    const absY = L.contentTop + content.y;
+
+    this.actionStatusLabel = new Label(this, {
+      x: absX,
+      y: absY,
+      text: "Pick a target on the left to see available actions.",
+      style: "caption",
+    });
+
+    this.queuedSummary = new Label(this, {
+      x: absX,
+      y: absY + content.height - 24,
+      text: "",
+      style: "caption",
+    });
+  }
+
+  // ─── State sync ─────────────────────────────────────────────────────────
+
+  private refreshFromState(): void {
+    const state = gameStore.getState();
+    this.refreshHeader(state);
+    this.refreshTargetTable(state);
+    this.refreshActionPanel();
+    this.refreshQueuedSummary(state);
+  }
+
+  private refreshHeader(state: GameState): void {
+    const d = state.diplomacy ?? EMPTY_DIPLOMACY_STATE;
+    const cap = getPerTurnCap(state);
+    const used = d.queuedActions.length;
+    this.headerCounter.setText(`Actions: ${used}/${cap}`);
+    const theme = getTheme();
+    this.headerCounter.setColor(
+      used >= cap
+        ? colorToHex(theme.colors.warning)
+        : colorToHex(theme.colors.textDim),
+    );
+  }
+
+  private refreshTargetTable(state: GameState): void {
+    const empires = state.galaxy?.empires ?? [];
+    const rivals = state.aiCompanies ?? [];
+    const playerId = state.playerEmpireId;
+    const d = state.diplomacy ?? EMPTY_DIPLOMACY_STATE;
+
+    const empireRows: TargetRow[] = empires
+      .filter((e) => e.id !== playerId)
+      .map((e: Empire) => {
+        const standing = state.empireReputation?.[e.id] ?? 50;
+        return {
+          rowKind: "empire",
+          id: e.id,
+          name: e.name,
+          tier: getStandingTier(standing),
+          standing,
+        };
+      });
+    const rivalRows: TargetRow[] = rivals
+      .filter((r) => !r.bankrupt)
+      .map((r: AICompany) => {
+        const standing = d.rivalStanding[r.id] ?? 50;
+        return {
+          rowKind: "rival",
+          id: r.id,
+          name: r.name,
+          tier: getStandingTier(standing),
+          standing,
+        };
+      });
+
+    const rows = [...empireRows, ...rivalRows].map((r) => ({
+      ...r,
+      type: r.rowKind === "empire" ? "Empire" : "Rival",
+    }));
+    this.targetTable.setRows(rows);
+  }
+
+  private refreshActionPanel(): void {
+    // Clear previous buttons.
+    for (const b of this.actionButtons) b.destroy();
+    this.actionButtons = [];
+
+    const state = gameStore.getState();
+    if (!this.selection) {
+      this.actionStatusLabel.setText(
+        "Pick a target on the left to see available actions.",
+      );
+      return;
+    }
+
+    const { kind, id } = this.selection;
+    let actions: readonly HubActionDescriptor[];
+    let header: string;
+    if (kind === "empire") {
+      const empire = state.galaxy?.empires.find((e) => e.id === id);
+      if (!empire) return;
+      actions = getActionsForEmpire(empire, state);
+      header = empire.name;
+    } else {
+      const rival = state.aiCompanies?.find((r) => r.id === id);
+      if (!rival) return;
+      actions = getActionsForRival(rival);
+      header = rival.name;
+    }
+
+    this.actionStatusLabel.setText(header);
+
+    const L = getLayout();
+    const panelX =
+      L.mainContentLeft + Math.floor(L.mainContentWidth * 0.55) + 8;
+    const content = this.actionPanel.getContentArea();
+    const absX = panelX + content.x;
+    const absY = L.contentTop + content.y + 28;
+    const btnH = 36;
+    const btnGap = 8;
+
+    actions.forEach((action, i) => {
+      const evalState = evaluateActionState(action, id, state);
+      const suffix = !evalState.enabled
+        ? evalState.reasonIfDisabled === "cooldown"
+          ? ` (cd ${evalState.cooldownTurnsRemaining ?? "?"}t)`
+          : evalState.reasonIfDisabled === "cap"
+            ? " (cap)"
+            : evalState.reasonIfDisabled === "cash"
+              ? " (low cash)"
+              : ""
+        : "";
+      const label = `${action.label} — $${formatCash(action.cashCost)}${suffix}`;
+      const btn = new Button(this, {
+        x: absX,
+        y: absY + i * (btnH + btnGap),
+        width: content.width - 16,
+        height: btnH,
+        label,
+        disabled: !evalState.enabled,
+        onClick: () => this.handleQueue(action, id),
+      });
+      this.actionButtons.push(btn);
+    });
+  }
+
+  private refreshQueuedSummary(state: GameState): void {
+    const d = state.diplomacy ?? EMPTY_DIPLOMACY_STATE;
+    if (d.queuedActions.length === 0) {
+      this.queuedSummary.setText("");
+      return;
+    }
+    const nameById: Record<string, string> = {};
+    for (const e of state.galaxy?.empires ?? []) nameById[e.id] = e.name;
+    for (const r of state.aiCompanies ?? []) nameById[r.id] = r.name;
+    const verbLabel: Record<string, string> = {
+      giftEmpire: "Gift",
+      giftRival: "Gift",
+      lobbyFor: "Lobby for",
+      lobbyAgainst: "Lobby against",
+      proposeNonCompete: "Non-Compete",
+      surveil: "Surveil",
+    };
+    const lines = d.queuedActions
+      .map((a) => {
+        const verb = verbLabel[a.kind] ?? a.kind;
+        const target = nameById[a.targetId] ?? a.targetId;
+        return `• ${verb} → ${target}`;
+      })
+      .join("\n");
+    this.queuedSummary.setText(`Queued this turn:\n${lines}`);
+  }
+
+  // ─── Action handler ─────────────────────────────────────────────────────
+
+  private handleQueue(action: HubActionDescriptor, targetId: string): void {
+    const state = gameStore.getState();
+    try {
+      const queued = buildQueuedAction(action, targetId, state.turn);
+      gameStore.setState(queueDiplomacyAction(state, queued));
+    } catch (err) {
+      // Disabled-state UI should normally prevent reaching here; keep a
+      // defensive log so unexpected races (e.g. concurrent state updates)
+      // surface during dev.
+      console.warn("[DiplomacyScene] queue rejected:", err);
+    }
+  }
+}
+
+function colorToHex(color: number): string {
+  return "#" + color.toString(16).padStart(6, "0");
+}
+
+function formatCash(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(n % 1000 === 0 ? 0 : 1)}k`;
+  return String(n);
 }

--- a/src/scenes/__tests__/diplomacyHubHelpers.test.ts
+++ b/src/scenes/__tests__/diplomacyHubHelpers.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeGiftCostForEmpire,
+  getActionsForEmpire,
+  getActionsForRival,
+  evaluateActionState,
+  buildQueuedAction,
+  getPerTurnCap,
+} from "../diplomacyHubHelpers.ts";
+import { EMPTY_DIPLOMACY_STATE } from "../../data/types.ts";
+import type {
+  AICompany,
+  Empire,
+  GameState,
+  StarSystem,
+} from "../../data/types.ts";
+
+const empire: Empire = {
+  id: "vex",
+  name: "Vex Hegemony",
+  color: 0xff0000,
+  tariffRate: 0.1,
+  disposition: "neutral",
+  homeSystemId: "sys-1",
+  leaderName: "Emperor Vex IX",
+  leaderPortrait: { portraitId: "p1", category: "alien" },
+};
+
+const rival: AICompany = {
+  id: "chen",
+  name: "Chen Logistics",
+  empireId: "sol",
+  cash: 1_000_000,
+  fleet: [],
+  activeRoutes: [],
+  reputation: 50,
+  totalCargoDelivered: 0,
+  personality: "steadyHauler",
+  bankrupt: false,
+  ceoName: "Chen Wei",
+  ceoPortrait: { portraitId: "p2", category: "human" },
+};
+
+function makeState(
+  opts: {
+    systems?: number;
+    cash?: number;
+    reputation?: number;
+    turn?: number;
+    queuedCount?: number;
+    cooldowns?: Record<string, number>;
+  } = {},
+): GameState {
+  const systemList: StarSystem[] = Array.from(
+    { length: opts.systems ?? 0 },
+    (_, i) => ({ id: `sys-${i}`, empireId: "vex" }) as unknown as StarSystem,
+  );
+  return {
+    seed: 1,
+    turn: opts.turn ?? 5,
+    cash: opts.cash ?? 100_000,
+    reputation: opts.reputation ?? 50,
+    galaxy: { empires: [empire], systems: systemList },
+    aiCompanies: [rival],
+    diplomacy: {
+      ...EMPTY_DIPLOMACY_STATE,
+      queuedActions: Array.from({ length: opts.queuedCount ?? 0 }, (_, i) => ({
+        id: `q${i}`,
+        kind: "giftEmpire" as const,
+        targetId: "vex",
+        cashCost: 0,
+      })),
+      cooldowns: opts.cooldowns ?? {},
+    },
+  } as unknown as GameState;
+}
+
+describe("computeGiftCostForEmpire", () => {
+  it("base cost when empire owns no systems", () => {
+    expect(computeGiftCostForEmpire(empire, makeState({ systems: 0 }))).toBe(
+      5_000,
+    );
+  });
+  it("scales 1.5k per system", () => {
+    expect(computeGiftCostForEmpire(empire, makeState({ systems: 4 }))).toBe(
+      11_000,
+    );
+  });
+  it("caps at 20k", () => {
+    expect(computeGiftCostForEmpire(empire, makeState({ systems: 50 }))).toBe(
+      20_000,
+    );
+  });
+});
+
+describe("getActionsForEmpire", () => {
+  it("returns a single Send Gift action", () => {
+    const actions = getActionsForEmpire(empire, makeState({ systems: 2 }));
+    expect(actions).toHaveLength(1);
+    expect(actions[0]!.kind).toBe("giftEmpire");
+    expect(actions[0]!.cashCost).toBe(8_000);
+  });
+});
+
+describe("getActionsForRival", () => {
+  it("returns gift + three surveil lenses", () => {
+    const actions = getActionsForRival(rival);
+    expect(actions.map((a) => a.kind)).toEqual([
+      "giftRival",
+      "surveil",
+      "surveil",
+      "surveil",
+    ]);
+    expect(actions.map((a) => a.surveilLens)).toEqual([
+      undefined,
+      "cash",
+      "topContractByValue",
+      "topEmpireStanding",
+    ]);
+  });
+});
+
+describe("getPerTurnCap", () => {
+  it("base cap = 2 below renowned reputation", () => {
+    expect(getPerTurnCap(makeState({ reputation: 50 }))).toBe(2);
+  });
+  it("high cap = 3 at reputation >= 75", () => {
+    expect(getPerTurnCap(makeState({ reputation: 75 }))).toBe(3);
+    expect(getPerTurnCap(makeState({ reputation: 90 }))).toBe(3);
+  });
+});
+
+describe("evaluateActionState", () => {
+  const action = getActionsForEmpire(empire, makeState({ systems: 2 }))[0]!;
+
+  it("enabled when target is fresh and cap not reached", () => {
+    expect(evaluateActionState(action, "vex", makeState()).enabled).toBe(true);
+  });
+
+  it("disables on cap (queued count >= cap)", () => {
+    const r = evaluateActionState(action, "vex", makeState({ queuedCount: 2 }));
+    expect(r.enabled).toBe(false);
+    expect(r.reasonIfDisabled).toBe("cap");
+  });
+
+  it("disables on cooldown and surfaces turns remaining", () => {
+    const r = evaluateActionState(
+      action,
+      "vex",
+      makeState({ turn: 5, cooldowns: { "giftEmpire:vex": 8 } }),
+    );
+    expect(r.enabled).toBe(false);
+    expect(r.reasonIfDisabled).toBe("cooldown");
+    expect(r.cooldownTurnsRemaining).toBe(3);
+  });
+
+  it("disables on insufficient cash", () => {
+    const r = evaluateActionState(action, "vex", makeState({ cash: 100 }));
+    expect(r.enabled).toBe(false);
+    expect(r.reasonIfDisabled).toBe("cash");
+  });
+
+  it("cap takes precedence over cooldown", () => {
+    const r = evaluateActionState(
+      action,
+      "vex",
+      makeState({
+        queuedCount: 2,
+        cooldowns: { "giftEmpire:vex": 99 },
+      }),
+    );
+    expect(r.reasonIfDisabled).toBe("cap");
+  });
+});
+
+describe("buildQueuedAction", () => {
+  it("constructs gift action without surveilLens", () => {
+    const action = getActionsForEmpire(empire, makeState({ systems: 0 }))[0]!;
+    const q = buildQueuedAction(action, "vex", 7);
+    expect(q.kind).toBe("giftEmpire");
+    expect(q.targetId).toBe("vex");
+    expect(q.surveilLens).toBeUndefined();
+    expect(q.id).toContain("7"); // includes turn
+  });
+
+  it("constructs surveil action with lens", () => {
+    const action = getActionsForRival(rival).find(
+      (a) => a.surveilLens === "cash",
+    )!;
+    const q = buildQueuedAction(action, "chen", 7);
+    expect(q.kind).toBe("surveil");
+    expect(q.surveilLens).toBe("cash");
+  });
+});

--- a/src/scenes/diplomacyHubHelpers.ts
+++ b/src/scenes/diplomacyHubHelpers.ts
@@ -1,0 +1,146 @@
+import type {
+  AICompany,
+  DiplomacyActionKind,
+  Empire,
+  GameState,
+  QueuedDiplomacyAction,
+  SurveilLens,
+} from "../data/types.ts";
+import { EMPTY_DIPLOMACY_STATE } from "../data/types.ts";
+import { cooldownKey, isOnCooldown } from "../game/diplomacy/Cooldowns.ts";
+
+export const HUB_THROTTLE_BASE = 2;
+export const HUB_THROTTLE_HIGH = 3;
+export const HUB_REPUTATION_THRESHOLD = 75;
+
+const GIFT_EMPIRE_BASE = 5_000;
+const GIFT_EMPIRE_PER_SYSTEM = 1_500;
+const GIFT_EMPIRE_CAP = 20_000;
+const GIFT_RIVAL_COST = 5_000;
+const SURVEIL_COST = 15_000;
+
+export interface HubActionDescriptor {
+  readonly id: string;
+  readonly kind: DiplomacyActionKind;
+  readonly label: string;
+  readonly cashCost: number;
+  readonly surveilLens?: SurveilLens;
+}
+
+export interface HubActionState {
+  readonly enabled: boolean;
+  readonly reasonIfDisabled?: "cooldown" | "cap" | "cash";
+  readonly cooldownTurnsRemaining?: number;
+}
+
+export function getPerTurnCap(state: GameState): number {
+  return (state.reputation ?? 0) >= HUB_REPUTATION_THRESHOLD
+    ? HUB_THROTTLE_HIGH
+    : HUB_THROTTLE_BASE;
+}
+
+export function computeGiftCostForEmpire(
+  empire: Empire,
+  state: GameState,
+): number {
+  const systems = state.galaxy.systems.filter(
+    (s) => s.empireId === empire.id,
+  ).length;
+  return Math.min(
+    GIFT_EMPIRE_CAP,
+    GIFT_EMPIRE_BASE + systems * GIFT_EMPIRE_PER_SYSTEM,
+  );
+}
+
+export function getActionsForEmpire(
+  empire: Empire,
+  state: GameState,
+): readonly HubActionDescriptor[] {
+  return [
+    {
+      id: `gift-${empire.id}`,
+      kind: "giftEmpire",
+      label: "Send Gift",
+      cashCost: computeGiftCostForEmpire(empire, state),
+    },
+  ];
+}
+
+export function getActionsForRival(
+  rival: AICompany,
+): readonly HubActionDescriptor[] {
+  return [
+    {
+      id: `gift-${rival.id}`,
+      kind: "giftRival",
+      label: "Send Gift",
+      cashCost: GIFT_RIVAL_COST,
+    },
+    {
+      id: `surveil-cash-${rival.id}`,
+      kind: "surveil",
+      label: "Surveil: Cash",
+      cashCost: SURVEIL_COST,
+      surveilLens: "cash",
+    },
+    {
+      id: `surveil-contract-${rival.id}`,
+      kind: "surveil",
+      label: "Surveil: Top Contract",
+      cashCost: SURVEIL_COST,
+      surveilLens: "topContractByValue",
+    },
+    {
+      id: `surveil-standing-${rival.id}`,
+      kind: "surveil",
+      label: "Surveil: Best Ally",
+      cashCost: SURVEIL_COST,
+      surveilLens: "topEmpireStanding",
+    },
+  ];
+}
+
+export function evaluateActionState(
+  action: HubActionDescriptor,
+  targetId: string,
+  state: GameState,
+): HubActionState {
+  const d = state.diplomacy ?? EMPTY_DIPLOMACY_STATE;
+
+  // Cap takes precedence — a cap-blocked action stays cap-blocked even if
+  // it's also on cooldown, since the cap is the more useful thing for the
+  // player to fix (skip a turn vs cancel something they queued).
+  if (d.queuedActions.length >= getPerTurnCap(state)) {
+    return { enabled: false, reasonIfDisabled: "cap" };
+  }
+
+  const key = cooldownKey(action.kind, targetId);
+  const until = d.cooldowns[key];
+  if (until !== undefined && isOnCooldown(d.cooldowns, key, state.turn)) {
+    return {
+      enabled: false,
+      reasonIfDisabled: "cooldown",
+      cooldownTurnsRemaining: until - state.turn,
+    };
+  }
+
+  if ((state.cash ?? 0) < action.cashCost) {
+    return { enabled: false, reasonIfDisabled: "cash" };
+  }
+
+  return { enabled: true };
+}
+
+export function buildQueuedAction(
+  action: HubActionDescriptor,
+  targetId: string,
+  turn: number,
+): QueuedDiplomacyAction {
+  return {
+    id: `${action.id}-${turn}`,
+    kind: action.kind,
+    targetId,
+    cashCost: action.cashCost,
+    ...(action.surveilLens ? { surveilLens: action.surveilLens } : {}),
+  };
+}


### PR DESCRIPTION
## Summary

First slice of wave-2 polish on top of the Diplomatic Relations System (#253, merged). Replaces the wave-1 placeholder \`DiplomacyScene\` with a functional Foreign Relations hub the player can actually use.

The wave-1 PR shipped the entire data + simulation + AI offer pipeline, but the hub was a stub showing "(Hub UI ships in wave 2 polish)". With this PR, players can finally trigger gifts and surveils from the menu — closing the loop end-to-end.

## What's playable now

- **Targets table** (left pane): every empire and rival with tier label + standing column. Player empire is excluded; bankrupt rivals are filtered out.
- **Action panel** (right pane): selecting a target reveals the verbs available for that target type with cost.
- **Header counter** \`Actions: X/Y\` showing queued vs cap (2 base, 3 at reputation ≥ renowned). Warning color when at cap.
- **Disabled-state UX**: each button surfaces *why* it's disabled — \`(cd 3t)\` / \`(cap)\` / \`(low cash)\`. Cap takes precedence over cooldown.
- **Queued summary** (bottom): "Queued this turn:" listing this turn's actions with display names.
- **Live updates**: subscribes to \`gameStore\` \`stateChanged\`; UI refreshes on every store mutation. Unsubscribes on scene shutdown.

## Verbs in v1

| Target | Verbs |
|---|---|
| Empire | Send Gift |
| Rival  | Send Gift; Surveil: Cash; Surveil: Top Contract; Surveil: Best Ally |

**Deferred to v2** (need multi-target pickers — empire×rival or rival×empire-pair):
- Lobby For / Lobby Against (empire targeting a rival)
- Propose Non-Compete (rival targeting two empires)

## Architecture

Pure helpers extracted to [\`src/scenes/diplomacyHubHelpers.ts\`](src/scenes/diplomacyHubHelpers.ts):

- \`computeGiftCostForEmpire(empire, state): number\` — \`5k base + 1.5k × systems controlled (cap 20k)\`, matching the design spec.
- \`getActionsForEmpire / getActionsForRival\` — verb catalog per target type.
- \`evaluateActionState(action, targetId, state)\` — returns \`{enabled, reasonIfDisabled, cooldownTurnsRemaining}\`.
- \`buildQueuedAction\` — id-stamped \`QueuedDiplomacyAction\`.

The scene is a thin orchestrator that consumes these helpers, so all eligibility/cost logic is unit-tested without spinning up Phaser.

## Test plan

- [x] 14 unit tests for the pure helpers (cost computation, eligibility, cap precedence, cooldown turn-remaining, surveil lens construction)
- [x] \`npm run check\` clean (typecheck + 1391 tests + production build)
- [x] Manual verification in dev preview: full flow gift → counter \`0/2 → 1/2 → 2/2\` → all buttons disabled with \`(cap)\` suffix → queued summary shows display names instead of IDs
- [ ] Reviewer: sanity-check the layout with \`npm run dev\` → New Game → Foreign Relations menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)