### PR TITLE
feat(diplomacy): wave 3 slice 1 — Sabotage operations

### DIFF
--- a/docs/plans/2026-04-30-diplomacy-wave3-sabotage-plan.md
+++ b/docs/plans/2026-04-30-diplomacy-wave3-sabotage-plan.md
@@ -1,0 +1,113 @@
+# Diplomacy Wave 3 — Slice 1: Sabotage
+
+Status: in-progress
+Branch: `claude/diplomacy-wave3-sabotage`
+
+## Why this slice
+
+Of the wave-3 backlog (sabotage / contract-poaching / smear / tech integration /
+empire-vs-empire reactions / blockades / multi-turn ops / call-in-favor),
+**sabotage is the highest-impact verb**. The original spec calls it out as
+"the most novel mechanic," and it slots cleanly into the existing
+`DiplomacyResolver` shape (gift / lobby / non-compete / surveil are all
+parallel single-call resolvers). It also opens the door for follow-up
+slices (smear is a tag-injection variant, contract-poaching is a payload
+swap) so it earns its complexity.
+
+## Concrete shape
+
+### Data model
+
+- New `DiplomacyActionKind`: `"sabotage"`.
+- New `StandingTag`: `{ kind: "Sabotaged"; expiresOnTurn: number }`. Applied to
+  the rival on success — surfaces in the hub as a "bad" intent badge.
+- Reuse the existing `SuspectedSpy:player` tag on exposure (failure path), so
+  the existing AI offer reaction in `selectDiplomacyOffer` already covers it.
+
+### Resolver
+
+`resolveSabotage(state, action, rng)` — mirrors `resolveSurveil` shape:
+
+- Cost: `30_000` cash. On failure, refund 50% (matches gift refund pattern).
+- Cooldown: `8` turns (longer than surveil's 6 — sabotage is heavier).
+- Base success: `0.5` (50/50 — riskier than surveil's 0.65).
+- On success:
+  - Add `Sabotaged` tag to the rival, expiring in `4` turns.
+  - Deduct `200_000` cash from the targeted rival's `cash` (in
+    `state.aiCompanies`). This models the disruption — capped at the rival's
+    current cash so we never go negative.
+  - Digest entry naming the rival and the cash hit.
+- On failure (exposed):
+  - Add `SuspectedSpy:player` tag to the rival (TTL `5` turns — same as
+    surveil exposure).
+  - Modal entry: "Sabotage exposed" — their counter-intel team flagged you.
+
+### Dispatcher + queue helper
+
+- Add `sabotage` to the switch in `resolveDiplomacyAction`.
+- Add `"Sabotage"` label to the verb map in `DiplomacyScene.refreshQueuedSummary`.
+
+### Hub integration
+
+- New action descriptor in `getActionsForRival`:
+  `{ kind: "sabotage", label: "Sabotage Operation", cashCost: 30_000, category: "single" }`.
+- New tag badge in `describeTag` for `Sabotaged`:
+  - Label: `Sabotaged`
+  - Intent: `bad` (it's bad for the rival, but the player sees it as their
+    own offensive action — neutral might also fit, but `bad` keeps the badge
+    color stable with the existing convention that "Spied!" on rival rows
+    means a hostile relation marker is in play).
+
+### AI reaction (light touch)
+
+- Extend `selectDiplomacyOffer` to also fire the rival warning event when the
+  rival has a `Sabotaged` tag. The warning copy stays the same — the
+  mechanic is identical (the rival is angry at the player). This means even
+  if the player gets in clean (no `SuspectedSpy:player`), they still face
+  some narrative blowback while the `Sabotaged` tag is live.
+
+### What we do NOT do in this slice
+
+- No tech-tree integration (deferred — slice 4 of the backlog).
+- No multi-turn setup→execute→reveal flow (slice 7).
+- No ripple to empire-of-rival's standing (slice 5 territory).
+- No blockades (slice 6).
+
+## TDD task list
+
+Each task gets a failing test first, then implementation, then `npm run check`.
+
+1. **Type plumbing** — extend `DiplomacyActionKind` and add `Sabotaged` to
+   `StandingTag`. (Compile-only; verified via typecheck rather than a test.)
+2. **`describeTag` for `Sabotaged`** — extend
+   `diplomacyHubHelpers.describeTag` so the new tag is renderable. Test:
+   intent + label assertions.
+3. **`getActionsForRival` includes sabotage** — extend the helper. Test:
+   sabotage descriptor present with right cost/category.
+4. **Resolver: success path** — `DiplomacyResolver.sabotage.test.ts`. Find
+   a success seed; assert `Sabotaged` tag on rival, rival cash deducted by
+   200k (or capped), digest entry, no modal, cash spent in full.
+5. **Resolver: failure path** — find a failure seed; assert
+   `SuspectedSpy:player` tag, modal entry, no `Sabotaged` tag, half cash
+   refunded.
+6. **Resolver: cooldown + counter** — assert `sabotage:<rival>` cooldown
+   set to `turn + 8` and `actionsResolvedThisTurn` incremented.
+7. **Resolver: rival cash floor** — when rival cash < 200k, deduction is
+   capped at current cash (no negatives).
+8. **Dispatcher integration** — extend
+   `DiplomacyResolver.dispatch.test.ts` with a `sabotage` dispatch case.
+9. **AI offer reaction** — extend `DiplomacyAI.test.ts`: when only the
+   `Sabotaged` tag is present (no `SuspectedSpy`), `selectDiplomacyOffer`
+   can still produce a `diplomacy:rivalSpyWarning` event.
+10. **Scene queue label** — verb-map test (the existing helpers tests
+    don't cover this; we'll add a smoke-test by exercising the hub helpers
+    only — the scene-level verb map is small enough to verify by reading
+    after the change).
+
+## Verification
+
+- `npm run check` clean.
+- New test count: ~10 added tests on top of 1417+.
+- Manual: skip — the slice is data + helpers + resolver. The hub UI
+  integration is exercised by existing scene tests + the helper tests.
+  No new picker shape, no new layout.

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1092,7 +1092,8 @@ export type StandingTag =
       lens: "cash" | "topContractByValue" | "topEmpireStanding";
       value: string;
       expiresOnTurn: number;
-    };
+    }
+  | { kind: "Sabotaged"; expiresOnTurn: number };
 
 export type AmbassadorPersonality =
   | "formal"
@@ -1112,7 +1113,8 @@ export type DiplomacyActionKind =
   | "lobbyFor"
   | "lobbyAgainst"
   | "proposeNonCompete"
-  | "surveil";
+  | "surveil"
+  | "sabotage";
 
 export type SurveilLens = "cash" | "topContractByValue" | "topEmpireStanding";
 

--- a/src/game/diplomacy/DiplomacyAI.ts
+++ b/src/game/diplomacy/DiplomacyAI.ts
@@ -60,10 +60,13 @@ export function selectDiplomacyOffer(
     }
   }
 
-  // Rival warnings: when SuspectedSpy is on the rival's tags.
+  // Rival warnings: when either SuspectedSpy:player OR Sabotaged is on the
+  // rival's tags. Both signal the rival is angry at the player. We don't
+  // double up the candidate weight when both are present — one warning per
+  // rival per turn is plenty.
   for (const r of state.aiCompanies ?? []) {
     const tags = d.rivalTags[r.id] ?? [];
-    if (hasTagOfKind(tags, "SuspectedSpy")) {
+    if (hasTagOfKind(tags, "SuspectedSpy") || hasTagOfKind(tags, "Sabotaged")) {
       candidates.push({
         weight: 4,
         build: () => ({

--- a/src/game/diplomacy/DiplomacyResolver.ts
+++ b/src/game/diplomacy/DiplomacyResolver.ts
@@ -1,5 +1,6 @@
 import type { SeededRNG } from "../../utils/SeededRNG.ts";
 import type {
+  AICompany,
   DiplomacyState,
   GameState,
   QueuedDiplomacyAction,
@@ -467,6 +468,85 @@ export function resolveSurveil(
   };
 }
 
+const SABOTAGE_BASE_SUCCESS = 0.5;
+const SABOTAGE_TAG_TTL = 4;
+const SABOTAGE_SPY_TTL = 5;
+const SABOTAGE_COOLDOWN = 8;
+const SABOTAGE_RIVAL_CASH_HIT = 200_000;
+
+export function resolveSabotage(
+  state: GameState,
+  action: QueuedDiplomacyAction,
+  rng: SeededRNG,
+): ResolutionOutcome {
+  const rivalId = action.targetId;
+  const success = rng.chance(SABOTAGE_BASE_SUCCESS);
+
+  const d = dip(state);
+  const tagsBefore = d.rivalTags[rivalId] ?? [];
+  let tagsAfter: readonly StandingTag[] = tagsBefore;
+  const modal: ModalEntry[] = [];
+  const digest: DigestEntry[] = [];
+  let cashAfter = state.cash - action.cashCost;
+  let aiCompanies = state.aiCompanies;
+
+  if (success) {
+    tagsAfter = addTag(tagsBefore, {
+      kind: "Sabotaged",
+      expiresOnTurn: state.turn + SABOTAGE_TAG_TTL,
+    });
+    // Apply the cash hit to the targeted rival, capped at their current cash
+    // so we never produce a negative balance.
+    if (aiCompanies) {
+      aiCompanies = aiCompanies.map((r): AICompany => {
+        if (r.id !== rivalId) return r;
+        const before = r.cash ?? 0;
+        const hit = Math.min(SABOTAGE_RIVAL_CASH_HIT, Math.max(0, before));
+        return { ...r, cash: before - hit };
+      });
+    }
+    digest.push({
+      text: `Sabotage of ${rivalId} succeeded: -$${SABOTAGE_RIVAL_CASH_HIT.toLocaleString("en-US")} disruption (${SABOTAGE_TAG_TTL} turns).`,
+    });
+  } else {
+    // Half-cost refund on exposure mirrors the gift-refused / lobby-failed
+    // pattern — the player still pays for the operation getting set up.
+    cashAfter = state.cash - Math.floor(action.cashCost * 0.5);
+    tagsAfter = addTag(tagsBefore, {
+      kind: "SuspectedSpy",
+      suspectId: "player",
+      expiresOnTurn: state.turn + SABOTAGE_SPY_TTL,
+    });
+    modal.push({
+      speakerKind: "rivalLiaison",
+      targetId: rivalId,
+      headline: "Sabotage exposed",
+      flavor: "Their counter-intel team has flagged your operation.",
+    });
+  }
+
+  return {
+    nextState: {
+      ...state,
+      cash: cashAfter,
+      ...(aiCompanies ? { aiCompanies } : {}),
+      diplomacy: {
+        ...d,
+        rivalTags: { ...d.rivalTags, [rivalId]: tagsAfter },
+        cooldowns: setCooldown(
+          d.cooldowns,
+          cooldownKey("sabotage", rivalId),
+          state.turn + SABOTAGE_COOLDOWN,
+        ),
+        actionsResolvedThisTurn: d.actionsResolvedThisTurn + 1,
+      },
+    },
+    modalEntries: modal,
+    digestEntries: digest,
+    success,
+  };
+}
+
 const THROTTLE_BASE = 2;
 const THROTTLE_HIGH = 3;
 const REPUTATION_THROTTLE_THRESHOLD = 75;
@@ -488,6 +568,8 @@ export function resolveDiplomacyAction(
       return resolveNonCompete(state, action, rng);
     case "surveil":
       return resolveSurveil(state, action, rng);
+    case "sabotage":
+      return resolveSabotage(state, action, rng);
   }
 }
 

--- a/src/game/diplomacy/__tests__/DiplomacyAI.test.ts
+++ b/src/game/diplomacy/__tests__/DiplomacyAI.test.ts
@@ -64,4 +64,31 @@ describe("selectDiplomacyOffer", () => {
     }
     expect(saw).toBe(true);
   });
+
+  it("fires rivalSpyWarning when only Sabotaged tag is present (no SuspectedSpy)", () => {
+    const sabotagedState: GameState = {
+      ...baseState(),
+      diplomacy: {
+        ...EMPTY_DIPLOMACY_STATE,
+        rivalStanding: { chen: 30 },
+        empireTags: { vex: [], sol: [] },
+        rivalTags: {
+          chen: [{ kind: "Sabotaged", expiresOnTurn: 9 }],
+        },
+      },
+      // Override empireReputation so empires don't add Warm/Allied candidates
+      // and dilute the test signal.
+      empireReputation: { vex: 50, sol: 50 },
+    } as unknown as GameState;
+
+    let saw = false;
+    for (let s = 0; s < 80; s++) {
+      const out = selectDiplomacyOffer(new SeededRNG(s), sabotagedState);
+      if (out && out.eventId === "diplomacy:rivalSpyWarning") {
+        saw = true;
+        break;
+      }
+    }
+    expect(saw).toBe(true);
+  });
 });

--- a/src/game/diplomacy/__tests__/DiplomacyResolver.dispatch.test.ts
+++ b/src/game/diplomacy/__tests__/DiplomacyResolver.dispatch.test.ts
@@ -99,6 +99,22 @@ describe("resolveDiplomacyAction (dispatcher)", () => {
     const out = resolveDiplomacyAction(s, action, rng);
     expect(out.nextState.diplomacy!.cooldowns["surveil:chen"]).toBe(5 + 6);
   });
+
+  it("dispatches sabotage", () => {
+    const rng = new SeededRNG(1);
+    const action: QueuedDiplomacyAction = {
+      id: "a1",
+      kind: "sabotage",
+      targetId: "chen",
+      cashCost: 30_000,
+    };
+    const s = baseState();
+    (s as unknown as { aiCompanies: unknown[] }).aiCompanies = [
+      { id: "chen", name: "Chen", cash: 1_000_000, activeRoutes: [] },
+    ];
+    const out = resolveDiplomacyAction(s, action, rng);
+    expect(out.nextState.diplomacy!.cooldowns["sabotage:chen"]).toBe(5 + 8);
+  });
 });
 
 describe("processQueuedDiplomacyActions (throttle)", () => {

--- a/src/game/diplomacy/__tests__/DiplomacyResolver.sabotage.test.ts
+++ b/src/game/diplomacy/__tests__/DiplomacyResolver.sabotage.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { resolveSabotage } from "../DiplomacyResolver.ts";
+import { SeededRNG } from "../../../utils/SeededRNG.ts";
+import type { GameState, QueuedDiplomacyAction } from "../../../data/types.ts";
+import { EMPTY_DIPLOMACY_STATE } from "../../../data/types.ts";
+
+function baseState(rivalCash = 1_000_000): GameState {
+  return {
+    seed: 1,
+    turn: 5,
+    cash: 100_000,
+    aiCompanies: [
+      {
+        id: "chen",
+        name: "Chen Logistics",
+        cash: rivalCash,
+        activeRoutes: [],
+      },
+      // Untouched second rival to ensure we don't accidentally mutate others.
+      {
+        id: "kade",
+        name: "Kade Reach",
+        cash: 500_000,
+        activeRoutes: [],
+      },
+    ],
+    diplomacy: {
+      ...EMPTY_DIPLOMACY_STATE,
+      rivalStanding: { chen: 50, kade: 50 },
+      rivalTags: { chen: [], kade: [] },
+    },
+  } as unknown as GameState;
+}
+
+function action(): QueuedDiplomacyAction {
+  return {
+    id: "a1",
+    kind: "sabotage",
+    targetId: "chen",
+    cashCost: 30_000,
+  };
+}
+
+describe("resolveSabotage", () => {
+  it("clean success: Sabotaged tag, rival cash deducted 200k, digest only, no modal", () => {
+    for (let seed = 1; seed < 200; seed++) {
+      const rng = new SeededRNG(seed);
+      const out = resolveSabotage(baseState(), action(), rng);
+      if (out.success) {
+        const tags = out.nextState.diplomacy!.rivalTags.chen!;
+        const sabo = tags.find((t) => t.kind === "Sabotaged");
+        expect(sabo).toBeDefined();
+        if (sabo && sabo.kind === "Sabotaged") {
+          expect(sabo.expiresOnTurn).toBe(5 + 4);
+        }
+        // Player paid full cost
+        expect(out.nextState.cash).toBe(100_000 - 30_000);
+        // Rival cash deducted by 200k
+        const chen = out.nextState.aiCompanies?.find((r) => r.id === "chen");
+        expect(chen?.cash).toBe(1_000_000 - 200_000);
+        // Other rivals untouched
+        const kade = out.nextState.aiCompanies?.find((r) => r.id === "kade");
+        expect(kade?.cash).toBe(500_000);
+        // Digest line surfaces, no modal on clean success
+        expect(out.modalEntries.length).toBe(0);
+        expect(out.digestEntries.length).toBeGreaterThanOrEqual(1);
+        // No SuspectedSpy on clean success
+        expect(tags.some((t) => t.kind === "SuspectedSpy")).toBe(false);
+        return;
+      }
+    }
+    throw new Error("no sabotage success across seeds");
+  });
+
+  it("exposed failure: SuspectedSpy:player tag, modal entry, no Sabotaged tag, half cash refunded", () => {
+    for (let seed = 1; seed < 500; seed++) {
+      const rng = new SeededRNG(seed);
+      const out = resolveSabotage(baseState(), action(), rng);
+      if (!out.success) {
+        const tags = out.nextState.diplomacy!.rivalTags.chen!;
+        const spy = tags.find((t) => t.kind === "SuspectedSpy");
+        expect(spy).toBeDefined();
+        if (spy && spy.kind === "SuspectedSpy") {
+          expect(spy.suspectId).toBe("player");
+          expect(spy.expiresOnTurn).toBe(5 + 5);
+        }
+        expect(tags.some((t) => t.kind === "Sabotaged")).toBe(false);
+        // Half cost on failure
+        expect(out.nextState.cash).toBe(100_000 - 15_000);
+        // Rival cash NOT deducted on failure
+        const chen = out.nextState.aiCompanies?.find((r) => r.id === "chen");
+        expect(chen?.cash).toBe(1_000_000);
+        // Modal surfaces the exposure
+        expect(out.modalEntries.length).toBeGreaterThanOrEqual(1);
+        return;
+      }
+    }
+    throw new Error("no sabotage failure across seeds");
+  });
+
+  it("sets cooldown 8 turns and increments actionsResolvedThisTurn", () => {
+    const rng = new SeededRNG(1);
+    const out = resolveSabotage(baseState(), action(), rng);
+    expect(out.nextState.diplomacy!.cooldowns["sabotage:chen"]).toBe(5 + 8);
+    expect(out.nextState.diplomacy!.actionsResolvedThisTurn).toBe(1);
+  });
+
+  it("rival cash deduction caps at the rival's current cash (no negatives)", () => {
+    for (let seed = 1; seed < 200; seed++) {
+      const rng = new SeededRNG(seed);
+      const out = resolveSabotage(baseState(50_000), action(), rng);
+      if (out.success) {
+        const chen = out.nextState.aiCompanies?.find((r) => r.id === "chen");
+        // Rival had 50k, deduction is 200k → floor at 0.
+        expect(chen?.cash).toBe(0);
+        return;
+      }
+    }
+    throw new Error("no sabotage success across seeds");
+  });
+});

--- a/src/game/diplomacy/__tests__/StandingTags.test.ts
+++ b/src/game/diplomacy/__tests__/StandingTags.test.ts
@@ -12,6 +12,7 @@ const tag = (kind: StandingTag["kind"], expiresOnTurn: number): StandingTag => {
   switch (kind) {
     case "OweFavor":
     case "RecentlyGifted":
+    case "Sabotaged":
       return { kind, expiresOnTurn };
     case "SuspectedSpy":
       return { kind, suspectId: "player", expiresOnTurn };

--- a/src/scenes/DiplomacyScene.ts
+++ b/src/scenes/DiplomacyScene.ts
@@ -669,6 +669,7 @@ export class DiplomacyScene extends Phaser.Scene {
       lobbyAgainst: "Lobby against",
       proposeNonCompete: "Non-Compete",
       surveil: "Surveil",
+      sabotage: "Sabotage",
     };
     const lines = d.queuedActions
       .map((a) => {

--- a/src/scenes/__tests__/diplomacyHubHelpers.test.ts
+++ b/src/scenes/__tests__/diplomacyHubHelpers.test.ts
@@ -126,7 +126,7 @@ describe("getActionsForEmpire", () => {
 });
 
 describe("getActionsForRival", () => {
-  it("returns gift + three surveil lenses + propose-non-compete", () => {
+  it("returns gift + three surveil lenses + propose-non-compete + sabotage", () => {
     const actions = getActionsForRival(rival);
     expect(actions.map((a) => a.kind)).toEqual([
       "giftRival",
@@ -134,12 +134,14 @@ describe("getActionsForRival", () => {
       "surveil",
       "surveil",
       "proposeNonCompete",
+      "sabotage",
     ]);
     expect(actions.map((a) => a.surveilLens)).toEqual([
       undefined,
       "cash",
       "topContractByValue",
       "topEmpireStanding",
+      undefined,
       undefined,
     ]);
   });
@@ -149,6 +151,14 @@ describe("getActionsForRival", () => {
     const nc = actions.find((a) => a.kind === "proposeNonCompete")!;
     expect(nc.category).toBe("pair");
     expect(nc.subjectPrompt).toContain("Chen Logistics");
+  });
+
+  it("sabotage is single-category with 30k cost", () => {
+    const actions = getActionsForRival(rival);
+    const sabo = actions.find((a) => a.kind === "sabotage")!;
+    expect(sabo.category).toBe("single");
+    expect(sabo.cashCost).toBe(30_000);
+    expect(sabo.subjectPrompt).toBeUndefined();
   });
 });
 
@@ -342,6 +352,10 @@ describe("getActiveTagBadges", () => {
         expiresOnTurn: 99,
       }).intent,
     ).toBe("good");
+    const sabo = describeTag({ kind: "Sabotaged", expiresOnTurn: 99 });
+    expect(sabo.intent).toBe("good");
+    expect(sabo.label).toBe("Sabotaged");
+    expect(sabo.tooltip.length).toBeGreaterThan(0);
   });
 
   it("non-compete tooltip lists protected empires", () => {

--- a/src/scenes/diplomacyHubHelpers.ts
+++ b/src/scenes/diplomacyHubHelpers.ts
@@ -27,6 +27,7 @@ const GIFT_RIVAL_COST = 5_000;
 const SURVEIL_COST = 15_000;
 const LOBBY_COST = 18_000;
 const NON_COMPETE_COST = 0; // proposal is free; the agreement itself binds both sides
+const SABOTAGE_COST = 30_000;
 
 /**
  * The picker shape an action requires before it can be queued:
@@ -150,6 +151,13 @@ export function getActionsForRival(
       cashCost: NON_COMPETE_COST,
       category: "pair",
       subjectPrompt: `Pick two empires for ${rival.name} to stay out of.`,
+    },
+    {
+      id: `sabotage-${rival.id}`,
+      kind: "sabotage",
+      label: "Sabotage Operation",
+      cashCost: SABOTAGE_COST,
+      category: "single",
     },
   ];
 }
@@ -288,6 +296,13 @@ export function describeTag(tag: StandingTag): TagBadge {
         label: `Intel:${tag.lens === "topContractByValue" ? "contract" : tag.lens}`,
         intent: "good",
         tooltip: `Surveillance leaked their ${tag.lens}: ${tag.value}`,
+      };
+    case "Sabotaged":
+      return {
+        label: "Sabotaged",
+        intent: "good",
+        tooltip:
+          "Your operation disrupted their cash flow — expect retaliation events.",
       };
   }
 }


### PR DESCRIPTION
## Summary

First wave-3 diplomacy verb: a player-targeted offensive action that disrupts a rival's cash flow at the risk of being exposed as a spy.

- New \`DiplomacyActionKind: \"sabotage\"\` — single-target, \$30k cost, 8-turn cooldown, 50% base success.
- New \`StandingTag: \"Sabotaged\"\` (4-turn TTL) — applied to the rival on success, surfaced as a hub badge.
- On success the targeted rival's cash is reduced by \$200k (floored at 0 — never negative).
- On exposure the existing \`SuspectedSpy:player\` tag is applied (5-turn TTL) and half the cash cost is refunded, mirroring the gift / surveil failure pattern.
- \`selectDiplomacyOffer\` also fires the \`rivalSpyWarning\` event when a rival carries the \`Sabotaged\` tag, so even a clean-success sabotage carries narrative blowback while the tag is live.

Hub UI gets a new \"Sabotage Operation\" button on rival rows; the queued-actions summary maps the verb to a \"Sabotage\" label.

Tests: **1420 → 1427** (7 new — resolver success/failure/cooldown/cash-cap, dispatcher case, AI offer reaction, hub helper coverage). \`npm run check\` clean (typecheck + tests + build + prettier + eslint).

Plan doc: [docs/plans/2026-04-30-diplomacy-wave3-sabotage-plan.md](docs/plans/2026-04-30-diplomacy-wave3-sabotage-plan.md).

## Test plan

- [x] \`npm run check\` — typecheck, 1427 vitest passes, production build, formatting, lint.
- [x] New resolver tests cover both success and exposure paths under multi-seed search to avoid flake.
- [x] Rival-cash floor test (rival with \$50k → sabotage hit floors at 0, no negative balance).
- [x] AI selector test confirms a rival carrying only \`Sabotaged\` (no \`SuspectedSpy\`) can still trigger the warning event.
- [ ] Manual hub click-through deferred — the slice is data + helpers + resolver behind existing UI patterns; no new picker shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)