### PR TITLE
feat(diplomacy): hub polish 4 — ambassador name + ambient greeting line

### DIFF
--- a/src/scenes/DiplomacyScene.ts
+++ b/src/scenes/DiplomacyScene.ts
@@ -27,6 +27,7 @@ import {
   getActionsForEmpire,
   getActionsForRival,
   getActiveTagBadges,
+  getAmbientGreeting,
   getPerTurnCap,
   getSubjectCandidates,
   getTierColorName,
@@ -372,28 +373,54 @@ export class DiplomacyScene extends Phaser.Scene {
     let actions: readonly HubActionDescriptor[];
     let header: string;
     let activeTags: ReturnType<typeof getActiveTagBadges>;
+    let ambassadorLine: string | null = null;
+    let greetingLine: string | null = null;
     if (kind === "empire") {
       const empire = state.galaxy?.empires.find((e) => e.id === id);
       if (!empire) return;
       actions = getActionsForEmpire(empire, state);
       header = empire.name;
       activeTags = getActiveTagBadges(d.empireTags[id] ?? [], state.turn);
+      const amb = d.empireAmbassadors[id];
+      if (amb) {
+        ambassadorLine = `Ambassador ${amb.name} · ${amb.personality}`;
+        const tier = getStandingTier(state.empireReputation?.[id] ?? 50);
+        greetingLine = getAmbientGreeting(amb.personality, tier);
+      }
     } else {
       const rival = state.aiCompanies?.find((r) => r.id === id);
       if (!rival) return;
       actions = getActionsForRival(rival);
       header = rival.name;
       activeTags = getActiveTagBadges(d.rivalTags[id] ?? [], state.turn);
+      const liaison = d.rivalLiaisons[id];
+      if (liaison) {
+        ambassadorLine = `Liaison ${liaison.name} · ${liaison.personality}`;
+        const tier = getStandingTier(d.rivalStanding[id] ?? 50);
+        greetingLine = getAmbientGreeting(liaison.personality, tier);
+      }
     }
 
     this.actionStatusLabel.setText(header);
 
     const { absX, absY, contentWidth } = this.getActionPanelGeometry();
+    // Ambassador name + ambient greeting render between the header and the
+    // tag detail rows. We reuse `tagDetailLabels` for lifecycle management
+    // since the cleanup loop in refreshActionPanel destroys all of them on
+    // each pass.
+    const ambassadorBottom = this.renderAmbassadorRows(
+      ambassadorLine,
+      greetingLine,
+      absX,
+      absY,
+      contentWidth - 16,
+    );
     const tagRowGap = 18;
+    const tagsStartY = ambassadorBottom > absY ? ambassadorBottom + 6 : absY;
     const tagRowsBottom = this.renderTagDetailRows(
       activeTags,
       absX,
-      absY,
+      tagsStartY,
       contentWidth - 16,
       tagRowGap,
     );
@@ -538,6 +565,47 @@ export class DiplomacyScene extends Phaser.Scene {
    * coordinate of the bottom of the last rendered row, so the caller can
    * push subsequent UI (action buttons) down beneath.
    */
+  /**
+   * Renders two text rows below the action header: the ambassador's name
+   * and personality, then a single ambient greeting line keyed to their
+   * `(personality, tier)`. Returns the y-coordinate of the bottom of the
+   * last rendered row so subsequent UI can stack beneath. If both inputs
+   * are null (no ambassador on this target — e.g. the player's own empire
+   * before that case is filtered), returns `yStart` unchanged.
+   */
+  private renderAmbassadorRows(
+    ambassadorLine: string | null,
+    greetingLine: string | null,
+    x: number,
+    yStart: number,
+    maxWidth: number,
+  ): number {
+    if (!ambassadorLine && !greetingLine) return yStart;
+    const theme = getTheme();
+    let y = yStart;
+    if (ambassadorLine) {
+      const lbl = this.add.text(x, y, ambassadorLine, {
+        fontFamily: "sans-serif",
+        fontSize: "12px",
+        color: colorToHex(theme.colors.text),
+        fontStyle: "italic",
+      });
+      this.tagDetailLabels.push(lbl);
+      y += lbl.height + 2;
+    }
+    if (greetingLine) {
+      const lbl = this.add.text(x, y, greetingLine, {
+        fontFamily: "sans-serif",
+        fontSize: "11px",
+        color: colorToHex(theme.colors.textDim),
+        wordWrap: { width: maxWidth },
+      });
+      this.tagDetailLabels.push(lbl);
+      y += lbl.height + 2;
+    }
+    return y;
+  }
+
   private renderTagDetailRows(
     tags: ReturnType<typeof getActiveTagBadges>,
     x: number,

--- a/src/scenes/__tests__/diplomacyHubHelpers.test.ts
+++ b/src/scenes/__tests__/diplomacyHubHelpers.test.ts
@@ -12,6 +12,7 @@ import {
   describeTag,
   detectTierShifts,
   snapshotTiers,
+  getAmbientGreeting,
 } from "../diplomacyHubHelpers.ts";
 import { EMPTY_DIPLOMACY_STATE } from "../../data/types.ts";
 import type {
@@ -489,5 +490,37 @@ describe("snapshotTiers", () => {
       aiCompanies: [],
     } as unknown as GameState;
     expect(snapshotTiers(s)).toEqual({});
+  });
+});
+
+describe("getAmbientGreeting", () => {
+  it("returns a non-empty string for every (personality, tier) pair", () => {
+    const personalities = [
+      "formal",
+      "mercenary",
+      "suspicious",
+      "warm",
+    ] as const;
+    const tiers = ["Hostile", "Cold", "Neutral", "Warm", "Allied"] as const;
+    for (const p of personalities) {
+      for (const t of tiers) {
+        const line = getAmbientGreeting(p, t);
+        expect(typeof line).toBe("string");
+        expect(line.length).toBeGreaterThan(5);
+      }
+    }
+  });
+
+  it("varies across personalities for the same tier", () => {
+    const formal = getAmbientGreeting("formal", "Neutral");
+    const mercenary = getAmbientGreeting("mercenary", "Neutral");
+    const warm = getAmbientGreeting("warm", "Neutral");
+    expect(new Set([formal, mercenary, warm]).size).toBe(3);
+  });
+
+  it("varies across tiers for the same personality", () => {
+    const hostile = getAmbientGreeting("warm", "Hostile");
+    const allied = getAmbientGreeting("warm", "Allied");
+    expect(hostile).not.toBe(allied);
   });
 });

--- a/src/scenes/diplomacyHubHelpers.ts
+++ b/src/scenes/diplomacyHubHelpers.ts
@@ -1,5 +1,6 @@
 import type {
   AICompany,
+  AmbassadorPersonality,
   DiplomacyActionKind,
   Empire,
   GameState,
@@ -342,6 +343,57 @@ export function getTierForRival(
 ): StandingTierName {
   const d = state.diplomacy ?? EMPTY_DIPLOMACY_STATE;
   return getStandingTier(d.rivalStanding[rivalId] ?? 50);
+}
+
+/**
+ * Ambient greeting line for an ambassador/liaison shown when the player
+ * selects their target in the hub. The pool is 4 personalities × 5 tiers =
+ * 20 lines; we intentionally keep them short so the right pane stays
+ * scannable rather than turning into a wall of flavor text.
+ *
+ * Distinct from `CopyTemplates.getFlavor` — that fires on event outcomes
+ * (gift accepted, lobby succeeded, etc.). This is the *idle* line: how
+ * does the ambassador receive you when you walk in.
+ */
+const AMBIENT_GREETINGS: Record<
+  AmbassadorPersonality,
+  Record<StandingTierName, string>
+> = {
+  formal: {
+    Hostile: "The aide refuses to look up from their ledger when you enter.",
+    Cold: "An aide receives you, citing protocol you didn't ask about.",
+    Neutral: "The ambassador greets you with measured precision.",
+    Warm: "The ambassador rises and offers a courteous bow.",
+    Allied: "The ambassador welcomes you with the warmth of long protocol.",
+  },
+  mercenary: {
+    Hostile: "They turn their back. 'Nothing for you here.'",
+    Cold: "They eye your purse. 'Make it worthwhile.'",
+    Neutral: "They tilt an eyebrow. 'What do you want?'",
+    Warm: "They smile, calculating. 'Always good to see a paying friend.'",
+    Allied: "They clasp your hand. 'My favorite line item.'",
+  },
+  suspicious: {
+    Hostile: "They squint at your envoy and motion for a body scan.",
+    Cold: "They watch your hands while you speak.",
+    Neutral: "They listen, weighing every word for hidden meaning.",
+    Warm: "Their guard slackens — barely.",
+    Allied: "They nod, almost trusting. 'You've earned a chair at this table.'",
+  },
+  warm: {
+    Hostile: "They look stricken — disappointed in you, more than angry.",
+    Cold: "They greet you with a smile that doesn't quite reach the eyes.",
+    Neutral: "They greet you genuinely, asking after the journey.",
+    Warm: "They embrace your envoy at the door.",
+    Allied: "They beam — 'It's been too long, my friend.'",
+  },
+};
+
+export function getAmbientGreeting(
+  personality: AmbassadorPersonality,
+  tier: StandingTierName,
+): string {
+  return AMBIENT_GREETINGS[personality][tier];
 }
 
 export type TierShiftDirection = "up" | "down";


### PR DESCRIPTION
## Summary

Fourth wave-2 polish slice on top of #258. Surfaces the **ambassador layer** that the wave-1 design described but the hub never showed. Each empire/rival has had a generated Ambassador or Liaison since wave 1 (with name + personality), but the right pane only ever showed the faction name. The character behind the dialog was invisible.

## What's new

Right pane now reads (between the target name and the tag detail rows):

\`\`\`
Dravian Imperium                         [target name, unchanged]

Ambassador Lyra Korr · suspicious        [italic flavor caption]
Their guard slackens — barely.            [muted ambient greeting]

Favor — Owes you a favor — boosts…       [tag detail rows, unchanged]
\`\`\`

The greeting is keyed by the ambassador's \`(personality, tier)\` — a 4 × 5 = 20 line static pool covering every combo. Distinct from \`CopyTemplates.getFlavor\` (which fires on event outcomes); this is the *idle* line — how does the ambassador receive you when you walk in.

### Examples

| personality × tier | line |
|---|---|
| formal × Hostile | "The aide refuses to look up from their ledger when you enter." |
| mercenary × Warm | "They smile, calculating. 'Always good to see a paying friend.'" |
| suspicious × Allied | "They nod, almost trusting. 'You've earned a chair at this table.'" |
| warm × Cold | "They greet you with a smile that doesn't quite reach the eyes." |

## Implementation

- **\`getAmbientGreeting(personality, tier)\`** — looks up the line from a 20-entry static table. Pure, no state dependency, theme-agnostic.
- **\`renderAmbassadorRows(ambassadorLine, greetingLine, x, y, maxWidth)\`** — renders two stacked text rows on the right pane. Reuses \`tagDetailLabels\` for lifecycle management (cleared on every refresh) — no new field.
- **\`renderActionList\`** reads \`state.diplomacy.empireAmbassadors[id]\` / \`state.diplomacy.rivalLiaisons[id]\`, computes the line, passes through. Tag detail rows shift down to fit beneath; action buttons follow.

## Scope notes

**Portrait wiring is deferred** — placeholder portrait IDs (\`amb-01\`..\`amb-08\`) aren't loaded textures, so showing them needs separate asset coordination. The textual flavor lands without that dependency, which is the bulk of the player-facing improvement.

## Test plan

- [x] **43 helper tests** (up from 40). New cases: greeting pool covers all 20 combos with non-empty strings; lines vary across personalities and tiers as advertised.
- [x] \`npm run check\` clean: typecheck + 1417 tests + production build
- [x] Manual verification in dev preview:
  - Empire at Warm tier with suspicious ambassador → \`Ambassador Lyra Korr · suspicious\` + \`Their guard slackens — barely.\`
  - Rival at Neutral tier with mercenary liaison → \`Liaison Galen Korr · mercenary\` + \`They tilt an eyebrow. 'What do you want?'\`

## What's next on the wave-2 polish list

- Confirmation dialog for irreversible queues (small modal)
- Ambassador portraits (needs asset coordination — placeholder IDs aren't loaded textures)

Or pivot to **wave-3 mechanics**: sabotage, contract poaching, smear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)