### PR TITLE
feat(diplomacy): hub polish 1 — tag visibility + tier color + affordance hints

### DIFF
--- a/src/scenes/DiplomacyScene.ts
+++ b/src/scenes/DiplomacyScene.ts
@@ -24,9 +24,12 @@ import {
   evaluateActionState,
   getActionsForEmpire,
   getActionsForRival,
+  getActiveTagBadges,
   getPerTurnCap,
   getSubjectCandidates,
+  getTierColorName,
   type HubActionDescriptor,
+  type TierColorName,
 } from "./diplomacyHubHelpers.ts";
 
 const REPUTATION_THROTTLE_THRESHOLD = 75;
@@ -85,6 +88,7 @@ interface TargetRow {
   name: string;
   tier: string;
   standing: number;
+  tags: string;
   empireRef?: string;
 }
 
@@ -180,10 +184,16 @@ export class DiplomacyScene extends Phaser.Scene {
       height: content.height - 16,
       contentSized: true,
       columns: [
-        { key: "type", label: "Type", width: 60 },
-        { key: "name", label: "Name", width: 180 },
-        { key: "tier", label: "Tier", width: 80 },
-        { key: "standing", label: "Standing", width: 80, align: "right" },
+        { key: "type", label: "Type", width: 56 },
+        { key: "name", label: "Name", width: 150 },
+        {
+          key: "tier",
+          label: "Tier",
+          width: 68,
+          colorFn: (value) => tierColorForCell(String(value ?? "")),
+        },
+        { key: "standing", label: "#", width: 36, align: "right" },
+        { key: "tags", label: "Tags", width: 140 },
       ],
       onRowSelect: (_idx, row) => {
         const kind = row["rowKind"] as "empire" | "rival";
@@ -257,28 +267,33 @@ export class DiplomacyScene extends Phaser.Scene {
     const playerId = state.playerEmpireId;
     const d = state.diplomacy ?? EMPTY_DIPLOMACY_STATE;
 
+    const turn = state.turn;
     const empireRows: TargetRow[] = empires
       .filter((e) => e.id !== playerId)
       .map((e: Empire) => {
         const standing = state.empireReputation?.[e.id] ?? 50;
+        const badges = getActiveTagBadges(d.empireTags[e.id] ?? [], turn);
         return {
           rowKind: "empire",
           id: e.id,
           name: e.name,
           tier: getStandingTier(standing),
           standing,
+          tags: badges.map((b) => b.label).join(" · "),
         };
       });
     const rivalRows: TargetRow[] = rivals
       .filter((r) => !r.bankrupt)
       .map((r: AICompany) => {
         const standing = d.rivalStanding[r.id] ?? 50;
+        const badges = getActiveTagBadges(d.rivalTags[r.id] ?? [], turn);
         return {
           rowKind: "rival",
           id: r.id,
           name: r.name,
           tier: getStandingTier(standing),
           standing,
+          tags: badges.map((b) => b.label).join(" · "),
         };
       });
 
@@ -317,28 +332,40 @@ export class DiplomacyScene extends Phaser.Scene {
     const sel = this.selection;
     if (!sel) return;
     const { kind, id } = sel;
+    const d = state.diplomacy ?? EMPTY_DIPLOMACY_STATE;
     let actions: readonly HubActionDescriptor[];
     let header: string;
+    let activeTags: ReturnType<typeof getActiveTagBadges>;
     if (kind === "empire") {
       const empire = state.galaxy?.empires.find((e) => e.id === id);
       if (!empire) return;
       actions = getActionsForEmpire(empire, state);
       header = empire.name;
+      activeTags = getActiveTagBadges(d.empireTags[id] ?? [], state.turn);
     } else {
       const rival = state.aiCompanies?.find((r) => r.id === id);
       if (!rival) return;
       actions = getActionsForRival(rival);
       header = rival.name;
+      activeTags = getActiveTagBadges(d.rivalTags[id] ?? [], state.turn);
     }
-    this.actionStatusLabel.setText(header);
+
+    const headerWithTags =
+      activeTags.length > 0
+        ? `${header}\nTags: ${activeTags.map((t) => t.label).join(" · ")}`
+        : header;
+    this.actionStatusLabel.setText(headerWithTags);
 
     const { absX, absY, contentWidth } = this.getActionPanelGeometry();
     const btnH = 36;
     const btnGap = 6;
+    // When tags are shown, push the action buttons down by one line so they
+    // don't collide with the wrapped header.
+    const yOffset = activeTags.length > 0 ? 18 : 0;
 
     actions.forEach((action, i) => {
       const evalState = evaluateActionState(action, id, state);
-      const suffix = !evalState.enabled
+      const disabledSuffix = !evalState.enabled
         ? evalState.reasonIfDisabled === "cooldown"
           ? ` (cd ${evalState.cooldownTurnsRemaining ?? "?"}t)`
           : evalState.reasonIfDisabled === "cap"
@@ -347,12 +374,16 @@ export class DiplomacyScene extends Phaser.Scene {
               ? " (low cash)"
               : ""
         : "";
+      const affordanceSuffix =
+        evalState.enabled && evalState.affordanceHint
+          ? ` · ${evalState.affordanceHint}`
+          : "";
       const costText =
         action.cashCost > 0 ? ` — $${formatCash(action.cashCost)}` : "";
-      const label = `${action.label}${costText}${suffix}`;
+      const label = `${action.label}${costText}${disabledSuffix}${affordanceSuffix}`;
       const btn = new Button(this, {
         x: absX,
-        y: absY + i * (btnH + btnGap),
+        y: absY + yOffset + i * (btnH + btnGap),
         width: contentWidth - 16,
         height: btnH,
         label,
@@ -590,4 +621,34 @@ function colorToHex(color: number): string {
 function formatCash(n: number): string {
   if (n >= 1000) return `${(n / 1000).toFixed(n % 1000 === 0 ? 0 : 1)}k`;
   return String(n);
+}
+
+/**
+ * Map a tier label (rendered in the Tier column) to the live theme color
+ * the cell should use. Returns null for unknown values so the column falls
+ * back to the default text color rather than turning white-on-white.
+ */
+function tierColorForCell(tierLabel: string): number | null {
+  const theme = getTheme();
+  const colorByName: Record<TierColorName, number> = {
+    danger: theme.colors.loss,
+    warning: theme.colors.warning,
+    muted: theme.colors.textDim,
+    accent: theme.colors.accent,
+    highlight: theme.colors.profit,
+  };
+  switch (tierLabel) {
+    case "Hostile":
+      return colorByName[getTierColorName("Hostile")];
+    case "Cold":
+      return colorByName[getTierColorName("Cold")];
+    case "Neutral":
+      return colorByName[getTierColorName("Neutral")];
+    case "Warm":
+      return colorByName[getTierColorName("Warm")];
+    case "Allied":
+      return colorByName[getTierColorName("Allied")];
+    default:
+      return null;
+  }
 }

--- a/src/scenes/__tests__/diplomacyHubHelpers.test.ts
+++ b/src/scenes/__tests__/diplomacyHubHelpers.test.ts
@@ -7,6 +7,9 @@ import {
   evaluateActionState,
   buildQueuedAction,
   getPerTurnCap,
+  getActiveTagBadges,
+  getTierColorName,
+  describeTag,
 } from "../diplomacyHubHelpers.ts";
 import { EMPTY_DIPLOMACY_STATE } from "../../data/types.ts";
 import type {
@@ -286,5 +289,131 @@ describe("buildQueuedAction", () => {
     expect(q.kind).toBe("proposeNonCompete");
     expect(q.subjectId).toBe("vex");
     expect(q.subjectIdSecondary).toBe("sol");
+  });
+});
+
+describe("getActiveTagBadges", () => {
+  it("filters out expired tags", () => {
+    const badges = getActiveTagBadges(
+      [
+        { kind: "OweFavor", expiresOnTurn: 5 },
+        { kind: "RecentlyGifted", expiresOnTurn: 10 },
+      ],
+      5, // currentTurn — OweFavor expires at 5, so should drop
+    );
+    expect(badges.map((b) => b.label)).toEqual(["Gifted"]);
+  });
+
+  it("returns empty array when all tags expired", () => {
+    expect(
+      getActiveTagBadges([{ kind: "OweFavor", expiresOnTurn: 1 }], 5),
+    ).toEqual([]);
+  });
+
+  it("describes each tag kind with intent", () => {
+    expect(describeTag({ kind: "OweFavor", expiresOnTurn: 99 }).intent).toBe(
+      "good",
+    );
+    expect(
+      describeTag({ kind: "RecentlyGifted", expiresOnTurn: 99 }).intent,
+    ).toBe("neutral");
+    expect(
+      describeTag({
+        kind: "SuspectedSpy",
+        suspectId: "player",
+        expiresOnTurn: 99,
+      }).intent,
+    ).toBe("bad");
+    expect(
+      describeTag({
+        kind: "NonCompete",
+        protectedEmpireIds: ["vex", "sol"],
+        expiresOnTurn: 99,
+      }).intent,
+    ).toBe("neutral");
+    expect(
+      describeTag({
+        kind: "LeakedIntel",
+        lens: "cash",
+        value: "1000",
+        expiresOnTurn: 99,
+      }).intent,
+    ).toBe("good");
+  });
+
+  it("non-compete tooltip lists protected empires", () => {
+    const t = describeTag({
+      kind: "NonCompete",
+      protectedEmpireIds: ["vex", "sol"],
+      expiresOnTurn: 99,
+    });
+    expect(t.tooltip).toContain("vex");
+    expect(t.tooltip).toContain("sol");
+  });
+});
+
+describe("getTierColorName", () => {
+  it("maps each tier to a stable color-name", () => {
+    expect(getTierColorName("Hostile")).toBe("danger");
+    expect(getTierColorName("Cold")).toBe("warning");
+    expect(getTierColorName("Neutral")).toBe("muted");
+    expect(getTierColorName("Warm")).toBe("accent");
+    expect(getTierColorName("Allied")).toBe("highlight");
+  });
+});
+
+describe("evaluateActionState — affordance hints", () => {
+  it("surfaces +15% favor on lobby when target empire has OweFavor", () => {
+    const action = getActionsForEmpire(empire, makeState({ systems: 0 })).find(
+      (a) => a.kind === "lobbyFor",
+    )!;
+    const s = makeState();
+    s.diplomacy = {
+      ...s.diplomacy!,
+      empireTags: { vex: [{ kind: "OweFavor", expiresOnTurn: 99 }] },
+    };
+    const r = evaluateActionState(action, "vex", s);
+    expect(r.enabled).toBe(true);
+    expect(r.affordanceHint).toBe("+15% favor");
+  });
+
+  it("surfaces -50% dampener on giftEmpire when ANY empire has RecentlyGifted", () => {
+    const action = getActionsForEmpire(empire, makeState({ systems: 0 }))[0]!;
+    const s = makeState();
+    s.diplomacy = {
+      ...s.diplomacy!,
+      empireTags: {
+        sol: [{ kind: "RecentlyGifted", expiresOnTurn: 99 }],
+      },
+    };
+    const r = evaluateActionState(action, "vex", s);
+    expect(r.enabled).toBe(true);
+    expect(r.affordanceHint).toBe("-50% dampener");
+  });
+
+  it("no hint on a fresh empire/rival", () => {
+    const action = getActionsForEmpire(empire, makeState({ systems: 0 }))[0]!;
+    const r = evaluateActionState(action, "vex", makeState());
+    expect(r.enabled).toBe(true);
+    expect(r.affordanceHint).toBeUndefined();
+  });
+
+  it("no hint surfaced on disabled actions (cap-blocked stays cap-blocked)", () => {
+    const action = getActionsForEmpire(empire, makeState({ systems: 0 })).find(
+      (a) => a.kind === "lobbyFor",
+    )!;
+    const s = makeState({ queuedCount: 2 });
+    s.diplomacy = {
+      ...s.diplomacy!,
+      queuedActions: [
+        { id: "x", kind: "giftEmpire", targetId: "vex", cashCost: 0 },
+        { id: "y", kind: "giftEmpire", targetId: "sol", cashCost: 0 },
+      ],
+      empireTags: { vex: [{ kind: "OweFavor", expiresOnTurn: 99 }] },
+    };
+    const r = evaluateActionState(action, "vex", s);
+    expect(r.enabled).toBe(false);
+    expect(r.reasonIfDisabled).toBe("cap");
+    expect(r.affordanceHint).toBeUndefined();
   });
 });

--- a/src/scenes/diplomacyHubHelpers.ts
+++ b/src/scenes/diplomacyHubHelpers.ts
@@ -4,10 +4,16 @@ import type {
   Empire,
   GameState,
   QueuedDiplomacyAction,
+  StandingTag,
   SurveilLens,
 } from "../data/types.ts";
 import { EMPTY_DIPLOMACY_STATE } from "../data/types.ts";
 import { cooldownKey, isOnCooldown } from "../game/diplomacy/Cooldowns.ts";
+import { hasTagOfKind } from "../game/diplomacy/StandingTags.ts";
+import {
+  getStandingTier,
+  type StandingTierName,
+} from "../game/diplomacy/StandingTiers.ts";
 
 export const HUB_THROTTLE_BASE = 2;
 export const HUB_THROTTLE_HIGH = 3;
@@ -43,6 +49,12 @@ export interface HubActionState {
   readonly enabled: boolean;
   readonly reasonIfDisabled?: "cooldown" | "cap" | "cash";
   readonly cooldownTurnsRemaining?: number;
+  /**
+   * Short hint surfaced on enabled buttons describing applicable bonuses or
+   * penalties (e.g. "+15% favor", "-50% dampener"). Undefined when neither
+   * applies; presence does NOT change `enabled`.
+   */
+  readonly affordanceHint?: string;
 }
 
 export function getPerTurnCap(state: GameState): number {
@@ -172,6 +184,31 @@ export function getSubjectCandidates(
   return [];
 }
 
+function computeAffordanceHint(
+  action: HubActionDescriptor,
+  targetId: string,
+  state: GameState,
+): string | undefined {
+  const d = state.diplomacy ?? EMPTY_DIPLOMACY_STATE;
+  if (action.kind === "lobbyFor" || action.kind === "lobbyAgainst") {
+    const tags = d.empireTags[targetId] ?? [];
+    if (hasTagOfKind(tags, "OweFavor")) return "+15% favor";
+  }
+  if (action.kind === "giftEmpire") {
+    const anyRecent = Object.values(d.empireTags).some((tags) =>
+      hasTagOfKind(tags, "RecentlyGifted"),
+    );
+    if (anyRecent) return "-50% dampener";
+  }
+  if (action.kind === "giftRival") {
+    const anyRecent = Object.values(d.rivalTags).some((tags) =>
+      hasTagOfKind(tags, "RecentlyGifted"),
+    );
+    if (anyRecent) return "-50% dampener";
+  }
+  return undefined;
+}
+
 export function evaluateActionState(
   action: HubActionDescriptor,
   targetId: string,
@@ -200,7 +237,111 @@ export function evaluateActionState(
     return { enabled: false, reasonIfDisabled: "cash" };
   }
 
-  return { enabled: true };
+  const affordanceHint = computeAffordanceHint(action, targetId, state);
+  return affordanceHint ? { enabled: true, affordanceHint } : { enabled: true };
+}
+
+/**
+ * Player-facing badge label and intent color for an active tag. The label is
+ * kept terse (4-7 chars) so multiple badges can fit a narrow table column.
+ *
+ * Intents:
+ *  - "good"     → friendly to the player (their relationship is favorable)
+ *  - "bad"      → adverse (rival has flagged the player as a spy, etc.)
+ *  - "neutral"  → informational, no value judgement
+ */
+export interface TagBadge {
+  readonly label: string;
+  readonly intent: "good" | "bad" | "neutral";
+  readonly tooltip: string;
+}
+
+export function describeTag(tag: StandingTag): TagBadge {
+  switch (tag.kind) {
+    case "OweFavor":
+      return {
+        label: "Favor",
+        intent: "good",
+        tooltip: "Owes you a favor — boosts next eligible action's success.",
+      };
+    case "RecentlyGifted":
+      return {
+        label: "Gifted",
+        intent: "neutral",
+        tooltip: "Recently received a gift — cross-target dampener active.",
+      };
+    case "SuspectedSpy":
+      return {
+        label: "Spied!",
+        intent: "bad",
+        tooltip: "They suspect you of espionage — expect retaliation events.",
+      };
+    case "NonCompete":
+      return {
+        label: "NC",
+        intent: "neutral",
+        tooltip: `Non-Compete pact protecting empires: ${tag.protectedEmpireIds.join(", ")}.`,
+      };
+    case "LeakedIntel":
+      return {
+        label: `Intel:${tag.lens === "topContractByValue" ? "contract" : tag.lens}`,
+        intent: "good",
+        tooltip: `Surveillance leaked their ${tag.lens}: ${tag.value}`,
+      };
+  }
+}
+
+/**
+ * Returns badges for tags that haven't expired yet. Reads from
+ * `expiresOnTurn > currentTurn`, matching the resolver's expiry semantic.
+ */
+export function getActiveTagBadges(
+  tags: readonly StandingTag[],
+  currentTurn: number,
+): readonly TagBadge[] {
+  return tags.filter((t) => t.expiresOnTurn > currentTurn).map(describeTag);
+}
+
+/**
+ * Per-tier color name. The scene maps these onto the active theme; helpers
+ * stay theme-agnostic so they're testable and the same names render in both
+ * dark and light themes.
+ */
+export type TierColorName =
+  | "danger"
+  | "warning"
+  | "muted"
+  | "accent"
+  | "highlight";
+
+export function getTierColorName(tier: StandingTierName): TierColorName {
+  switch (tier) {
+    case "Hostile":
+      return "danger";
+    case "Cold":
+      return "warning";
+    case "Neutral":
+      return "muted";
+    case "Warm":
+      return "accent";
+    case "Allied":
+      return "highlight";
+  }
+}
+
+export function getTierForEmpire(
+  empireId: string,
+  state: GameState,
+): StandingTierName {
+  return getStandingTier(state.empireReputation?.[empireId] ?? 50);
+}
+
+export function getTierForRival(
+  rivalId: string,
+  state: GameState,
+): StandingTierName {
+  const d = state.diplomacy ?? EMPTY_DIPLOMACY_STATE;
+  return getStandingTier(d.rivalStanding[rivalId] ?? 50);
 }
 
 export function buildQueuedAction(


### PR DESCRIPTION
## Summary

First wave-2 polish slice on top of hubs v1 (#254) and v2 (#255). Surfaces the **tag layer** the wave-1 design promised but the hub never rendered.

The temperature number (Standing column) was visible, but the durable narrative state — \`OweFavor\`, \`RecentlyGifted\`, \`SuspectedSpy\`, \`NonCompete\`, \`LeakedIntel\` — was dark UI. Half the design's emergent strategy was invisible: players couldn't see the +15% favor bonus, the cross-target gift dampener, surveillance leak windows, or active non-compete pacts.

## What's newly visible

| Surface | Before | After |
|---|---|---|
| Targets table | Type / Name / Tier / Standing | + **Tags** column showing active badges (\`Favor\`, \`Gifted\`, \`Spied!\`, \`NC\`, \`Intel:cash\`) |
| Tier column | Plain text | **Color-coded**: Hostile→loss, Cold→warning, Neutral→muted, Warm→accent, Allied→profit |
| Right pane | Target name only | + \`Tags: ...\` line when any active tag |
| Action buttons | Cost + disabled-reason | + **Affordance hints**: \`+15% favor\` on lobby when target has \`OweFavor\`, \`-50% dampener\` on gifts when *any* target of that type has \`RecentlyGifted\` |

## Architecture

Pure helpers (theme-agnostic, testable without Phaser):

- \`getActiveTagBadges(tags, currentTurn)\` filters expired tags using the same \`expiresOnTurn > currentTurn\` rule as the resolver, so cross-cutting fixtures stay aligned.
- \`describeTag(tag)\` is the single source of truth for tag presentation — terse labels, intent (good/bad/neutral), and tooltip text. Extends cleanly when wave-3 verbs add new tag kinds.
- \`getTierColorName(tier)\` returns a theme-name token; the scene maps these to live theme colors so helpers stay theme-agnostic and work in both dark and light themes.
- \`evaluateActionState\` extended with \`affordanceHint?: string\` — surfaced only when the action is enabled. Cap-blocked actions never show a hint (the player should fix the cap first).

The matrix of "which tag triggers which hint on which action" is centralized in \`computeAffordanceHint\` so future verbs (sabotage, smear) can plug in by adding cases — no scene changes needed.

## Test plan

- [x] **32 helper tests** (up from 23) — see \`describe\` blocks for \`getActiveTagBadges\`, \`describeTag\`, \`getTierColorName\`, and \`evaluateActionState — affordance hints\`
- [x] \`npm run check\` clean: typecheck + 1409 tests + production build
- [x] Manual verification in dev preview with seeded tags: empire with \`OweFavor\` + \`RecentlyGifted\` → table shows \`Favor · Gifted\`, right pane shows \`Tags: Favor · Gifted\`, lobby buttons show \`+15% favor\`, gift button shows \`-50% dampener\`. Rival with \`SuspectedSpy\` + \`LeakedIntel\` → table shows \`Spied! · Intel:cash\`. Rival with \`NonCompete\` → table shows \`NC\`.
- [ ] Reviewer: \`npm run dev\` → New Game → Foreign Relations menu → after a few turns of play, tags should appear naturally as you trigger gifts and surveils

## What's still on the wave-2 polish list (deferred)

- Confirmation dialog for irreversible actions
- Tier-transition animation/highlight
- Ambassador portrait + flavor lines on the right pane (needs portrait asset wiring)
- Tag tooltips on hover (currently the tooltip text exists in the descriptor but isn't surfaced — needs a hover wiring on DataTable cells)

🤖 Generated with [Claude Code](https://claude.com/claude-code)