### PR TITLE
feat(diplomacy): hub polish 2 — per-tag detail rows with intent color

### DIFF
--- a/src/scenes/DiplomacyScene.ts
+++ b/src/scenes/DiplomacyScene.ts
@@ -109,6 +109,7 @@ export class DiplomacyScene extends Phaser.Scene {
   private targetTable!: DataTable;
   private actionPanel!: Panel;
   private actionButtons: Button[] = [];
+  private tagDetailLabels: Phaser.GameObjects.Text[] = [];
   private actionStatusLabel!: Label;
   private headerCounter!: Label;
   private queuedSummary!: Label;
@@ -308,6 +309,9 @@ export class DiplomacyScene extends Phaser.Scene {
     // Clear previous buttons.
     for (const b of this.actionButtons) b.destroy();
     this.actionButtons = [];
+    // Clear previous tag detail rows.
+    for (const t of this.tagDetailLabels) t.destroy();
+    this.tagDetailLabels = [];
 
     const state = gameStore.getState();
     if (!this.selection) {
@@ -350,18 +354,21 @@ export class DiplomacyScene extends Phaser.Scene {
       activeTags = getActiveTagBadges(d.rivalTags[id] ?? [], state.turn);
     }
 
-    const headerWithTags =
-      activeTags.length > 0
-        ? `${header}\nTags: ${activeTags.map((t) => t.label).join(" · ")}`
-        : header;
-    this.actionStatusLabel.setText(headerWithTags);
+    this.actionStatusLabel.setText(header);
 
     const { absX, absY, contentWidth } = this.getActionPanelGeometry();
+    const tagRowGap = 18;
+    const tagRowsBottom = this.renderTagDetailRows(
+      activeTags,
+      absX,
+      absY,
+      contentWidth - 16,
+      tagRowGap,
+    );
+
     const btnH = 36;
     const btnGap = 6;
-    // When tags are shown, push the action buttons down by one line so they
-    // don't collide with the wrapped header.
-    const yOffset = activeTags.length > 0 ? 18 : 0;
+    const yOffset = tagRowsBottom > absY ? tagRowsBottom - absY + 8 : 0;
 
     actions.forEach((action, i) => {
       const evalState = evaluateActionState(action, id, state);
@@ -491,6 +498,43 @@ export class DiplomacyScene extends Phaser.Scene {
       },
     });
     this.actionButtons.push(cancelBtn);
+  }
+
+  /**
+   * Renders one Phaser.Text per active tag below the action header. Each row
+   * shows `<label> — <tooltip>` colored by the tag's intent. Returns the y
+   * coordinate of the bottom of the last rendered row, so the caller can
+   * push subsequent UI (action buttons) down beneath.
+   */
+  private renderTagDetailRows(
+    tags: ReturnType<typeof getActiveTagBadges>,
+    x: number,
+    yStart: number,
+    maxWidth: number,
+    rowHeight: number,
+  ): number {
+    if (tags.length === 0) return yStart;
+    const theme = getTheme();
+    const colorByIntent: Record<"good" | "bad" | "neutral", number> = {
+      good: theme.colors.profit,
+      bad: theme.colors.warning,
+      neutral: theme.colors.accent,
+    };
+    let y = yStart;
+    for (const t of tags) {
+      const text = `${t.label} — ${t.tooltip}`;
+      const lbl = this.add.text(x, y, text, {
+        fontFamily: "sans-serif",
+        fontSize: "11px",
+        color: colorToHex(colorByIntent[t.intent]),
+        wordWrap: { width: maxWidth },
+      });
+      this.tagDetailLabels.push(lbl);
+      // wrap may produce multiple visual lines; advance y by the actual
+      // rendered height plus a small gap.
+      y += Math.max(rowHeight, lbl.height + 2);
+    }
+    return y;
   }
 
   private getActionPanelGeometry(): {


### PR DESCRIPTION
## Summary

Second wave-2 polish slice on top of #256. Replaces the single \`Tags: Favor · Gifted\` line in the right pane with **one detail row per active tag** — \`Label — Tooltip\` — colored by the tag's intent (good = profit green, bad = warning orange, neutral = accent cyan).

The system is now **self-documenting**: instead of memorizing what \"Favor\" or \"NC\" means, the player just selects a target and reads the descriptions. New players don't need a tutorial.

## Before / After

**Before** (polish 1):
\`\`\`
Dravian Imperium
Tags: Favor · Gifted
\`\`\`

**After** (polish 2):
\`\`\`
Dravian Imperium

Favor — Owes you a favor — boosts next eligible action's success.   [green]
Gifted — Recently received a gift — cross-target dampener active.   [cyan]
\`\`\`

For a rival with adverse tags:
\`\`\`
Deep Shipping Corp

Spied! — They suspect you of espionage — expect retaliation events.   [orange]
Intel:cash — Surveillance leaked their cash: 2100000                  [green]
\`\`\`

## Implementation

- Added \`tagDetailLabels: Phaser.GameObjects.Text[]\` lifecycle-managed alongside \`actionButtons\`. Cleared on each \`refreshActionPanel\` pass to prevent leaks across re-renders.
- New \`renderTagDetailRows(tags, x, y, maxWidth, rowHeight)\` consumes the existing \`getActiveTagBadges\` output (intent + tooltip already there from polish 1) and returns the bottom-y so action buttons push down beneath naturally.
- Long tooltips wrap at panel width.
- Picker modes (subject/pair) skip the tag rows by design — the picker has its own contextual prompt, and tags remain visible in the Targets table cell.

**No new helpers** — \`describeTag\` from polish 1 already exposes intent + tooltip. The intent-to-theme-color mapping is local to the scene (kept theme-aware).

## Test plan

- [x] No new tests required — \`describeTag\` and \`getActiveTagBadges\` already covered by 32 helper tests from polish 1
- [x] \`npm run check\` clean: typecheck + 1409 tests + production build
- [x] Manual verification in dev preview with seeded tags:
  - Empire with \`OweFavor\` + \`RecentlyGifted\` → 2 rows in green/cyan with full descriptions
  - Rival with \`SuspectedSpy\` + \`LeakedIntel\` → 2 rows in warning/profit with the leaked value visible

## What's next on the wave-2 polish list

- Tier-transition animation (flash/pulse on row when tier flipped this turn)
- Confirmation dialog for irreversible queues
- Ambassador portrait + flavor lines (needs portrait asset wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)