### PR TITLE
feat(3d): camera + renderer resize for galaxy and system maps

### DIFF
--- a/src/scenes/GalaxyMapScene.ts
+++ b/src/scenes/GalaxyMapScene.ts
@@ -302,17 +302,17 @@ export class GalaxyMapScene extends Phaser.Scene {
 
   /**
    * Re-flow the 2D overlay chrome on canvas resize. The 3D viewport rect is
-   * updated via `view3D.setViewport`; the underlying Three.js renderer/camera
-   * keeps its design dimensions and is not resized here.
-   * TODO(3d-resize): wire renderer.setSize + camera aspect when the canvas
-   * dimensions themselves change (out of scope for this pass).
+   * updated via `view3D.setViewport`, and the underlying Three.js
+   * renderer/camera is resized via `view3D.setSize` so the WebGL drawing
+   * buffer matches the new host-canvas dimensions.
    */
   private relayout(): void {
     const L = getLayout();
 
-    // 3D viewport rect (overlay-side only).
+    // 3D viewport rect (overlay-side) + WebGL drawing buffer + camera aspect.
     this.vizRect = this.computeVizRect(L);
     this.view3D?.setViewport(this.vizRect);
+    this.view3D?.setSize(L.gameWidth, L.gameHeight);
 
     // HUD overlay strip.
     const hudLabelTop = L.contentTop + 18;

--- a/src/scenes/SimPlaybackScene.ts
+++ b/src/scenes/SimPlaybackScene.ts
@@ -665,15 +665,14 @@ export class SimPlaybackScene extends Phaser.Scene {
   private relayout(): void {
     const L = getLayout();
 
-    // 3D galaxy viewport — recompute viewport rect.
-    // TODO(3d-resize): GalaxyView3D's renderer canvas is sized to the design
-    // dimensions captured at construction; only the viewport rect updates here.
+    // 3D galaxy viewport + WebGL drawing buffer + camera aspect.
     const vpX = L.navSidebarWidth;
     const vpY = L.contentTop;
     const vpW = L.gameWidth - L.navSidebarWidth;
     const vpH = L.gameHeight - L.contentTop - L.hudBottomBarHeight;
     this.vizRect = { x: vpX, y: vpY, w: vpW, h: vpH };
     this.view3D?.setViewport(this.vizRect);
+    this.view3D?.setSize(L.gameWidth, L.gameHeight);
 
     const sfW = vpW;
     const sfH = vpH;

--- a/src/scenes/SystemMapScene.ts
+++ b/src/scenes/SystemMapScene.ts
@@ -359,7 +359,7 @@ export class SystemMapScene extends Phaser.Scene {
     }
     this.lockMsg?.setPosition(cx, cy - 20);
 
-    // 3D viewport rect — pure data, safe to update.
+    // 3D viewport rect + WebGL drawing buffer + camera aspect.
     this.vizRect = {
       x: L.mainContentLeft + 4,
       y: L.contentTop + 60,
@@ -367,10 +367,7 @@ export class SystemMapScene extends Phaser.Scene {
       h: L.contentHeight - 130,
     };
     this.view3D?.setViewport(this.vizRect);
-    // TODO(3d-resize): SystemView3D's renderer/camera are sized to the design
-    // dimensions captured at construction. A true 3D resize would require
-    // calling renderer.setSize and updating the camera projection matrix —
-    // out of scope for this UI overlay reflow.
+    this.view3D?.setSize(L.gameWidth, L.gameHeight);
   }
 
   override update(_time: number, delta: number): void {

--- a/src/scenes/galaxy3d/GalaxyView3D.ts
+++ b/src/scenes/galaxy3d/GalaxyView3D.ts
@@ -6,6 +6,7 @@ import type {
   StarSystem,
 } from "../../data/types.ts";
 import type { RouteTrafficVisual } from "../../game/routes/RouteManager.ts";
+import { applyView3DResize } from "../view3d/applyView3DResize.ts";
 
 /**
  * Three.js controller for the 3D galaxy view. Renders star systems as glowing
@@ -101,8 +102,12 @@ export class GalaxyView3D {
   private viewport: ViewportRect = { x: 0, y: 0, w: 0, h: 0 };
 
   private readonly phaserCanvas: HTMLCanvasElement;
-  private readonly designWidth: number;
-  private readonly designHeight: number;
+  // Drawing-buffer size of the WebGL canvas. Initialized from the design
+  // dimensions and then updated by `setSize` whenever the host canvas resizes
+  // so the renderer scissor/viewport math in `render()` stays in canvas-pixel
+  // space and the 3D viewport never gets clipped or stretched.
+  private designWidth: number;
+  private designHeight: number;
 
   private rafId: number | null = null;
   private resizeObserver: ResizeObserver | null = null;
@@ -192,6 +197,21 @@ export class GalaxyView3D {
 
   setViewport(rect: ViewportRect): void {
     this.viewport = rect;
+  }
+
+  /**
+   * Resize the WebGL drawing buffer + camera projection to match the new
+   * host-canvas dimensions. The third arg to renderer.setSize is `false` so
+   * Three.js leaves the canvas's CSS size alone — `syncCanvasPosition` already
+   * mirrors the Phaser canvas's offset/size via inline styles, and we don't
+   * want WebGLRenderer to fight that. After this call the scissor/viewport
+   * math in `render()` (which references designWidth/designHeight) stays in
+   * sync with the actual drawing buffer.
+   */
+  setSize(width: number, height: number): void {
+    this.designWidth = width;
+    this.designHeight = height;
+    applyView3DResize(this.renderer, this.camera, width, height);
   }
 
   setGalaxy(

--- a/src/scenes/system3d/SystemView3D.ts
+++ b/src/scenes/system3d/SystemView3D.ts
@@ -10,6 +10,7 @@ import {
   planetPositionAtTurn,
   type Vec3,
 } from "../../game/system/OrbitalMechanics.ts";
+import { applyView3DResize } from "../view3d/applyView3DResize.ts";
 
 const PLANET_BASE_COLORS: Record<PlanetType, number> = {
   terran: 0x4b86d6,
@@ -73,8 +74,11 @@ export class SystemView3D {
   private routes: ActiveRoute[] = [];
 
   private readonly phaserCanvas: HTMLCanvasElement;
-  private readonly designWidth: number;
-  private readonly designHeight: number;
+  // Drawing-buffer size of the WebGL canvas. Initialized from the design
+  // dimensions and updated by `setSize` whenever the host canvas resizes so
+  // the scissor/viewport math in `render()` stays in canvas-pixel space.
+  private designWidth: number;
+  private designHeight: number;
 
   private rafId: number | null = null;
   private resizeObserver: ResizeObserver | null = null;
@@ -167,6 +171,18 @@ export class SystemView3D {
 
   setViewport(rect: ViewportRect): void {
     this.viewport = rect;
+  }
+
+  /**
+   * Resize the WebGL drawing buffer + camera projection to match the new
+   * host-canvas dimensions. The third arg to renderer.setSize is `false` so
+   * Three.js leaves the canvas's CSS size alone — `syncCanvasPosition` already
+   * mirrors the Phaser canvas's offset/size via inline styles.
+   */
+  setSize(width: number, height: number): void {
+    this.designWidth = width;
+    this.designHeight = height;
+    applyView3DResize(this.renderer, this.camera, width, height);
   }
 
   setSystem(

--- a/src/scenes/view3d/__tests__/applyView3DResize.test.ts
+++ b/src/scenes/view3d/__tests__/applyView3DResize.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { applyView3DResize } from "../applyView3DResize.ts";
+
+describe("applyView3DResize", () => {
+  it("forwards width/height to renderer.setSize with updateStyle=false", () => {
+    const renderer = { setSize: vi.fn() };
+    const camera = { aspect: 1, updateProjectionMatrix: vi.fn() };
+
+    applyView3DResize(renderer, camera, 1920, 1080);
+
+    expect(renderer.setSize).toHaveBeenCalledTimes(1);
+    // updateStyle must be false so Three.js does not overwrite the canvas's
+    // CSS size — both view classes manage that themselves.
+    expect(renderer.setSize).toHaveBeenCalledWith(1920, 1080, false);
+  });
+
+  it("updates camera.aspect to width / height and calls updateProjectionMatrix", () => {
+    const renderer = { setSize: vi.fn() };
+    const camera = { aspect: 1, updateProjectionMatrix: vi.fn() };
+
+    applyView3DResize(renderer, camera, 1600, 900);
+
+    expect(camera.aspect).toBeCloseTo(1600 / 900, 6);
+    expect(camera.updateProjectionMatrix).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not divide by zero when height is 0", () => {
+    const renderer = { setSize: vi.fn() };
+    const camera = { aspect: 2, updateProjectionMatrix: vi.fn() };
+
+    applyView3DResize(renderer, camera, 800, 0);
+
+    // Renderer still resized — caller may temporarily collapse the canvas.
+    expect(renderer.setSize).toHaveBeenCalledWith(800, 0, false);
+    // Aspect must be left untouched so it can never become NaN/Infinity.
+    expect(camera.aspect).toBe(2);
+    expect(camera.updateProjectionMatrix).not.toHaveBeenCalled();
+  });
+});

--- a/src/scenes/view3d/applyView3DResize.ts
+++ b/src/scenes/view3d/applyView3DResize.ts
@@ -1,0 +1,31 @@
+// Shared resize helper for the 3D view classes (GalaxyView3D, SystemView3D).
+// Both views own a WebGLRenderer + PerspectiveCamera pair that needs to stay
+// in sync with the host canvas dimensions. The resize math is identical
+// between them, so it lives here as a single tested function.
+//
+// The `updateStyle: false` flag on renderer.setSize is intentional — both
+// view classes mirror the Phaser canvas's CSS size via syncCanvasPosition,
+// and we don't want Three.js to fight that by writing canvas.style.width /
+// canvas.style.height itself.
+
+export interface ResizableRenderer {
+  setSize(width: number, height: number, updateStyle?: boolean): void;
+}
+
+export interface ResizableCamera {
+  aspect: number;
+  updateProjectionMatrix(): void;
+}
+
+export function applyView3DResize(
+  renderer: ResizableRenderer,
+  camera: ResizableCamera,
+  width: number,
+  height: number,
+): void {
+  renderer.setSize(width, height, false);
+  if (height > 0) {
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+  }
+}


### PR DESCRIPTION
## Summary

Wires up `renderer.setSize` + `camera.aspect` updates on canvas resize for the three map-style scenes whose 2D UI was migrated in #264 but whose Three.js viewport was still pinned to construction-time dimensions. Resolves all `TODO(3d-resize)` markers.

Without this, growing the window left the 3D viewport clipped to the original drawing buffer; shrinking it letterboxed the content.

### Changes

**View3D classes** (the 3D side of the map):

- `src/scenes/galaxy3d/GalaxyView3D.ts` — added `setSize(width, height)`; `designWidth`/`designHeight` are now mutable so the scissor/viewport math in `render()` keeps tracking the live drawing-buffer size.
- `src/scenes/system3d/SystemView3D.ts` — same treatment.
- `src/scenes/view3d/applyView3DResize.ts` (new) — small shared helper invoked by both view classes. Calls `renderer.setSize(w, h, false)` (`updateStyle: false` so Three.js doesn't fight the inline-style canvas placement managed by `syncCanvasPosition`), updates `camera.aspect`, and calls `updateProjectionMatrix()`. Guards against `height === 0` so aspect can't go NaN.

**Scenes** (call sites in `relayout()`):

- `src/scenes/GalaxyMapScene.ts`
- `src/scenes/SystemMapScene.ts`
- `src/scenes/SimPlaybackScene.ts` (also uses `GalaxyView3D`, so the fix lands there for free)

Each `relayout()` now calls `view3D.setSize(L.gameWidth, L.gameHeight)` immediately after `view3D.setViewport(...)`. The `TODO(3d-resize)` comments are gone — `grep -rn "TODO(3d-resize)" src` returns zero matches.

**Test**

- `src/scenes/view3d/__tests__/applyView3DResize.test.ts` — three cases covering renderer.setSize forwarding (with `updateStyle=false`), camera aspect update + `updateProjectionMatrix` call, and the height=0 guard.

## Test plan

- [x] `npm run check` — typecheck + lint + format + 1468 unit tests + production build all pass
- [ ] Manually resize the browser window in dev across `GalaxyMapScene`, `SystemMapScene`, and `SimPlaybackScene` and confirm the 3D viewport reflows without clipping/letterboxing
- [ ] Verify camera framing (aspect, FOV) still looks correct at 16:9, ultrawide, and portrait window shapes

screenshots not applicable: this PR fixes a behavior that only manifests on dynamic window resize, which the static screenshot workflow can't easily exercise. The visual-QA pass at 5 HD resolutions in 4dd18d4 covered the 2D side; this PR is the 3D companion to that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)