### PR TITLE
feat(diplomacy): hub v2 — Lobby + Propose Non-Compete (multi-target pickers)

### DIFF
--- a/src/scenes/DiplomacyScene.ts
+++ b/src/scenes/DiplomacyScene.ts
@@ -25,6 +25,7 @@ import {
   getActionsForEmpire,
   getActionsForRival,
   getPerTurnCap,
+  getSubjectCandidates,
   type HubActionDescriptor,
 } from "./diplomacyHubHelpers.ts";
 
@@ -36,6 +37,20 @@ type Selection =
   | { kind: "empire"; id: string }
   | { kind: "rival"; id: string }
   | null;
+
+type PanelMode =
+  | { kind: "list" }
+  | {
+      kind: "subjectPicker";
+      action: HubActionDescriptor;
+      targetId: string;
+    }
+  | {
+      kind: "pairPicker";
+      action: HubActionDescriptor;
+      targetId: string;
+      selected: readonly string[];
+    };
 
 /**
  * Pure helper: queue a diplomacy action onto the game state. Throws if the
@@ -94,6 +109,7 @@ export class DiplomacyScene extends Phaser.Scene {
   private headerCounter!: Label;
   private queuedSummary!: Label;
   private selection: Selection = null;
+  private mode: PanelMode = { kind: "list" };
   private storeUnsub: (() => void) | null = null;
 
   constructor() {
@@ -173,6 +189,8 @@ export class DiplomacyScene extends Phaser.Scene {
         const kind = row["rowKind"] as "empire" | "rival";
         const id = row["id"] as string;
         this.selection = { kind, id };
+        // Switching targets always exits any picker.
+        this.mode = { kind: "list" };
         this.refreshActionPanel();
       },
     });
@@ -284,7 +302,21 @@ export class DiplomacyScene extends Phaser.Scene {
       return;
     }
 
-    const { kind, id } = this.selection;
+    if (this.mode.kind === "subjectPicker") {
+      this.renderSubjectPicker(state, this.mode);
+      return;
+    }
+    if (this.mode.kind === "pairPicker") {
+      this.renderPairPicker(state, this.mode);
+      return;
+    }
+    this.renderActionList(state);
+  }
+
+  private renderActionList(state: GameState): void {
+    const sel = this.selection;
+    if (!sel) return;
+    const { kind, id } = sel;
     let actions: readonly HubActionDescriptor[];
     let header: string;
     if (kind === "empire") {
@@ -298,17 +330,11 @@ export class DiplomacyScene extends Phaser.Scene {
       actions = getActionsForRival(rival);
       header = rival.name;
     }
-
     this.actionStatusLabel.setText(header);
 
-    const L = getLayout();
-    const panelX =
-      L.mainContentLeft + Math.floor(L.mainContentWidth * 0.55) + 8;
-    const content = this.actionPanel.getContentArea();
-    const absX = panelX + content.x;
-    const absY = L.contentTop + content.y + 28;
+    const { absX, absY, contentWidth } = this.getActionPanelGeometry();
     const btnH = 36;
-    const btnGap = 8;
+    const btnGap = 6;
 
     actions.forEach((action, i) => {
       const evalState = evaluateActionState(action, id, state);
@@ -321,18 +347,135 @@ export class DiplomacyScene extends Phaser.Scene {
               ? " (low cash)"
               : ""
         : "";
-      const label = `${action.label} — $${formatCash(action.cashCost)}${suffix}`;
+      const costText =
+        action.cashCost > 0 ? ` — $${formatCash(action.cashCost)}` : "";
+      const label = `${action.label}${costText}${suffix}`;
       const btn = new Button(this, {
         x: absX,
         y: absY + i * (btnH + btnGap),
-        width: content.width - 16,
+        width: contentWidth - 16,
         height: btnH,
         label,
         disabled: !evalState.enabled,
-        onClick: () => this.handleQueue(action, id),
+        onClick: () => this.handleActionClick(action, id),
       });
       this.actionButtons.push(btn);
     });
+  }
+
+  private renderSubjectPicker(
+    state: GameState,
+    mode: { action: HubActionDescriptor; targetId: string },
+  ): void {
+    this.actionStatusLabel.setText(
+      mode.action.subjectPrompt ?? "Pick a subject:",
+    );
+    const candidates = getSubjectCandidates(mode.action, state);
+    const { absX, absY, contentWidth } = this.getActionPanelGeometry();
+    const btnH = 32;
+    const btnGap = 4;
+
+    candidates.forEach((cand, i) => {
+      const btn = new Button(this, {
+        x: absX,
+        y: absY + i * (btnH + btnGap),
+        width: contentWidth - 16,
+        height: btnH,
+        label: cand.name,
+        onClick: () =>
+          this.handleSubjectChosen(mode.action, mode.targetId, cand.id),
+      });
+      this.actionButtons.push(btn);
+    });
+
+    const cancelBtn = new Button(this, {
+      x: absX,
+      y: absY + candidates.length * (btnH + btnGap) + 8,
+      width: contentWidth - 16,
+      height: btnH,
+      label: "Cancel",
+      onClick: () => {
+        this.mode = { kind: "list" };
+        this.refreshActionPanel();
+      },
+    });
+    this.actionButtons.push(cancelBtn);
+  }
+
+  private renderPairPicker(
+    state: GameState,
+    mode: {
+      action: HubActionDescriptor;
+      targetId: string;
+      selected: readonly string[];
+    },
+  ): void {
+    const need = 2;
+    const have = mode.selected.length;
+    const promptBase = mode.action.subjectPrompt ?? "Pick two subjects:";
+    this.actionStatusLabel.setText(`${promptBase} (${have}/${need} chosen)`);
+    const candidates = getSubjectCandidates(mode.action, state);
+    const { absX, absY, contentWidth } = this.getActionPanelGeometry();
+    const btnH = 30;
+    const btnGap = 3;
+
+    candidates.forEach((cand, i) => {
+      const isSelected = mode.selected.includes(cand.id);
+      const isMaxed = !isSelected && have >= need;
+      const label = isSelected ? `[x] ${cand.name}` : `[ ] ${cand.name}`;
+      const btn = new Button(this, {
+        x: absX,
+        y: absY + i * (btnH + btnGap),
+        width: contentWidth - 16,
+        height: btnH,
+        label,
+        disabled: isMaxed,
+        onClick: () => this.togglePairSelection(cand.id),
+      });
+      this.actionButtons.push(btn);
+    });
+
+    const baseY = absY + candidates.length * (btnH + btnGap) + 8;
+    const confirmBtn = new Button(this, {
+      x: absX,
+      y: baseY,
+      width: Math.floor((contentWidth - 24) / 2),
+      height: btnH,
+      label: have === need ? "Confirm" : `Confirm (${have}/${need})`,
+      disabled: have !== need,
+      onClick: () =>
+        this.handlePairConfirmed(mode.action, mode.targetId, mode.selected),
+    });
+    this.actionButtons.push(confirmBtn);
+
+    const cancelBtn = new Button(this, {
+      x: absX + Math.floor((contentWidth - 24) / 2) + 8,
+      y: baseY,
+      width: Math.floor((contentWidth - 24) / 2),
+      height: btnH,
+      label: "Cancel",
+      onClick: () => {
+        this.mode = { kind: "list" };
+        this.refreshActionPanel();
+      },
+    });
+    this.actionButtons.push(cancelBtn);
+  }
+
+  private getActionPanelGeometry(): {
+    absX: number;
+    absY: number;
+    contentWidth: number;
+  } {
+    const L = getLayout();
+    const panelX =
+      L.mainContentLeft + Math.floor(L.mainContentWidth * 0.55) + 8;
+    const content = this.actionPanel.getContentArea();
+    return {
+      absX: panelX + content.x,
+      absY: L.contentTop + content.y + 28,
+      contentWidth: content.width,
+    };
   }
 
   private refreshQueuedSummary(state: GameState): void {
@@ -362,12 +505,74 @@ export class DiplomacyScene extends Phaser.Scene {
     this.queuedSummary.setText(`Queued this turn:\n${lines}`);
   }
 
-  // ─── Action handler ─────────────────────────────────────────────────────
+  // ─── Action handlers ────────────────────────────────────────────────────
 
-  private handleQueue(action: HubActionDescriptor, targetId: string): void {
+  private handleActionClick(
+    action: HubActionDescriptor,
+    targetId: string,
+  ): void {
+    if (action.category === "single") {
+      this.queueAction(action, targetId);
+      return;
+    }
+    if (action.category === "subject") {
+      this.mode = { kind: "subjectPicker", action, targetId };
+      this.refreshActionPanel();
+      return;
+    }
+    if (action.category === "pair") {
+      this.mode = { kind: "pairPicker", action, targetId, selected: [] };
+      this.refreshActionPanel();
+      return;
+    }
+  }
+
+  private handleSubjectChosen(
+    action: HubActionDescriptor,
+    targetId: string,
+    subjectId: string,
+  ): void {
+    this.queueAction(action, targetId, { subjectId });
+    this.mode = { kind: "list" };
+    // refresh handled by gameStore.stateChanged subscription
+  }
+
+  private togglePairSelection(candidateId: string): void {
+    if (this.mode.kind !== "pairPicker") return;
+    const cur = this.mode.selected;
+    let next: string[];
+    if (cur.includes(candidateId)) {
+      next = cur.filter((id) => id !== candidateId);
+    } else if (cur.length < 2) {
+      next = [...cur, candidateId];
+    } else {
+      next = [...cur]; // already at max — buttons should already be disabled
+    }
+    this.mode = { ...this.mode, selected: next };
+    this.refreshActionPanel();
+  }
+
+  private handlePairConfirmed(
+    action: HubActionDescriptor,
+    targetId: string,
+    selected: readonly string[],
+  ): void {
+    if (selected.length !== 2) return;
+    this.queueAction(action, targetId, {
+      subjectId: selected[0],
+      subjectIdSecondary: selected[1],
+    });
+    this.mode = { kind: "list" };
+  }
+
+  private queueAction(
+    action: HubActionDescriptor,
+    targetId: string,
+    subjects: { subjectId?: string; subjectIdSecondary?: string } = {},
+  ): void {
     const state = gameStore.getState();
     try {
-      const queued = buildQueuedAction(action, targetId, state.turn);
+      const queued = buildQueuedAction(action, targetId, state.turn, subjects);
       gameStore.setState(queueDiplomacyAction(state, queued));
     } catch (err) {
       // Disabled-state UI should normally prevent reaching here; keep a

--- a/src/scenes/__tests__/diplomacyHubHelpers.test.ts
+++ b/src/scenes/__tests__/diplomacyHubHelpers.test.ts
@@ -3,6 +3,7 @@ import {
   computeGiftCostForEmpire,
   getActionsForEmpire,
   getActionsForRival,
+  getSubjectCandidates,
   evaluateActionState,
   buildQueuedAction,
   getPerTurnCap,
@@ -94,29 +95,100 @@ describe("computeGiftCostForEmpire", () => {
 });
 
 describe("getActionsForEmpire", () => {
-  it("returns a single Send Gift action", () => {
+  it("returns gift + lobbyFor + lobbyAgainst", () => {
     const actions = getActionsForEmpire(empire, makeState({ systems: 2 }));
-    expect(actions).toHaveLength(1);
-    expect(actions[0]!.kind).toBe("giftEmpire");
+    expect(actions.map((a) => a.kind)).toEqual([
+      "giftEmpire",
+      "lobbyFor",
+      "lobbyAgainst",
+    ]);
     expect(actions[0]!.cashCost).toBe(8_000);
+  });
+
+  it("marks gift as single-category and lobby as subject-category", () => {
+    const actions = getActionsForEmpire(empire, makeState({ systems: 0 }));
+    expect(actions[0]!.category).toBe("single");
+    expect(actions[1]!.category).toBe("subject");
+    expect(actions[2]!.category).toBe("subject");
+  });
+
+  it("lobby actions carry a subjectPrompt referencing the empire", () => {
+    const actions = getActionsForEmpire(empire, makeState({ systems: 0 }));
+    expect(actions[1]!.subjectPrompt).toContain("Vex Hegemony");
+    expect(actions[2]!.subjectPrompt).toContain("Vex Hegemony");
   });
 });
 
 describe("getActionsForRival", () => {
-  it("returns gift + three surveil lenses", () => {
+  it("returns gift + three surveil lenses + propose-non-compete", () => {
     const actions = getActionsForRival(rival);
     expect(actions.map((a) => a.kind)).toEqual([
       "giftRival",
       "surveil",
       "surveil",
       "surveil",
+      "proposeNonCompete",
     ]);
     expect(actions.map((a) => a.surveilLens)).toEqual([
       undefined,
       "cash",
       "topContractByValue",
       "topEmpireStanding",
+      undefined,
     ]);
+  });
+
+  it("non-compete is pair-category with subjectPrompt", () => {
+    const actions = getActionsForRival(rival);
+    const nc = actions.find((a) => a.kind === "proposeNonCompete")!;
+    expect(nc.category).toBe("pair");
+    expect(nc.subjectPrompt).toContain("Chen Logistics");
+  });
+});
+
+describe("getSubjectCandidates", () => {
+  it("returns rivals for lobbyFor", () => {
+    const action = getActionsForEmpire(empire, makeState({ systems: 0 })).find(
+      (a) => a.kind === "lobbyFor",
+    )!;
+    const cands = getSubjectCandidates(action, makeState());
+    expect(cands).toEqual([{ id: "chen", name: "Chen Logistics" }]);
+  });
+
+  it("excludes bankrupt rivals from lobby candidates", () => {
+    const action = getActionsForEmpire(empire, makeState({ systems: 0 })).find(
+      (a) => a.kind === "lobbyFor",
+    )!;
+    const s = makeState();
+    s.aiCompanies = [{ ...rival, bankrupt: true }];
+    const cands = getSubjectCandidates(action, s);
+    expect(cands).toEqual([]);
+  });
+
+  it("returns all non-player empires for proposeNonCompete", () => {
+    const action = getActionsForRival(rival).find(
+      (a) => a.kind === "proposeNonCompete",
+    )!;
+    const s = makeState();
+    s.galaxy = {
+      ...s.galaxy,
+      empires: [
+        empire,
+        { ...empire, id: "sol", name: "Sol Federation" },
+        { ...empire, id: "kade", name: "Kade Reach" },
+      ],
+    };
+    s.playerEmpireId = "sol";
+    const cands = getSubjectCandidates(action, s);
+    expect(cands.map((c) => c.id)).toEqual(["vex", "kade"]);
+  });
+
+  it("returns empty for single-category actions", () => {
+    const giftAction = getActionsForEmpire(
+      empire,
+      makeState({ systems: 0 }),
+    )[0]!;
+    expect(getSubjectCandidates(giftAction, makeState())).toEqual([]);
   });
 });
 
@@ -190,5 +262,29 @@ describe("buildQueuedAction", () => {
     const q = buildQueuedAction(action, "chen", 7);
     expect(q.kind).toBe("surveil");
     expect(q.surveilLens).toBe("cash");
+  });
+
+  it("constructs lobby action with single subjectId", () => {
+    const action = getActionsForEmpire(empire, makeState({ systems: 0 })).find(
+      (a) => a.kind === "lobbyFor",
+    )!;
+    const q = buildQueuedAction(action, "vex", 7, { subjectId: "chen" });
+    expect(q.kind).toBe("lobbyFor");
+    expect(q.targetId).toBe("vex");
+    expect(q.subjectId).toBe("chen");
+    expect(q.subjectIdSecondary).toBeUndefined();
+  });
+
+  it("constructs non-compete with two subject ids", () => {
+    const action = getActionsForRival(rival).find(
+      (a) => a.kind === "proposeNonCompete",
+    )!;
+    const q = buildQueuedAction(action, "chen", 7, {
+      subjectId: "vex",
+      subjectIdSecondary: "sol",
+    });
+    expect(q.kind).toBe("proposeNonCompete");
+    expect(q.subjectId).toBe("vex");
+    expect(q.subjectIdSecondary).toBe("sol");
   });
 });

--- a/src/scenes/diplomacyHubHelpers.ts
+++ b/src/scenes/diplomacyHubHelpers.ts
@@ -18,13 +18,25 @@ const GIFT_EMPIRE_PER_SYSTEM = 1_500;
 const GIFT_EMPIRE_CAP = 20_000;
 const GIFT_RIVAL_COST = 5_000;
 const SURVEIL_COST = 15_000;
+const LOBBY_COST = 18_000;
+const NON_COMPETE_COST = 0; // proposal is free; the agreement itself binds both sides
+
+/**
+ * The picker shape an action requires before it can be queued:
+ *  - "single"   → no extra picks needed (gift, surveil)
+ *  - "subject"  → one extra subject id (lobby targets a third-party rival)
+ *  - "pair"     → two extra subject ids (non-compete picks two empires to segregate)
+ */
+export type HubActionCategory = "single" | "subject" | "pair";
 
 export interface HubActionDescriptor {
   readonly id: string;
   readonly kind: DiplomacyActionKind;
   readonly label: string;
   readonly cashCost: number;
+  readonly category: HubActionCategory;
   readonly surveilLens?: SurveilLens;
+  readonly subjectPrompt?: string; // shown above the picker (e.g. "Lobby Vex against…")
 }
 
 export interface HubActionState {
@@ -62,6 +74,23 @@ export function getActionsForEmpire(
       kind: "giftEmpire",
       label: "Send Gift",
       cashCost: computeGiftCostForEmpire(empire, state),
+      category: "single",
+    },
+    {
+      id: `lobby-for-${empire.id}`,
+      kind: "lobbyFor",
+      label: "Lobby For…",
+      cashCost: LOBBY_COST,
+      category: "subject",
+      subjectPrompt: `Lobby ${empire.name} for which rival?`,
+    },
+    {
+      id: `lobby-against-${empire.id}`,
+      kind: "lobbyAgainst",
+      label: "Lobby Against…",
+      cashCost: LOBBY_COST,
+      category: "subject",
+      subjectPrompt: `Lobby ${empire.name} against which rival?`,
     },
   ];
 }
@@ -75,12 +104,14 @@ export function getActionsForRival(
       kind: "giftRival",
       label: "Send Gift",
       cashCost: GIFT_RIVAL_COST,
+      category: "single",
     },
     {
       id: `surveil-cash-${rival.id}`,
       kind: "surveil",
       label: "Surveil: Cash",
       cashCost: SURVEIL_COST,
+      category: "single",
       surveilLens: "cash",
     },
     {
@@ -88,6 +119,7 @@ export function getActionsForRival(
       kind: "surveil",
       label: "Surveil: Top Contract",
       cashCost: SURVEIL_COST,
+      category: "single",
       surveilLens: "topContractByValue",
     },
     {
@@ -95,9 +127,49 @@ export function getActionsForRival(
       kind: "surveil",
       label: "Surveil: Best Ally",
       cashCost: SURVEIL_COST,
+      category: "single",
       surveilLens: "topEmpireStanding",
     },
+    {
+      id: `non-compete-${rival.id}`,
+      kind: "proposeNonCompete",
+      label: "Propose Non-Compete…",
+      cashCost: NON_COMPETE_COST,
+      category: "pair",
+      subjectPrompt: `Pick two empires for ${rival.name} to stay out of.`,
+    },
   ];
+}
+
+export interface SubjectCandidate {
+  readonly id: string;
+  readonly name: string;
+}
+
+/**
+ * Returns the subject pool for a multi-target action:
+ *  - lobbyFor / lobbyAgainst → all non-bankrupt rivals (excluding the
+ *    selected empire's own owned rivals would be a wave-3 polish)
+ *  - proposeNonCompete → all empires except the player's own
+ *
+ * For "single"-category actions the result is empty.
+ */
+export function getSubjectCandidates(
+  action: HubActionDescriptor,
+  state: GameState,
+): readonly SubjectCandidate[] {
+  if (action.kind === "lobbyFor" || action.kind === "lobbyAgainst") {
+    return (state.aiCompanies ?? [])
+      .filter((r) => !r.bankrupt)
+      .map((r) => ({ id: r.id, name: r.name }));
+  }
+  if (action.kind === "proposeNonCompete") {
+    const playerId = state.playerEmpireId;
+    return (state.galaxy?.empires ?? [])
+      .filter((e) => e.id !== playerId)
+      .map((e) => ({ id: e.id, name: e.name }));
+  }
+  return [];
 }
 
 export function evaluateActionState(
@@ -135,6 +207,7 @@ export function buildQueuedAction(
   action: HubActionDescriptor,
   targetId: string,
   turn: number,
+  subjects: { subjectId?: string; subjectIdSecondary?: string } = {},
 ): QueuedDiplomacyAction {
   return {
     id: `${action.id}-${turn}`,
@@ -142,5 +215,9 @@ export function buildQueuedAction(
     targetId,
     cashCost: action.cashCost,
     ...(action.surveilLens ? { surveilLens: action.surveilLens } : {}),
+    ...(subjects.subjectId ? { subjectId: subjects.subjectId } : {}),
+    ...(subjects.subjectIdSecondary
+      ? { subjectIdSecondary: subjects.subjectIdSecondary }
+      : {}),
   };
 }


### PR DESCRIPTION
## Summary

Closes the wave-2 verb gap by adding the two verbs that hub v1 (#254) deferred — they needed **multi-target pickers** (lobby = empire × rival; non-compete = rival × empire-pair) which v1's flat action list couldn't express.

With this PR, all five wave-1 verbs are now playable from the Foreign Relations hub: gift, surveil, **lobby for**, **lobby against**, **propose non-compete**.

## UX additions

### Subject picker (single-pick) — Lobby

Clicking \`Lobby For…\` or \`Lobby Against…\` on an empire swaps the Actions panel into a list of rivals with a contextual header (e.g., *"Lobby Vex Hegemony for which rival?"*) and a Cancel button. **One click on a rival queues the action and returns to the action list.**

### Pair picker (multi-pick) — Propose Non-Compete

Clicking \`Propose Non-Compete…\` on a rival swaps the panel into a checkbox list of empires with a \`(N/2 chosen)\` counter, a Confirm button (disabled until exactly 2 are chosen), and Cancel. **Once 2 are selected, remaining checkboxes disable to enforce the max** — no need to deselect first.

### Other UX nits handled

- Switching the target row always exits any picker — no orphaned picker state across selections.
- The \`subjectPrompt\` lives on the descriptor rather than the scene so it stays close to the verb definition.

## Helper additions (testable without Phaser)

- \`HubActionDescriptor.category: "single" | "subject" | "pair"\` — drives the picker fork.
- \`subjectPrompt: string\` for picker headers.
- \`getSubjectCandidates(action, state)\` — rivals for lobby (excluding bankrupt), non-player empires for non-compete; empty for \`single\` actions.
- \`buildQueuedAction\` now accepts \`{ subjectId, subjectIdSecondary }\` for multi-target verbs.

## Test plan

- [x] **23 helper tests** (up from 14) covering category tagging, subject-candidate filtering (incl. bankrupt-rival exclusion and player-empire exclusion), and multi-arg queued action construction
- [x] \`npm run check\` clean: typecheck + 1400 tests + production build
- [x] Manual verification in dev preview:
  - **Lobby**: select empire → click Lobby For → picker opens with rival list → click rival → queues \`lobbyFor\` with \`subjectId\` set → returns to list
  - **Non-Compete**: select rival → click Propose Non-Compete → 7 empire checkboxes appear → status updates *"(0/2 chosen)" → "(1/2 chosen)" → "(2/2 chosen)"* → Confirm enables only at 2 → click → queues \`proposeNonCompete\` with \`subjectId\` + \`subjectIdSecondary\` → returns to list
- [ ] Reviewer: \`npm run dev\` → New Game → Foreign Relations menu → try Lobby and Non-Compete flows

## Stack context

Hub v1 (#254) merged earlier today. This PR is v2 of the same hub — same target file (\`DiplomacyScene\`), same helper module. After this lands, the wave-1 verb set is fully exposed to the player.

## What's next (deferred)

- **Polish**: portraits in target table, ambassador flavor lines on action click, per-target tag badges
- **Wave 3 verbs**: sabotage, contract poaching, smear
- **Confirmation dialog** for irreversible actions (currently one-click queue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)