### PR TITLE
feat(scenes): MainMenuScene fluid reflow

### DIFF
--- a/src/scenes/MainMenuScene.ts
+++ b/src/scenes/MainMenuScene.ts
@@ -7,6 +7,7 @@ import {
   Button,
   getTheme,
   getLayout,
+  attachReflowHandler,
 } from "../ui/index.ts";
 import { hasSaveGame, loadGameIntoStore } from "../game/SaveManager.ts";
 import { getAudioDirector } from "../audio/AudioDirector.ts";
@@ -61,229 +62,161 @@ const HERO_CONFIGS: readonly HeroConfig[] = [
 ];
 
 export class MainMenuScene extends Phaser.Scene {
+  private heroConfig!: HeroConfig;
+  private canContinue = false;
+  private canResumeSandbox = false;
+
+  // Decorative layer (rebuilt on every relayout — raw Phaser objects without setSize)
+  private decorativeLayer: Phaser.GameObjects.GameObject[] = [];
+
+  // Title card
+  private titlePanel!: Panel;
+  private strapLabel!: Label;
+  private titleLabel!: Label;
+  private subtitleLabel!: Label;
+
+  // Bottom command dock
+  private dockPanel!: Panel;
+  private deckLabel!: Label;
+  private promptLabel!: Label;
+  private statusLabel!: Label;
+  private vignetteLabel!: Label;
+
+  // Buttons
+  private newGameButton!: Button;
+  private continueButton!: Button;
+  private sandboxButton!: Button;
+  private resumeSandboxButton: Button | null = null;
+  private styleGuideButton: Button | null = null;
+
   constructor() {
     super({ key: "MainMenuScene" });
   }
 
   create(): void {
-    const L = getLayout();
     const theme = getTheme();
     this.cameras.main.setBackgroundColor(theme.colors.background);
     const audio = getAudioDirector();
     audio.setMusicState("menu");
 
-    const cx = L.gameWidth / 2;
-    const canContinue = hasSaveGame();
-    const heroConfig = Phaser.Utils.Array.GetRandom([...HERO_CONFIGS]);
-    const heroTexture = this.textures.get(heroConfig.key).getSourceImage() as {
-      width: number;
-      height: number;
-    };
-    const coverScale =
-      Math.max(
-        (L.gameWidth + 120) / heroTexture.width,
-        (L.gameHeight + 110) / heroTexture.height,
-      ) * heroConfig.zoom;
+    this.heroConfig = Phaser.Utils.Array.GetRandom([...HERO_CONFIGS]);
+    this.canContinue = hasSaveGame();
+    this.canResumeSandbox = hasResumableSandbox();
 
-    const hero = this.add
-      .image(
-        L.gameWidth * heroConfig.anchorX,
-        L.gameHeight * heroConfig.anchorY,
-        heroConfig.key,
-      )
-      .setOrigin(heroConfig.focusX, heroConfig.focusY)
-      .setScale(coverScale)
-      .setAlpha(0.98);
-    this.tweens.add({
-      targets: hero,
-      scaleX: coverScale * 1.035,
-      scaleY: coverScale * 1.035,
-      x: L.gameWidth * heroConfig.anchorX + heroConfig.driftX,
-      y: L.gameHeight * heroConfig.anchorY + heroConfig.driftY,
-      duration: 16000,
-      yoyo: true,
-      repeat: -1,
-      ease: "Sine.easeInOut",
-    });
-
-    const heroSheen = this.add
-      .rectangle(
-        -220,
-        L.gameHeight * 0.42,
-        220,
-        L.gameHeight * 1.2,
-        theme.colors.accent,
-        0.08,
-      )
-      .setAngle(16)
-      .setBlendMode(Phaser.BlendModes.SCREEN);
-    this.tweens.add({
-      targets: heroSheen,
-      x: L.gameWidth + 220,
-      duration: 9000,
-      repeat: -1,
-      ease: "Sine.easeInOut",
-      delay: 1200,
-    });
-
-    // Top and bottom readability scrims so the art stays visible while UI remains legible.
-    this.add
-      .rectangle(0, 0, L.gameWidth, 220, theme.colors.background, 0.54)
-      .setOrigin(0, 0);
-    this.add
-      .rectangle(
-        0,
-        L.gameHeight - 270,
-        L.gameWidth,
-        270,
-        theme.colors.background,
-        0.78,
-      )
-      .setOrigin(0, 0);
-    this.add
-      .rectangle(0, 0, L.gameWidth, L.gameHeight, theme.colors.background, 0.16)
-      .setOrigin(0, 0);
-
-    const depthCircle = this.add.circle(
-      cx,
-      150,
-      320,
-      theme.colors.panelBg,
-      0.14,
-    );
-    addPulseTween(this, depthCircle, {
-      minAlpha: 0.08,
-      maxAlpha: 0.2,
-      duration: 5200,
-    });
-
-    // Top title card
-    const titlePanelW = 620;
-    const titlePanelH = 132;
-    const titlePanelX = cx - titlePanelW / 2;
-    const titlePanelY = 24;
-    new Panel(this, {
-      x: titlePanelX,
-      y: titlePanelY,
-      width: titlePanelW,
-      height: titlePanelH,
+    // Title card built once — geometry applied in relayout().
+    this.titlePanel = new Panel(this, {
+      x: 0,
+      y: 0,
+      width: 620,
+      height: 132,
       showGlow: true,
     });
 
-    const strap = new Label(this, {
-      x: cx,
-      y: titlePanelY + 18,
-      text: heroConfig.strap,
+    this.strapLabel = new Label(this, {
+      x: 0,
+      y: 0,
+      text: this.heroConfig.strap,
       style: "caption",
       color: theme.colors.accent,
     });
-    strap.setOrigin(0.5, 0);
+    this.strapLabel.setOrigin(0.5, 0);
 
-    const title = new Label(this, {
-      x: cx,
-      y: titlePanelY + 52,
+    this.titleLabel = new Label(this, {
+      x: 0,
+      y: 0,
       text: "STAR FREIGHT TYCOON",
       style: "heading",
       color: theme.colors.accent,
       glow: true,
     });
-    title.setOrigin(0.5);
-    title.setFontSize(42);
-    addFloatTween(this, title, { dx: 0, dy: -4, duration: 4000, delay: 800 });
+    this.titleLabel.setOrigin(0.5);
+    this.titleLabel.setFontSize(42);
+    addFloatTween(this, this.titleLabel, {
+      dx: 0,
+      dy: -4,
+      duration: 4000,
+      delay: 800,
+    });
 
-    const subtitle = new Label(this, {
-      x: cx,
-      y: titlePanelY + 98,
-      text: heroConfig.subtitle,
+    this.subtitleLabel = new Label(this, {
+      x: 0,
+      y: 0,
+      text: this.heroConfig.subtitle,
       style: "caption",
       color: theme.colors.textDim,
     });
-    subtitle.setOrigin(0.5);
+    this.subtitleLabel.setOrigin(0.5);
 
-    // Bottom command dock keeps the center of the art clear.
-    const panelW = 760;
-    const panelH = 260;
-    const panelX = cx - panelW / 2;
-    const panelY = L.gameHeight - panelH - 22;
-    const btnHeight = 52;
-    const btnGap = 18;
-    const canResumeSandbox = hasResumableSandbox();
-    const totalBtns = canResumeSandbox ? 4 : 3;
-    const btnWidth = canResumeSandbox ? 168 : 220;
-    const totalBtnWidth = btnWidth * totalBtns + btnGap * (totalBtns - 1);
-    const btnStartX = panelX + (panelW - totalBtnWidth) / 2;
-    const btnY = panelY + panelH - btnHeight - 28;
-    const textLeftX = panelX + 28;
-    const textColumnWidth = panelW - 56;
-    new Panel(this, {
-      x: panelX,
-      y: panelY,
-      width: panelW,
-      height: panelH,
+    // Bottom command dock built once — geometry applied in relayout().
+    this.dockPanel = new Panel(this, {
+      x: 0,
+      y: 0,
+      width: 760,
+      height: 260,
       showGlow: true,
     });
 
-    const deckLabel = new Label(this, {
-      x: textLeftX,
-      y: panelY + 22,
+    this.deckLabel = new Label(this, {
+      x: 0,
+      y: 0,
       text: "Command Deck",
       style: "caption",
       color: theme.colors.accent,
     });
-    deckLabel.setOrigin(0, 0);
+    this.deckLabel.setOrigin(0, 0);
 
-    const promptLabel = new Label(this, {
-      x: textLeftX,
-      y: panelY + 48,
+    this.promptLabel = new Label(this, {
+      x: 0,
+      y: 0,
       text: "Select your next operation.",
       style: "body",
       color: theme.colors.text,
     });
-    promptLabel.setOrigin(0, 0);
+    this.promptLabel.setOrigin(0, 0);
 
-    const statusText = canResumeSandbox
+    const statusText = this.canResumeSandbox
       ? "Sandbox session detected — resume current simulation or start a new run."
-      : canContinue
+      : this.canContinue
         ? "Saved company detected — continue from the last checkpoint."
         : "No save detected — initialize a new company profile.";
-    const statusLabel = new Label(this, {
-      x: textLeftX,
-      y: panelY + 80,
+    this.statusLabel = new Label(this, {
+      x: 0,
+      y: 0,
       text: statusText,
       style: "caption",
       color: theme.colors.textDim,
-      maxWidth: textColumnWidth,
+      maxWidth: 760 - 56,
     });
-    statusLabel.setOrigin(0, 0);
+    this.statusLabel.setOrigin(0, 0);
 
-    const vignetteLabel = new Label(this, {
-      x: textLeftX,
-      y: panelY + 112,
-      text: heroConfig.vignette,
+    this.vignetteLabel = new Label(this, {
+      x: 0,
+      y: 0,
+      text: this.heroConfig.vignette,
       style: "caption",
       color: theme.colors.textDim,
-      maxWidth: textColumnWidth,
+      maxWidth: 760 - 56,
     });
-    vignetteLabel.setOrigin(0, 0);
+    this.vignetteLabel.setOrigin(0, 0);
 
-    new Button(this, {
-      x: btnStartX,
-      y: btnY,
-      width: btnWidth,
-      height: btnHeight,
+    this.newGameButton = new Button(this, {
+      x: 0,
+      y: 0,
+      width: 220,
+      height: 52,
       label: "New Game",
       onClick: () => {
         this.scene.start("GalaxySetupScene");
       },
     });
 
-    new Button(this, {
-      x: btnStartX + btnWidth + btnGap,
-      y: btnY,
-      width: btnWidth,
-      height: btnHeight,
+    this.continueButton = new Button(this, {
+      x: 0,
+      y: 0,
+      width: 220,
+      height: 52,
       label: "Continue",
-      disabled: !canContinue,
+      disabled: !this.canContinue,
       onClick: () => {
         if (loadGameIntoStore()) {
           this.scene.start("GameHUDScene");
@@ -291,23 +224,23 @@ export class MainMenuScene extends Phaser.Scene {
       },
     });
 
-    new Button(this, {
-      x: btnStartX + (btnWidth + btnGap) * 2,
-      y: btnY,
-      width: btnWidth,
-      height: btnHeight,
+    this.sandboxButton = new Button(this, {
+      x: 0,
+      y: 0,
+      width: 220,
+      height: 52,
       label: "AI Sandbox",
       onClick: () => {
         this.scene.start("SandboxSetupScene");
       },
     });
 
-    if (canResumeSandbox) {
-      new Button(this, {
-        x: btnStartX + (btnWidth + btnGap) * 3,
-        y: btnY,
-        width: btnWidth,
-        height: btnHeight,
+    if (this.canResumeSandbox) {
+      this.resumeSandboxButton = new Button(this, {
+        x: 0,
+        y: 0,
+        width: 168,
+        height: 52,
         label: "Resume Sandbox",
         onClick: () => {
           const data = getActiveSandboxData();
@@ -325,15 +258,12 @@ export class MainMenuScene extends Phaser.Scene {
       });
     }
 
-    // Style Guide link — only shown in development builds
     if (import.meta.env.DEV) {
-      const sgBtnW = 120;
-      const sgBtnH = 32;
-      new Button(this, {
-        x: L.gameWidth - sgBtnW - 16,
-        y: L.gameHeight - sgBtnH - 8,
-        width: sgBtnW,
-        height: sgBtnH,
+      this.styleGuideButton = new Button(this, {
+        x: 0,
+        y: 0,
+        width: 120,
+        height: 32,
         label: "Style Guide",
         onClick: () => {
           window.open("./styleguide/index.html", "_blank");
@@ -341,13 +271,178 @@ export class MainMenuScene extends Phaser.Scene {
       });
     }
 
-    // Restart scene on resize so layout recalculates
-    const onResize = () => {
-      this.scene.restart();
-    };
-    this.scale.on("resize", onResize);
-    this.events.once("shutdown", () => {
-      this.scale.off("resize", onResize);
+    this.relayout();
+    attachReflowHandler(this, () => this.relayout());
+  }
+
+  private relayout(): void {
+    const L = getLayout();
+    const cx = L.gameWidth / 2;
+
+    // Decorative layer (hero image, sheen, scrims, depth circle) has no
+    // setSize() — destroy and rebuild on each reflow.
+    this.rebuildDecorativeLayer();
+
+    // Title card
+    const titlePanelW = 620;
+    const titlePanelH = 132;
+    const titlePanelX = cx - titlePanelW / 2;
+    const titlePanelY = 24;
+    this.titlePanel.setPosition(titlePanelX, titlePanelY);
+    this.titlePanel.setSize(titlePanelW, titlePanelH);
+
+    this.strapLabel.setPosition(cx, titlePanelY + 18);
+    this.titleLabel.setPosition(cx, titlePanelY + 52);
+    this.subtitleLabel.setPosition(cx, titlePanelY + 98);
+
+    // Bottom command dock
+    const panelW = 760;
+    const panelH = 260;
+    const panelX = cx - panelW / 2;
+    const panelY = L.gameHeight - panelH - 22;
+    const btnHeight = 52;
+    const btnGap = 18;
+    const totalBtns = this.canResumeSandbox ? 4 : 3;
+    const btnWidth = this.canResumeSandbox ? 168 : 220;
+    const totalBtnWidth = btnWidth * totalBtns + btnGap * (totalBtns - 1);
+    const btnStartX = panelX + (panelW - totalBtnWidth) / 2;
+    const btnY = panelY + panelH - btnHeight - 28;
+    const textLeftX = panelX + 28;
+
+    this.dockPanel.setPosition(panelX, panelY);
+    this.dockPanel.setSize(panelW, panelH);
+
+    this.deckLabel.setPosition(textLeftX, panelY + 22);
+    this.promptLabel.setPosition(textLeftX, panelY + 48);
+    this.statusLabel.setPosition(textLeftX, panelY + 80);
+    this.vignetteLabel.setPosition(textLeftX, panelY + 112);
+
+    this.newGameButton.setPosition(btnStartX, btnY);
+    this.continueButton.setPosition(btnStartX + btnWidth + btnGap, btnY);
+    this.sandboxButton.setPosition(btnStartX + (btnWidth + btnGap) * 2, btnY);
+    if (this.resumeSandboxButton) {
+      this.resumeSandboxButton.setPosition(
+        btnStartX + (btnWidth + btnGap) * 3,
+        btnY,
+      );
+    }
+
+    if (this.styleGuideButton) {
+      const sgBtnW = 120;
+      const sgBtnH = 32;
+      this.styleGuideButton.setPosition(
+        L.gameWidth - sgBtnW - 16,
+        L.gameHeight - sgBtnH - 8,
+      );
+    }
+  }
+
+  private rebuildDecorativeLayer(): void {
+    const L = getLayout();
+    const theme = getTheme();
+    const cx = L.gameWidth / 2;
+
+    // Tear down previous decorative objects (and their tweens).
+    for (const obj of this.decorativeLayer) {
+      this.tweens.killTweensOf(obj);
+      obj.destroy();
+    }
+    this.decorativeLayer = [];
+
+    // Hero image
+    const heroTexture = this.textures
+      .get(this.heroConfig.key)
+      .getSourceImage() as { width: number; height: number };
+    const coverScale =
+      Math.max(
+        (L.gameWidth + 120) / heroTexture.width,
+        (L.gameHeight + 110) / heroTexture.height,
+      ) * this.heroConfig.zoom;
+
+    const hero = this.add
+      .image(
+        L.gameWidth * this.heroConfig.anchorX,
+        L.gameHeight * this.heroConfig.anchorY,
+        this.heroConfig.key,
+      )
+      .setOrigin(this.heroConfig.focusX, this.heroConfig.focusY)
+      .setScale(coverScale)
+      .setAlpha(0.98);
+    hero.setDepth(-100);
+    this.decorativeLayer.push(hero);
+    this.tweens.add({
+      targets: hero,
+      scaleX: coverScale * 1.035,
+      scaleY: coverScale * 1.035,
+      x: L.gameWidth * this.heroConfig.anchorX + this.heroConfig.driftX,
+      y: L.gameHeight * this.heroConfig.anchorY + this.heroConfig.driftY,
+      duration: 16000,
+      yoyo: true,
+      repeat: -1,
+      ease: "Sine.easeInOut",
+    });
+
+    const heroSheen = this.add
+      .rectangle(
+        -220,
+        L.gameHeight * 0.42,
+        220,
+        L.gameHeight * 1.2,
+        theme.colors.accent,
+        0.08,
+      )
+      .setAngle(16)
+      .setBlendMode(Phaser.BlendModes.SCREEN);
+    heroSheen.setDepth(-90);
+    this.decorativeLayer.push(heroSheen);
+    this.tweens.add({
+      targets: heroSheen,
+      x: L.gameWidth + 220,
+      duration: 9000,
+      repeat: -1,
+      ease: "Sine.easeInOut",
+      delay: 1200,
+    });
+
+    // Top and bottom readability scrims so the art stays visible while UI remains legible.
+    const topScrim = this.add
+      .rectangle(0, 0, L.gameWidth, 220, theme.colors.background, 0.54)
+      .setOrigin(0, 0);
+    topScrim.setDepth(-80);
+    this.decorativeLayer.push(topScrim);
+
+    const bottomScrim = this.add
+      .rectangle(
+        0,
+        L.gameHeight - 270,
+        L.gameWidth,
+        270,
+        theme.colors.background,
+        0.78,
+      )
+      .setOrigin(0, 0);
+    bottomScrim.setDepth(-80);
+    this.decorativeLayer.push(bottomScrim);
+
+    const fullScrim = this.add
+      .rectangle(0, 0, L.gameWidth, L.gameHeight, theme.colors.background, 0.16)
+      .setOrigin(0, 0);
+    fullScrim.setDepth(-80);
+    this.decorativeLayer.push(fullScrim);
+
+    const depthCircle = this.add.circle(
+      cx,
+      150,
+      320,
+      theme.colors.panelBg,
+      0.14,
+    );
+    depthCircle.setDepth(-70);
+    this.decorativeLayer.push(depthCircle);
+    addPulseTween(this, depthCircle, {
+      minAlpha: 0.08,
+      maxAlpha: 0.2,
+      duration: 5200,
     });
   }
 }


### PR DESCRIPTION
## Summary
- Apply the locked fluid-layout reflow pattern to `MainMenuScene` so it reflows on window resize instead of restarting the scene.
- Promote title card, command dock, status/vignette labels, and all action buttons to instance fields; geometry now lives entirely inside `relayout()`.
- Decorative layer (hero image + sheen tween, top/bottom/full scrims, depth circle pulse) has no `setSize()` so it is torn down and rebuilt each reflow with associated tweens killed first.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (1465 tests)
- [x] `npm run build` passes
- [ ] Manual: resize window on main menu — panels, labels, and buttons re-center; hero/scrim/depth-circle redraw at new dimensions.

## Screenshots
Screenshots not applicable: per-unit E2E was skipped per the rollout plan; this PR only changes layout wiring (visual parity with the previous `scene.restart()` flow on resize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)