### PR TITLE
feat(diplomacy): hub polish 3 — tier-shift indicators (↑/↓ arrows)

### DIFF
--- a/src/scenes/DiplomacyScene.ts
+++ b/src/scenes/DiplomacyScene.ts
@@ -19,8 +19,10 @@ import {
   getLayout,
   getTheme,
 } from "../ui/index.ts";
+import type { StandingTierName } from "../game/diplomacy/StandingTiers.ts";
 import {
   buildQueuedAction,
+  detectTierShifts,
   evaluateActionState,
   getActionsForEmpire,
   getActionsForRival,
@@ -28,6 +30,7 @@ import {
   getPerTurnCap,
   getSubjectCandidates,
   getTierColorName,
+  snapshotTiers,
   type HubActionDescriptor,
   type TierColorName,
 } from "./diplomacyHubHelpers.ts";
@@ -116,6 +119,14 @@ export class DiplomacyScene extends Phaser.Scene {
   private selection: Selection = null;
   private mode: PanelMode = { kind: "list" };
   private storeUnsub: (() => void) | null = null;
+  /**
+   * Tier-by-id snapshot from the previous render. The next render diffs
+   * against this to surface ↑/↓ arrows on shifted tier cells. `null` on
+   * first render — no shifts to surface yet.
+   */
+  private lastTierSnapshot: Record<string, StandingTierName> | null = null;
+  /** Per-target shift direction surfaced in the current render. */
+  private currentShifts: Record<string, "up" | "down"> = {};
 
   constructor() {
     super({ key: "DiplomacyScene" });
@@ -185,15 +196,15 @@ export class DiplomacyScene extends Phaser.Scene {
       height: content.height - 16,
       contentSized: true,
       columns: [
-        { key: "type", label: "Type", width: 56 },
-        { key: "name", label: "Name", width: 150 },
+        { key: "type", label: "Type", width: 50 },
+        { key: "name", label: "Name", width: 140 },
         {
           key: "tier",
           label: "Tier",
-          width: 68,
+          width: 90,
           colorFn: (value) => tierColorForCell(String(value ?? "")),
         },
-        { key: "standing", label: "#", width: 36, align: "right" },
+        { key: "standing", label: "#", width: 30, align: "right" },
         { key: "tags", label: "Tags", width: 140 },
       ],
       onRowSelect: (_idx, row) => {
@@ -268,6 +279,21 @@ export class DiplomacyScene extends Phaser.Scene {
     const playerId = state.playerEmpireId;
     const d = state.diplomacy ?? EMPTY_DIPLOMACY_STATE;
 
+    // Detect tier shifts since the last render. On first render
+    // (`lastTierSnapshot === null`) there's nothing to compare against, so
+    // no arrows surface — they only appear after the first state mutation.
+    const currentSnap = snapshotTiers(state);
+    if (this.lastTierSnapshot !== null) {
+      const shifts = detectTierShifts(this.lastTierSnapshot, currentSnap);
+      // Merge into the persistent shift map. Shifts persist visually
+      // across re-renders within this scene session — only cleared when
+      // a target's tier flips back or the scene is destroyed/recreated.
+      for (const s of shifts) {
+        this.currentShifts[s.id] = s.direction;
+      }
+    }
+    this.lastTierSnapshot = currentSnap;
+
     const turn = state.turn;
     const empireRows: TargetRow[] = empires
       .filter((e) => e.id !== playerId)
@@ -278,7 +304,10 @@ export class DiplomacyScene extends Phaser.Scene {
           rowKind: "empire",
           id: e.id,
           name: e.name,
-          tier: getStandingTier(standing),
+          tier: tierWithShiftArrow(
+            getStandingTier(standing),
+            this.currentShifts[e.id],
+          ),
           standing,
           tags: badges.map((b) => b.label).join(" · "),
         };
@@ -292,7 +321,10 @@ export class DiplomacyScene extends Phaser.Scene {
           rowKind: "rival",
           id: r.id,
           name: r.name,
-          tier: getStandingTier(standing),
+          tier: tierWithShiftArrow(
+            getStandingTier(standing),
+            this.currentShifts[r.id],
+          ),
           standing,
           tags: badges.map((b) => b.label).join(" · "),
         };
@@ -668,9 +700,26 @@ function formatCash(n: number): string {
 }
 
 /**
+ * Append a ↑/↓ arrow to a tier label when the row's tier shifted since the
+ * last render. The arrow lives inside the cell value so the existing
+ * `colorFn` keeps coloring by tier — `tierColorForCell` strips the arrow
+ * before doing the tier match.
+ */
+function tierWithShiftArrow(
+  tier: StandingTierName,
+  shift: "up" | "down" | undefined,
+): string {
+  if (shift === "up") return `${tier} ↑`;
+  if (shift === "down") return `${tier} ↓`;
+  return tier;
+}
+
+/**
  * Map a tier label (rendered in the Tier column) to the live theme color
- * the cell should use. Returns null for unknown values so the column falls
- * back to the default text color rather than turning white-on-white.
+ * the cell should use. Strips any ↑/↓ shift arrow before matching so the
+ * coloring stays consistent regardless of whether a shift indicator is
+ * present. Returns null for unknown values so the column falls back to
+ * the default text color rather than turning white-on-white.
  */
 function tierColorForCell(tierLabel: string): number | null {
   const theme = getTheme();
@@ -681,7 +730,9 @@ function tierColorForCell(tierLabel: string): number | null {
     accent: theme.colors.accent,
     highlight: theme.colors.profit,
   };
-  switch (tierLabel) {
+  // Strip the optional " ↑" / " ↓" shift suffix so the switch matches.
+  const base = tierLabel.replace(/\s*[↑↓]\s*$/, "").trim();
+  switch (base) {
     case "Hostile":
       return colorByName[getTierColorName("Hostile")];
     case "Cold":

--- a/src/scenes/__tests__/diplomacyHubHelpers.test.ts
+++ b/src/scenes/__tests__/diplomacyHubHelpers.test.ts
@@ -10,6 +10,8 @@ import {
   getActiveTagBadges,
   getTierColorName,
   describeTag,
+  detectTierShifts,
+  snapshotTiers,
 } from "../diplomacyHubHelpers.ts";
 import { EMPTY_DIPLOMACY_STATE } from "../../data/types.ts";
 import type {
@@ -415,5 +417,77 @@ describe("evaluateActionState — affordance hints", () => {
     expect(r.enabled).toBe(false);
     expect(r.reasonIfDisabled).toBe("cap");
     expect(r.affordanceHint).toBeUndefined();
+  });
+});
+
+describe("detectTierShifts", () => {
+  it("returns empty array when nothing changed", () => {
+    expect(
+      detectTierShifts(
+        { vex: "Neutral", sol: "Cold" },
+        { vex: "Neutral", sol: "Cold" },
+      ),
+    ).toEqual([]);
+  });
+
+  it("flags upward shift", () => {
+    const shifts = detectTierShifts({ vex: "Neutral" }, { vex: "Warm" });
+    expect(shifts).toEqual([
+      { id: "vex", from: "Neutral", to: "Warm", direction: "up" },
+    ]);
+  });
+
+  it("flags downward shift", () => {
+    const shifts = detectTierShifts({ vex: "Warm" }, { vex: "Cold" });
+    expect(shifts).toEqual([
+      { id: "vex", from: "Warm", to: "Cold", direction: "down" },
+    ]);
+  });
+
+  it("flags multiple targets in one diff", () => {
+    const shifts = detectTierShifts(
+      { vex: "Hostile", sol: "Neutral" },
+      { vex: "Cold", sol: "Hostile" },
+    );
+    expect(shifts).toHaveLength(2);
+    expect(shifts.find((s) => s.id === "vex")?.direction).toBe("up");
+    expect(shifts.find((s) => s.id === "sol")?.direction).toBe("down");
+  });
+
+  it("ignores ids missing from prev (newly added targets)", () => {
+    const shifts = detectTierShifts({}, { vex: "Allied" });
+    expect(shifts).toEqual([]);
+  });
+
+  it("ignores ids missing from current (removed targets)", () => {
+    const shifts = detectTierShifts({ vex: "Allied" }, {});
+    expect(shifts).toEqual([]);
+  });
+});
+
+describe("snapshotTiers", () => {
+  it("captures empire and rival tiers from the active state", () => {
+    const s = makeState();
+    s.empireReputation = { vex: 70, sol: 25 };
+    s.diplomacy = {
+      ...s.diplomacy!,
+      rivalStanding: { chen: 50, kade: 85 },
+    };
+    expect(snapshotTiers(s)).toEqual({
+      vex: "Warm",
+      sol: "Cold",
+      chen: "Neutral",
+      kade: "Allied",
+    });
+  });
+
+  it("treats missing fields as empty (no tiers)", () => {
+    const s = {
+      seed: 1,
+      turn: 1,
+      galaxy: { empires: [], systems: [] },
+      aiCompanies: [],
+    } as unknown as GameState;
+    expect(snapshotTiers(s)).toEqual({});
   });
 });

--- a/src/scenes/diplomacyHubHelpers.ts
+++ b/src/scenes/diplomacyHubHelpers.ts
@@ -344,6 +344,72 @@ export function getTierForRival(
   return getStandingTier(d.rivalStanding[rivalId] ?? 50);
 }
 
+export type TierShiftDirection = "up" | "down";
+
+export interface TierShift {
+  readonly id: string;
+  readonly direction: TierShiftDirection;
+  readonly from: StandingTierName;
+  readonly to: StandingTierName;
+}
+
+const TIER_ORDER: readonly StandingTierName[] = [
+  "Hostile",
+  "Cold",
+  "Neutral",
+  "Warm",
+  "Allied",
+];
+
+/**
+ * Compares two snapshots of (id → tier) maps and returns the set of ids
+ * whose tier name changed. The scene snapshots tiers between renders and
+ * uses this to highlight changed rows.
+ *
+ * Targets present only in `prev` (target removed) or only in `current`
+ * (target added) are skipped — they're not "shifts" in the conventional
+ * sense. If we ever need to surface those, add separate predicates.
+ */
+export function detectTierShifts(
+  prev: Record<string, StandingTierName>,
+  current: Record<string, StandingTierName>,
+): readonly TierShift[] {
+  const out: TierShift[] = [];
+  for (const [id, tier] of Object.entries(current)) {
+    const before = prev[id];
+    if (before === undefined || before === tier) continue;
+    const beforeIdx = TIER_ORDER.indexOf(before);
+    const afterIdx = TIER_ORDER.indexOf(tier);
+    out.push({
+      id,
+      from: before,
+      to: tier,
+      direction: afterIdx > beforeIdx ? "up" : "down",
+    });
+  }
+  return out;
+}
+
+/**
+ * Builds a snapshot of (target id → current tier) for both empires and
+ * rivals. Used by the scene to record state-at-render-time so the next
+ * render can diff against it.
+ */
+export function snapshotTiers(
+  state: GameState,
+): Record<string, StandingTierName> {
+  const out: Record<string, StandingTierName> = {};
+  const empireRep = state.empireReputation ?? {};
+  for (const id of Object.keys(empireRep)) {
+    out[id] = getStandingTier(empireRep[id] ?? 50);
+  }
+  const d = state.diplomacy ?? EMPTY_DIPLOMACY_STATE;
+  for (const id of Object.keys(d.rivalStanding)) {
+    out[id] = getStandingTier(d.rivalStanding[id] ?? 50);
+  }
+  return out;
+}
+
 export function buildQueuedAction(
   action: HubActionDescriptor,
   targetId: string,


### PR DESCRIPTION
## Summary

Third wave-2 polish slice on top of #257. Surfaces **tier transitions visually** in the Targets table — when a target's tier flips since the last render (Neutral → Warm, Warm → Cold, etc.), the Tier column shows \`Warm ↑\` or \`Cold ↓\` with the existing tier color.

## Why

The resolver already fires modal entries for tier transitions during simulation, but those are one-shot — when the player opens the hub on a later turn, there was no visual reminder of *which targets moved last turn*. Now they open the hub, see \`Warm ↑\` next to Vex Hegemony, and immediately understand the change.

## Detection model

Purely scene-side — no game-state mutation, no resolver changes. The scene snapshots \`(targetId → tier)\` between renders and diffs against \`state.empireReputation\` + \`state.diplomacy.rivalStanding\` on each \`stateChanged\` event.

Indicators persist within the scene session: once a row gets \`↑\`, it keeps the arrow even through re-renders triggered by other state changes (queueing actions, etc.). The arrow only clears when the tier flips back or the scene tears down.

## New helpers (theme-agnostic, testable without Phaser)

- \`detectTierShifts(prev, current): TierShift[]\` — returns \`{ id, from, to, direction: \"up\" | \"down\" }\` triples for tiers that changed. Ignores newly-added or removed targets (not \"shifts\" in the strict sense).
- \`snapshotTiers(state)\` — builds the (id → tier) map for both empires and rivals from current state.

## Scene wiring

- New \`lastTierSnapshot\` and \`currentShifts\` fields.
- \`refreshTargetTable\` snapshots tiers at render time, diffs, merges into \`currentShifts\`.
- \`tierWithShiftArrow(tier, shift)\` produces the cell text.
- \`tierColorForCell\` updated to strip the optional ↑/↓ suffix before matching, so coloring stays consistent.
- Tier column widened 68 → 90px to fit \`Allied ↓\` without truncation.

## Test plan

- [x] **40 helper tests** (up from 32). New cases: up/down detection, ignored-when-added/removed, multi-target diffs, \`snapshotTiers\` reading both empire-rep and rival-standing maps.
- [x] \`npm run check\` clean: typecheck + 1417 tests + production build
- [x] Manual verification in dev preview: bumping \`empire-0\` from 50 → 65 flipped tier Neutral → Warm and rendered as \`Warm ↑\`; dropping \`empire-1\` from 50 → 30 rendered as \`Cold ↓\`; unchanged rows stayed plain.

## What's next on the wave-2 polish list

- Confirmation dialog for irreversible queues (small modal)
- Ambassador portrait + flavor lines (needs portrait asset wiring)
- Or pivot to wave-3 mechanics: sabotage, contract poaching, smear

🤖 Generated with [Claude Code](https://claude.com/claude-code)