### PR TITLE
feat(diplomacy): hub polish 6 — confirm dialog for single-category actions

### DIFF
--- a/src/scenes/DiplomacyScene.ts
+++ b/src/scenes/DiplomacyScene.ts
@@ -24,6 +24,7 @@ import {
 import type { StandingTierName } from "../game/diplomacy/StandingTiers.ts";
 import {
   buildQueuedAction,
+  describeActionEffect,
   detectTierShifts,
   evaluateActionState,
   getActionsForEmpire,
@@ -59,6 +60,11 @@ type PanelMode =
       action: HubActionDescriptor;
       targetId: string;
       selected: readonly string[];
+    }
+  | {
+      kind: "confirm";
+      action: HubActionDescriptor;
+      targetId: string;
     };
 
 /**
@@ -377,6 +383,10 @@ export class DiplomacyScene extends Phaser.Scene {
       this.renderPairPicker(state, this.mode);
       return;
     }
+    if (this.mode.kind === "confirm") {
+      this.renderConfirmPanel(state, this.mode);
+      return;
+    }
     this.renderActionList(state);
   }
 
@@ -575,6 +585,105 @@ export class DiplomacyScene extends Phaser.Scene {
       x: absX + Math.floor((contentWidth - 24) / 2) + 8,
       y: baseY,
       width: Math.floor((contentWidth - 24) / 2),
+      height: btnH,
+      label: "Cancel",
+      onClick: () => {
+        this.mode = { kind: "list" };
+        this.refreshActionPanel();
+      },
+    });
+    this.actionButtons.push(cancelBtn);
+  }
+
+  /**
+   * Confirm panel for single-category actions (Send Gift, Surveil X,
+   * Sabotage). The action list button doesn't queue immediately — it routes
+   * here so the player sees a short effect summary and an explicit cost
+   * line before committing the spend.
+   */
+  private renderConfirmPanel(
+    state: GameState,
+    mode: { action: HubActionDescriptor; targetId: string },
+  ): void {
+    const { action, targetId } = mode;
+    // Header restates the action so it's always visible above the buttons.
+    let targetName = targetId;
+    if (this.selection?.kind === "empire") {
+      const e = state.galaxy?.empires.find((x) => x.id === targetId);
+      if (e) targetName = e.name;
+    } else if (this.selection?.kind === "rival") {
+      const r = state.aiCompanies?.find((x) => x.id === targetId);
+      if (r) targetName = r.name;
+    }
+    this.actionStatusLabel.setText(`${action.label} — ${targetName}?`);
+
+    const { absX, absY, contentWidth } = this.getActionPanelGeometry();
+    const theme = getTheme();
+
+    // Effect summary line. Falls back to the bare label if the action kind
+    // isn't a known single-category one (defensive — shouldn't happen).
+    const effect = describeActionEffect(action) ?? action.label;
+    const effectLabel = this.add.text(absX, absY, effect, {
+      fontFamily: theme.fonts.body.family,
+      fontSize: "13px",
+      color: colorToHex(theme.colors.text),
+      wordWrap: { width: contentWidth - 16 },
+    });
+    this.tagDetailLabels.push(effectLabel);
+
+    // Cost line — explicit second row so the spend is unambiguous.
+    const costText =
+      action.cashCost > 0
+        ? `Cost: $${formatCash(action.cashCost)}`
+        : "Cost: free";
+    const costLabel = this.add.text(
+      absX,
+      absY + effectLabel.height + 6,
+      costText,
+      {
+        fontFamily: theme.fonts.value.family,
+        fontSize: "13px",
+        color: colorToHex(theme.colors.accent),
+      },
+    );
+    this.tagDetailLabels.push(costLabel);
+
+    // Affordance hint, if any (e.g. "+15% favor" / "-50% dampener").
+    const evalState = evaluateActionState(action, targetId, state);
+    let nextY = absY + effectLabel.height + 6 + costLabel.height + 4;
+    if (evalState.affordanceHint) {
+      const hint = this.add.text(absX, nextY, evalState.affordanceHint, {
+        fontFamily: theme.fonts.caption.family,
+        fontSize: "12px",
+        color: colorToHex(theme.colors.textDim),
+      });
+      this.tagDetailLabels.push(hint);
+      nextY += hint.height + 4;
+    }
+
+    // Confirm + Cancel sit on a shared row so the layout matches the pair
+    // picker's "Confirm | Cancel" footer.
+    const btnH = 36;
+    const btnY = nextY + 8;
+    const btnW = Math.floor((contentWidth - 24) / 2);
+    const confirmBtn = new Button(this, {
+      x: absX,
+      y: btnY,
+      width: btnW,
+      height: btnH,
+      label: "Confirm",
+      onClick: () => {
+        this.queueAction(action, targetId);
+        this.mode = { kind: "list" };
+        // refresh handled by gameStore.stateChanged subscription
+      },
+    });
+    this.actionButtons.push(confirmBtn);
+
+    const cancelBtn = new Button(this, {
+      x: absX + btnW + 8,
+      y: btnY,
+      width: btnW,
       height: btnH,
       label: "Cancel",
       onClick: () => {
@@ -795,7 +904,11 @@ export class DiplomacyScene extends Phaser.Scene {
     targetId: string,
   ): void {
     if (action.category === "single") {
-      this.queueAction(action, targetId);
+      // Send Gift / Surveil / Sabotage cost cash and have no picker step,
+      // so a stray click would otherwise spend the player's money silently.
+      // Route through a confirm panel so the action is always intentional.
+      this.mode = { kind: "confirm", action, targetId };
+      this.refreshActionPanel();
       return;
     }
     if (action.category === "subject") {

--- a/src/scenes/__tests__/diplomacyHubHelpers.test.ts
+++ b/src/scenes/__tests__/diplomacyHubHelpers.test.ts
@@ -10,9 +10,11 @@ import {
   getActiveTagBadges,
   getTierColorName,
   describeTag,
+  describeActionEffect,
   detectTierShifts,
   snapshotTiers,
   getAmbientGreeting,
+  type HubActionDescriptor,
 } from "../diplomacyHubHelpers.ts";
 import { EMPTY_DIPLOMACY_STATE } from "../../data/types.ts";
 import type {
@@ -536,5 +538,63 @@ describe("getAmbientGreeting", () => {
     const hostile = getAmbientGreeting("warm", "Hostile");
     const allied = getAmbientGreeting("warm", "Allied");
     expect(hostile).not.toBe(allied);
+  });
+});
+
+describe("describeActionEffect", () => {
+  const baseAction = (
+    overrides: Partial<HubActionDescriptor>,
+  ): HubActionDescriptor => ({
+    id: "x",
+    kind: "giftEmpire",
+    label: "Send Gift",
+    cashCost: 10_000,
+    category: "single",
+    ...overrides,
+  });
+
+  it("describes giftEmpire", () => {
+    const s = describeActionEffect(baseAction({ kind: "giftEmpire" }));
+    expect(s).toMatch(/empire/i);
+  });
+
+  it("describes giftRival", () => {
+    const s = describeActionEffect(baseAction({ kind: "giftRival" }));
+    expect(s).toMatch(/rival/i);
+  });
+
+  it("describes surveil with each lens", () => {
+    const cash = describeActionEffect(
+      baseAction({ kind: "surveil", surveilLens: "cash" }),
+    );
+    const top = describeActionEffect(
+      baseAction({ kind: "surveil", surveilLens: "topContractByValue" }),
+    );
+    const standing = describeActionEffect(
+      baseAction({ kind: "surveil", surveilLens: "topEmpireStanding" }),
+    );
+    expect(cash).toMatch(/cash/i);
+    expect(top).toMatch(/contract/i);
+    expect(standing).toMatch(/empire|favor/i);
+  });
+
+  it("falls back to a generic surveil description when lens is missing", () => {
+    const s = describeActionEffect(baseAction({ kind: "surveil" }));
+    expect(s).toMatch(/intelligence|gather/i);
+  });
+
+  it("describes sabotage", () => {
+    const s = describeActionEffect(baseAction({ kind: "sabotage" }));
+    expect(s).toMatch(/sabotage|disrupt|risk/i);
+  });
+
+  it("returns null for non-single-category kinds", () => {
+    expect(describeActionEffect(baseAction({ kind: "lobbyFor" }))).toBeNull();
+    expect(
+      describeActionEffect(baseAction({ kind: "lobbyAgainst" })),
+    ).toBeNull();
+    expect(
+      describeActionEffect(baseAction({ kind: "proposeNonCompete" })),
+    ).toBeNull();
   });
 });

--- a/src/scenes/diplomacyHubHelpers.ts
+++ b/src/scenes/diplomacyHubHelpers.ts
@@ -477,6 +477,38 @@ export function snapshotTiers(
   return out;
 }
 
+/**
+ * Short prose summary of what a single-category action will do, used in the
+ * confirm panel. Lobby/non-compete actions go through their own pickers and
+ * never reach this helper, so we don't enumerate them here.
+ *
+ * Returns `null` for kinds that aren't single-category — callers should fall
+ * back to the action label.
+ */
+export function describeActionEffect(
+  action: HubActionDescriptor,
+): string | null {
+  switch (action.kind) {
+    case "giftEmpire":
+      return "Sends a one-time gift to improve standing with this empire.";
+    case "giftRival":
+      return "Sends a peace offering to improve standing with this rival.";
+    case "surveil": {
+      const lens = action.surveilLens;
+      if (lens === "cash") return "Reveals this rival's current cash reserves.";
+      if (lens === "topContractByValue")
+        return "Reveals this rival's most valuable active contract.";
+      if (lens === "topEmpireStanding")
+        return "Reveals which empire most favors this rival.";
+      return "Gathers intelligence on this rival.";
+    }
+    case "sabotage":
+      return "Disrupts a rival operation. High risk if detected.";
+    default:
+      return null;
+  }
+}
+
 export function buildQueuedAction(
   action: HubActionDescriptor,
   targetId: string,


### PR DESCRIPTION
## Summary

Final wave-2 polish slice. Single-category actions (Send Gift, Surveil X, Sabotage) used to queue on the first click, which made it easy to spend cash by accident. Now they route through an explicit Confirm step that mirrors the picker flows already used by Lobby and Propose Non-Compete.

- `PanelMode` gains a `confirm` variant carrying the action + target.
- `handleActionClick` routes `category === "single"` through the new mode instead of queueing immediately.
- `renderConfirmPanel` shows the action label + target name in the header, then an effect summary, an explicit cost row, the affordance hint when present, and Confirm | Cancel.
- New pure helper `describeActionEffect(action)` returns the effect copy keyed on kind (and surveil lens). Six new tests cover every single-category kind plus a null fallback for non-single kinds.

Subject- and pair-picker flows are untouched — they already had their own explicit confirm UX.

## Test plan

- [x] `npm run check` — typecheck, **1433 tests** (+6), build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)