### PR TITLE
feat(ui): GalaxySidebarPanel + starfield reflow

### DIFF
--- a/packages/spacebiz-ui/src/Starfield.ts
+++ b/packages/spacebiz-ui/src/Starfield.ts
@@ -41,6 +41,22 @@ export interface StarfieldConfig {
   layers?: StarfieldLayerConfig[];
 }
 
+/**
+ * Handle returned from {@link createStarfield} so consumers (most usefully
+ * scenes that reflow on resize) can re-fit the field to a new viewport
+ * without owning the underlying objects directly.
+ *
+ * `setSize` is implemented as teardown + rebuild because stars are placed
+ * with a fixed random seed at construction time; reflowing each star in
+ * place would require remembering its normalised position and re-deriving
+ * its drift tween targets, which costs more code than the few ms saved.
+ * Mirrors the StandingsGraph reflow precedent.
+ */
+export interface StarfieldHandle {
+  setSize: (width: number, height: number) => void;
+  destroy: () => void;
+}
+
 const DEFAULT_LAYERS: StarfieldLayerConfig[] = [
   {
     count: 110,
@@ -125,149 +141,192 @@ function getEdgeFade(
 export function createStarfield(
   scene: Phaser.Scene,
   config?: StarfieldConfig,
-): void {
-  const drift = config?.drift ?? true;
-  const depth = config?.depth ?? -100;
-  const twinkle = config?.twinkle ?? true;
-  const shimmer = config?.shimmer ?? true;
-  const haze = config?.haze ?? true;
-  const minZoom = Math.max(0.1, config?.minZoom ?? 1);
-  const overscan = config?.overscan ?? 320;
-  const edgeFeather = Phaser.Math.Clamp(config?.edgeFeather ?? 0.2, 0.05, 0.45);
-  const layers = config?.layers ?? DEFAULT_LAYERS;
+): StarfieldHandle {
+  // Track everything we add so setSize / destroy can tear it down cleanly.
+  const containers: Phaser.GameObjects.Container[] = [];
+  const tweens: Phaser.Tweens.Tween[] = [];
+  let destroyed = false;
 
-  const theme = getTheme();
-  const { ambient } = theme;
-  const bounds = resolveBounds(scene, config);
-  const visibleW = scene.scale.width / minZoom;
-  const visibleH = scene.scale.height / minZoom;
+  const build = (cfg: StarfieldConfig | undefined): void => {
+    const drift = cfg?.drift ?? true;
+    const depth = cfg?.depth ?? -100;
+    const twinkle = cfg?.twinkle ?? true;
+    const shimmer = cfg?.shimmer ?? true;
+    const haze = cfg?.haze ?? true;
+    const minZoom = Math.max(0.1, cfg?.minZoom ?? 1);
+    const overscan = cfg?.overscan ?? 320;
+    const edgeFeather = Phaser.Math.Clamp(cfg?.edgeFeather ?? 0.2, 0.05, 0.45);
+    const layers = cfg?.layers ?? DEFAULT_LAYERS;
 
-  // Ambient tweens that need explicit cleanup on scene shutdown
-  const ambientTweens: Phaser.Tweens.Tween[] = [];
+    const theme = getTheme();
+    const { ambient } = theme;
+    const bounds = resolveBounds(scene, cfg);
+    const visibleW = scene.scale.width / minZoom;
+    const visibleH = scene.scale.height / minZoom;
 
-  for (const layer of layers) {
-    // Each layer is a top-level scene object so setScrollFactor creates real parallax.
-    // Nesting layers inside a parent Container breaks scrollFactor — Phaser ignores it
-    // for Container children.
-    const layerContainer = scene.add.container(0, 0);
-    layerContainer.setScrollFactor(layer.scrollFactor);
-    layerContainer.setDepth(depth);
+    for (const layer of layers) {
+      // Each layer is a top-level scene object so setScrollFactor creates real parallax.
+      // Nesting layers inside a parent Container breaks scrollFactor — Phaser ignores it
+      // for Container children.
+      const layerContainer = scene.add.container(0, 0);
+      layerContainer.setScrollFactor(layer.scrollFactor);
+      layerContainer.setDepth(depth);
+      containers.push(layerContainer);
 
-    const layerOverscanX =
-      visibleW * (0.85 + (1 - layer.scrollFactor) * 1.65) + overscan;
-    const layerOverscanY =
-      visibleH * (0.85 + (1 - layer.scrollFactor) * 1.65) + overscan;
-    const spreadW = bounds.width + layerOverscanX * 2;
-    const spreadH = bounds.height + layerOverscanY * 2;
+      const layerOverscanX =
+        visibleW * (0.85 + (1 - layer.scrollFactor) * 1.65) + overscan;
+      const layerOverscanY =
+        visibleH * (0.85 + (1 - layer.scrollFactor) * 1.65) + overscan;
+      const spreadW = bounds.width + layerOverscanX * 2;
+      const spreadH = bounds.height + layerOverscanY * 2;
 
-    if (
-      haze &&
-      layer.hazeAlpha &&
-      layer.hazeScale &&
-      scene.textures.exists("glow-dot")
-    ) {
-      const hazeCount = layer.scrollFactor < 0.2 ? 3 : 2;
-      for (let i = 0; i < hazeCount; i++) {
-        const hazeTint = layer.tints[i % layer.tints.length] ?? 0xffffff;
-        const hazeX =
-          bounds.centerX + (Math.random() - 0.5) * bounds.width * 0.65;
-        const hazeY =
-          bounds.centerY + (Math.random() - 0.5) * bounds.height * 0.65;
-        const hazeSprite = scene.add
-          .image(hazeX, hazeY, "glow-dot")
-          .setTint(hazeTint)
-          .setAlpha(layer.hazeAlpha * (0.7 + Math.random() * 0.5))
-          .setScale(
-            (Math.max(bounds.width, bounds.height) / 64) * layer.hazeScale,
-          )
-          .setBlendMode(Phaser.BlendModes.ADD);
-        layerContainer.add(hazeSprite);
+      if (
+        haze &&
+        layer.hazeAlpha &&
+        layer.hazeScale &&
+        scene.textures.exists("glow-dot")
+      ) {
+        const hazeCount = layer.scrollFactor < 0.2 ? 3 : 2;
+        for (let i = 0; i < hazeCount; i++) {
+          const hazeTint = layer.tints[i % layer.tints.length] ?? 0xffffff;
+          const hazeX =
+            bounds.centerX + (Math.random() - 0.5) * bounds.width * 0.65;
+          const hazeY =
+            bounds.centerY + (Math.random() - 0.5) * bounds.height * 0.65;
+          const hazeSprite = scene.add
+            .image(hazeX, hazeY, "glow-dot")
+            .setTint(hazeTint)
+            .setAlpha(layer.hazeAlpha * (0.7 + Math.random() * 0.5))
+            .setScale(
+              (Math.max(bounds.width, bounds.height) / 64) * layer.hazeScale,
+            )
+            .setBlendMode(Phaser.BlendModes.ADD);
+          layerContainer.add(hazeSprite);
+        }
+      }
+
+      for (let i = 0; i < layer.count; i++) {
+        const x = bounds.centerX + (Math.random() - 0.5) * spreadW;
+        const y = bounds.centerY + (Math.random() - 0.5) * spreadH;
+        const edgeFade = getEdgeFade(
+          x,
+          y,
+          bounds.centerX,
+          bounds.centerY,
+          spreadW,
+          spreadH,
+          edgeFeather,
+        );
+        const alphaRange = layer.maxAlpha - layer.minAlpha;
+        const baseAlpha =
+          (layer.minAlpha + Math.random() * alphaRange) *
+          (0.3 + edgeFade * 0.7);
+        const scale =
+          layer.minScale + Math.random() * (layer.maxScale - layer.minScale);
+
+        const star = scene.add
+          .image(x, y, "glow-dot")
+          .setAlpha(baseAlpha)
+          .setScale(scale);
+
+        const tint =
+          layer.tints[Math.floor(Math.random() * layer.tints.length)] ??
+          0xffffff;
+        const isWhiteStar = tint === 0xffffff;
+        if (tint !== 0xffffff) {
+          star.setTint(tint);
+        }
+
+        layerContainer.add(star);
+
+        if (drift) {
+          const driftX =
+            (-2 + Math.random() * 4) * (0.8 + layer.scrollFactor * 0.6);
+          const driftY =
+            (-2 + Math.random() * 4) * (0.8 + layer.scrollFactor * 0.6);
+          const duration = 7000 + Math.random() * 9000;
+          const tween = scene.tweens.add({
+            targets: star,
+            x: x + driftX,
+            y: y + driftY,
+            duration,
+            yoyo: true,
+            repeat: -1,
+            ease: "Sine.easeInOut",
+          });
+          tweens.push(tween);
+        }
+
+        if (twinkle && Math.random() > 0.65) {
+          const tw = addTwinkleTween(scene, star, {
+            minAlpha: Math.max(0.03, baseAlpha * 0.28),
+            maxAlpha: Math.min(0.95, baseAlpha * 1.55),
+            minDuration: ambient.starTwinkleDurationMin,
+            maxDuration: ambient.starTwinkleDurationMax,
+            delay: Math.random() * ambient.starTwinkleDurationMax,
+          });
+          tweens.push(tw);
+        }
+
+        if (shimmer && isWhiteStar && Math.random() > 0.84) {
+          const shimmerObj = { t: 0 };
+          const dur = ambient.starShimmerDuration + Math.random() * 4000;
+          const tw = scene.tweens.add({
+            targets: shimmerObj,
+            t: 1,
+            duration: dur,
+            delay: Math.random() * dur,
+            yoyo: true,
+            repeat: -1,
+            ease: "Sine.easeInOut",
+            onUpdate: () => {
+              star.setTint(lerpColor(0xffffff, 0xaaccff, shimmerObj.t));
+            },
+          });
+          tweens.push(tw);
+        }
       }
     }
 
-    for (let i = 0; i < layer.count; i++) {
-      const x = bounds.centerX + (Math.random() - 0.5) * spreadW;
-      const y = bounds.centerY + (Math.random() - 0.5) * spreadH;
-      const edgeFade = getEdgeFade(
-        x,
-        y,
-        bounds.centerX,
-        bounds.centerY,
-        spreadW,
-        spreadH,
-        edgeFeather,
-      );
-      const alphaRange = layer.maxAlpha - layer.minAlpha;
-      const baseAlpha =
-        (layer.minAlpha + Math.random() * alphaRange) * (0.3 + edgeFade * 0.7);
-      const scale =
-        layer.minScale + Math.random() * (layer.maxScale - layer.minScale);
-
-      const star = scene.add
-        .image(x, y, "glow-dot")
-        .setAlpha(baseAlpha)
-        .setScale(scale);
-
-      const tint =
-        layer.tints[Math.floor(Math.random() * layer.tints.length)] ?? 0xffffff;
-      const isWhiteStar = tint === 0xffffff;
-      if (tint !== 0xffffff) {
-        star.setTint(tint);
-      }
-
-      layerContainer.add(star);
-
-      if (drift) {
-        const driftX =
-          (-2 + Math.random() * 4) * (0.8 + layer.scrollFactor * 0.6);
-        const driftY =
-          (-2 + Math.random() * 4) * (0.8 + layer.scrollFactor * 0.6);
-        const duration = 7000 + Math.random() * 9000;
-        const tween = scene.tweens.add({
-          targets: star,
-          x: x + driftX,
-          y: y + driftY,
-          duration,
-          yoyo: true,
-          repeat: -1,
-          ease: "Sine.easeInOut",
-        });
-        ambientTweens.push(tween);
-      }
-
-      if (twinkle && Math.random() > 0.65) {
-        const tw = addTwinkleTween(scene, star, {
-          minAlpha: Math.max(0.03, baseAlpha * 0.28),
-          maxAlpha: Math.min(0.95, baseAlpha * 1.55),
-          minDuration: ambient.starTwinkleDurationMin,
-          maxDuration: ambient.starTwinkleDurationMax,
-          delay: Math.random() * ambient.starTwinkleDurationMax,
-        });
-        ambientTweens.push(tw);
-      }
-
-      if (shimmer && isWhiteStar && Math.random() > 0.84) {
-        const shimmerObj = { t: 0 };
-        const dur = ambient.starShimmerDuration + Math.random() * 4000;
-        const tw = scene.tweens.add({
-          targets: shimmerObj,
-          t: 1,
-          duration: dur,
-          delay: Math.random() * dur,
-          yoyo: true,
-          repeat: -1,
-          ease: "Sine.easeInOut",
-          onUpdate: () => {
-            star.setTint(lerpColor(0xffffff, 0xaaccff, shimmerObj.t));
-          },
-        });
-        ambientTweens.push(tw);
-      }
+    // Register cleanup so perpetual tweens stop cleanly on scene shutdown
+    if (tweens.length > 0) {
+      registerAmbientCleanup(scene, tweens);
     }
-  }
+  };
 
-  // Register cleanup so perpetual tweens stop cleanly on scene shutdown
-  if (ambientTweens.length > 0) {
-    registerAmbientCleanup(scene, ambientTweens);
-  }
+  const teardown = (): void => {
+    for (const tw of tweens) {
+      tw.stop();
+    }
+    tweens.length = 0;
+    for (const c of containers) {
+      c.destroy();
+    }
+    containers.length = 0;
+  };
+
+  build(config);
+
+  return {
+    setSize: (width: number, height: number): void => {
+      if (destroyed) return;
+      // Reflow strategy: destroy and rebuild with the new bounds. Stars are
+      // randomly placed, so regenerating with the same config produces a
+      // visually equivalent field at the new size. Cheaper in code than
+      // remembering each star's normalised position + drift origin.
+      teardown();
+      // Drop centerX/centerY from the original config so resolveBounds can
+      // re-derive them from the new width/height — keeping the old centres
+      // would offset the field against the resized viewport.
+      const next: StarfieldConfig = { ...(config ?? {}), width, height };
+      next.centerX = undefined;
+      next.centerY = undefined;
+      build(next);
+    },
+    destroy: (): void => {
+      if (destroyed) return;
+      destroyed = true;
+      teardown();
+    },
+  };
 }

--- a/packages/spacebiz-ui/src/__tests__/feedback/Starfield.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/feedback/Starfield.test.ts
@@ -38,9 +38,72 @@ describe("Starfield", () => {
     scene.textures.add("glow-dot");
   });
 
-  it("returns void (no handle exposed)", () => {
+  it("returns a handle exposing setSize + destroy", () => {
     const handle = createStarfield(scene as never);
-    expect(handle).toBeUndefined();
+    expect(handle).toBeDefined();
+    expect(typeof handle.setSize).toBe("function");
+    expect(typeof handle.destroy).toBe("function");
+  });
+
+  it("setSize tears down old containers and rebuilds with the new bounds", () => {
+    const handle = createStarfield(scene as never, {
+      drift: false,
+      twinkle: false,
+      shimmer: false,
+      haze: false,
+      layers: [
+        {
+          count: 3,
+          scrollFactor: 0.1,
+          minAlpha: 0.2,
+          maxAlpha: 0.5,
+          minScale: 0.5,
+          maxScale: 1.0,
+          tints: [0xffffff],
+        },
+      ],
+    });
+    expect(getLayerContainers(scene).length).toBe(1);
+    const initialContainers = getLayerContainers(scene);
+    handle.setSize(1600, 900);
+    // Old containers were destroyed and removed from the scene; a new one was
+    // added in their place.
+    for (const c of initialContainers) {
+      expect(c.destroyed).toBe(true);
+    }
+    expect(getLayerContainers(scene).length).toBe(1);
+    expect(totalStars(scene)).toBe(3);
+  });
+
+  it("destroy tears down all containers and stops perpetual tweens", () => {
+    const handle = createStarfield(scene as never, {
+      drift: true,
+      twinkle: false,
+      shimmer: false,
+      haze: false,
+      layers: [
+        {
+          count: 2,
+          scrollFactor: 0.1,
+          minAlpha: 0.2,
+          maxAlpha: 0.5,
+          minScale: 0.5,
+          maxScale: 1.0,
+          tints: [0xffffff],
+        },
+      ],
+    });
+    const initial = getLayerContainers(scene);
+    const initialTweens = scene.tweens._all.slice();
+    expect(initial.length).toBe(1);
+    expect(initialTweens.length).toBeGreaterThan(0);
+    handle.destroy();
+    for (const c of initial) {
+      expect(c.destroyed).toBe(true);
+    }
+    for (const t of initialTweens) {
+      expect(t.stopped).toBe(true);
+    }
   });
 
   it("creates one container per default layer", () => {

--- a/packages/spacebiz-ui/src/index.ts
+++ b/packages/spacebiz-ui/src/index.ts
@@ -60,7 +60,7 @@ export { applyClippingMask } from "./MaskUtils.ts";
 
 // Ambient / visual effects
 export { createStarfield } from "./Starfield.ts";
-export type { StarfieldConfig } from "./Starfield.ts";
+export type { StarfieldConfig, StarfieldHandle } from "./Starfield.ts";
 
 export {
   addPulseTween,

--- a/src/scenes/GalaxyMapScene.ts
+++ b/src/scenes/GalaxyMapScene.ts
@@ -11,7 +11,9 @@ import {
   getShipMapKey,
   getShipMapAnimKey,
   attachReflowHandler,
+  GalaxySidebarPanel,
 } from "../ui/index.ts";
+import type { GalaxySidebarData } from "../ui/index.ts";
 import {
   getEmpireFlagKey,
   generateEmpireFlags,
@@ -98,7 +100,7 @@ export class GalaxyMapScene extends Phaser.Scene {
   private companyFilterCycle: (string | null)[] = [null];
   private layerToggles: LayerToggleButton[] = [];
   private companyFilterButton: LayerToggleButton | null = null;
-  private sidebarObjects: Phaser.GameObjects.GameObject[] = [];
+  private sidebar: GalaxySidebarPanel | null = null;
 
   // ── Reflow-tracked overlay chrome ─────────────────────────────────────────
   // Cached so relayout() can reposition without rebuilding the world.
@@ -168,7 +170,7 @@ export class GalaxyMapScene extends Phaser.Scene {
 
     // ── HUD overlay (top-of-content strip) ─────────────────────────────────
     this.buildHud(state, theme, L);
-    this.buildSidebar(state, theme, L);
+    this.buildSidebar(state, L);
     this.buildLayerToggleRow(state, theme, L);
 
     attachReflowHandler(this, () => this.relayout());
@@ -257,8 +259,8 @@ export class GalaxyMapScene extends Phaser.Scene {
         m.nameText.destroy();
       }
       this.empireMarkers = [];
-      for (const obj of this.sidebarObjects) obj.destroy();
-      this.sidebarObjects = [];
+      this.sidebar?.destroy();
+      this.sidebar = null;
       for (const t of this.layerToggles) {
         t.bg.destroy();
         t.label.destroy();
@@ -348,17 +350,15 @@ export class GalaxyMapScene extends Phaser.Scene {
       cf.hit.setPosition(x, rowY);
     }
 
-    // Sidebar contents are ad-hoc text/rect primitives without a sized
-    // container; rebuild so the per-row height clamp re-evaluates
-    // against the new sidebar height. Lifting into a sidebar widget is
-    // future work — out of scope for the setSize sub-widget pass.
-    this.rebuildSidebar();
-  }
-
-  private rebuildSidebar(): void {
-    for (const obj of this.sidebarObjects) obj.destroy();
-    this.sidebarObjects = [];
-    this.buildSidebar(gameStore.getState(), getTheme(), getLayout());
+    // Sidebar widget reflows in place — its row count is height-clamped, so
+    // setSize() may show or hide rows depending on the new content height.
+    // Refresh data alongside the resize so the per-empire row reflects the
+    // latest state (matches the previous rebuildSidebar() behaviour).
+    if (this.sidebar && L.sidebarWidth > 0) {
+      this.sidebar.setPosition(L.sidebarLeft, L.contentTop);
+      this.sidebar.setSize(L.sidebarWidth, L.contentHeight);
+      this.sidebar.setSidebarData(this.gatherSidebarData(gameStore.getState()));
+    }
   }
 
   private buildHud(
@@ -451,63 +451,23 @@ export class GalaxyMapScene extends Phaser.Scene {
    */
   private buildSidebar(
     state: GameState,
-    theme: ReturnType<typeof getTheme>,
     L: ReturnType<typeof getLayout>,
   ): void {
     if (L.sidebarWidth <= 0) return;
-    const x = L.sidebarLeft;
-    const y = L.contentTop;
-    const w = L.sidebarWidth;
-    const h = L.contentHeight;
+    this.sidebar = new GalaxySidebarPanel(this, {
+      x: L.sidebarLeft,
+      y: L.contentTop,
+      width: L.sidebarWidth,
+      height: L.contentHeight,
+    });
+    this.sidebar.setDepth(40);
+    this.sidebar.setSidebarData(this.gatherSidebarData(state));
+  }
 
-    const bg = this.add
-      .rectangle(x, y, w, h, theme.colors.panelBg, 0.55)
-      .setStrokeStyle(1, theme.colors.panelBorder, 0.4)
-      .setOrigin(0, 0)
-      .setDepth(40);
-    this.sidebarObjects.push(bg);
-
-    const titleText = this.add
-      .text(x + 12, y + 12, "Galaxy Overview", {
-        fontSize: `${theme.fonts.heading.size}px`,
-        fontFamily: theme.fonts.heading.family,
-        color: colorToString(theme.colors.accent),
-      })
-      .setDepth(41);
-    this.sidebarObjects.push(titleText);
-
+  private gatherSidebarData(state: GameState): GalaxySidebarData {
     const empires = state.galaxy.empires;
     const systems = state.galaxy.systems;
     const hyperlanes = state.hyperlanes ?? [];
-    const stats = [
-      `Systems: ${systems.length}`,
-      `Empires: ${empires.length}`,
-      `Hyperlanes: ${hyperlanes.length}`,
-      `Player Empire: ${empires.find((e) => e.id === state.playerEmpireId)?.name ?? "—"}`,
-    ];
-    let cy = y + 38;
-    for (const line of stats) {
-      const t = this.add
-        .text(x + 12, cy, line, {
-          fontSize: `${theme.fonts.caption.size}px`,
-          fontFamily: theme.fonts.caption.family,
-          color: colorToString(theme.colors.text),
-        })
-        .setDepth(41);
-      this.sidebarObjects.push(t);
-      cy += 16;
-    }
-
-    cy += 8;
-    const empireHeader = this.add
-      .text(x + 12, cy, "EMPIRES", {
-        fontSize: `${theme.fonts.caption.size}px`,
-        fontFamily: theme.fonts.caption.family,
-        color: colorToString(theme.colors.accent),
-      })
-      .setDepth(41);
-    this.sidebarObjects.push(empireHeader);
-    cy += 20;
 
     // System count per empire so the player can rank empires by size at a
     // glance — matches the visual mass of empire halos in the 3D view.
@@ -522,34 +482,22 @@ export class GalaxyMapScene extends Phaser.Scene {
       (a, b) =>
         (empSystemCount.get(b.id) ?? 0) - (empSystemCount.get(a.id) ?? 0),
     );
-    for (const emp of empiresSorted) {
-      const swatch = this.add
-        .rectangle(x + 12, cy + 6, 10, 10, emp.color)
-        .setOrigin(0, 0.5)
-        .setDepth(41);
-      this.sidebarObjects.push(swatch);
-      const accessible = isEmpireAccessible(emp.id, state);
-      const lockSuffix = accessible ? "" : " 🔒";
-      const sysCount = empSystemCount.get(emp.id) ?? 0;
-      const txt = this.add
-        .text(
-          x + 28,
-          cy,
-          `${emp.name}${lockSuffix}\n${sysCount} systems · ${Math.round(emp.tariffRate * 100)}% tariff`,
-          {
-            fontSize: `${theme.fonts.caption.size}px`,
-            fontFamily: theme.fonts.caption.family,
-            color: colorToString(
-              accessible ? theme.colors.text : theme.colors.textDim,
-            ),
-          },
-        )
-        .setAlpha(accessible ? 1 : 0.6)
-        .setDepth(41);
-      this.sidebarObjects.push(txt);
-      cy += 32;
-      if (cy > y + h - 24) break;
-    }
+
+    return {
+      systemCount: systems.length,
+      empireCount: empires.length,
+      hyperlaneCount: hyperlanes.length,
+      playerEmpireName:
+        empires.find((e) => e.id === state.playerEmpireId)?.name ?? "—",
+      empires: empiresSorted.map((emp) => ({
+        id: emp.id,
+        name: emp.name,
+        color: emp.color,
+        systemCount: empSystemCount.get(emp.id) ?? 0,
+        tariffRate: emp.tariffRate,
+        accessible: isEmpireAccessible(emp.id, state),
+      })),
+    };
   }
 
   /**

--- a/src/scenes/TurnReportScene.ts
+++ b/src/scenes/TurnReportScene.ts
@@ -13,6 +13,7 @@ import {
   getLayout,
   attachReflowHandler,
 } from "../ui/index.ts";
+import type { StarfieldHandle } from "../ui/index.ts";
 import { autoSave } from "../game/SaveManager.ts";
 import type { TurnResult } from "../data/types.ts";
 import type { GameHUDScene } from "./GameHUDScene.ts";
@@ -52,6 +53,7 @@ const TR_PL_ROW_GAP = 20;
 export class TurnReportScene extends Phaser.Scene {
   // Backdrop + structural panels.
   private backdrop?: Phaser.GameObjects.Rectangle;
+  private starfield?: StarfieldHandle;
   private portrait?: PortraitPanel;
   private plPanel?: Panel;
   private routePanel?: Panel;
@@ -122,8 +124,9 @@ export class TurnReportScene extends Phaser.Scene {
       .setOrigin(0, 0)
       .setDepth(-200);
 
-    // Starfield background
-    createStarfield(this);
+    // Starfield background — handle is retained so relayout() can refit it
+    // to the new canvas bounds when the window resizes.
+    this.starfield = createStarfield(this);
 
     // -----------------------------------------------------------------------
     // Left sidebar — PortraitPanel with turn summary
@@ -716,9 +719,10 @@ export class TurnReportScene extends Phaser.Scene {
     // Backdrop covers the full canvas.
     this.backdrop?.setPosition(0, 0).setSize(L.gameWidth, L.gameHeight);
 
-    // Note: createStarfield builds particle emitters sized to the canvas
-    // at create() time; emitters cannot be resized in place. Out of scope
-    // for the sub-widget setSize pass.
+    // Refit the starfield to the new canvas size. Stars are randomly placed,
+    // so the handle internally tears down + rebuilds with the new bounds —
+    // visually equivalent to the original field at the new size.
+    this.starfield?.setSize(L.gameWidth, L.gameHeight);
 
     // Sidebar portrait — setPosition before setSize.
     this.portrait?.setPosition(L.sidebarLeft, L.contentTop);

--- a/src/ui/GalaxySidebarPanel.ts
+++ b/src/ui/GalaxySidebarPanel.ts
@@ -1,0 +1,206 @@
+import * as Phaser from "phaser";
+import { getTheme, colorToString } from "@spacebiz/ui";
+
+/**
+ * Per-empire row data consumed by {@link GalaxySidebarPanel}. The host scene
+ * derives this from `GameState.galaxy.empires` (plus `isEmpireAccessible` and
+ * a per-empire system count) so the widget itself stays free of game-state
+ * imports.
+ */
+export interface GalaxySidebarEmpireRow {
+  id: string;
+  name: string;
+  color: number;
+  systemCount: number;
+  /** Tariff rate as a fraction (e.g. 0.12 for 12 %). */
+  tariffRate: number;
+  accessible: boolean;
+}
+
+export interface GalaxySidebarData {
+  systemCount: number;
+  empireCount: number;
+  hyperlaneCount: number;
+  /** Player empire display name; falls back to "—" when unknown. */
+  playerEmpireName: string;
+  /** Sorted empires (host scene controls the sort order). */
+  empires: GalaxySidebarEmpireRow[];
+}
+
+export interface GalaxySidebarPanelConfig {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const HEADER_OFFSET_Y = 12;
+const STATS_OFFSET_Y = 38;
+const STAT_LINE_HEIGHT = 16;
+const STATS_TO_EMPIRES_GAP = 8;
+const EMPIRES_HEADER_TO_ROWS_GAP = 20;
+const EMPIRE_ROW_HEIGHT = 32;
+const ROW_BOTTOM_PADDING = 24;
+const ROW_LABEL_X = 28;
+const SWATCH_X = 12;
+const SWATCH_SIZE = 10;
+
+/**
+ * Sidebar widget for {@link GalaxyMapScene}. Owns its own layout so the host
+ * scene can call `setSize()` on resize without rebuilding the world (the
+ * previous teardown path).
+ *
+ * The widget renders relative to its container origin (top-left at 0,0) — the
+ * host scene positions it via `setPosition`. `setSidebarData()` re-populates
+ * the empire roster while keeping the panel chrome (background + headers) in
+ * place; `setSize()` reflows everything in place against the new bounds.
+ *
+ * The setter is named `setSidebarData` (not `setData`) to avoid clashing with
+ * Phaser's built-in `Container.setData(key, value)` from its DataManager.
+ */
+export class GalaxySidebarPanel extends Phaser.GameObjects.Container {
+  private panelHeight: number;
+  private currentData: GalaxySidebarData | null = null;
+
+  private bg: Phaser.GameObjects.Rectangle;
+  private titleText: Phaser.GameObjects.Text;
+  private statLabels: Phaser.GameObjects.Text[] = [];
+  private empiresHeader: Phaser.GameObjects.Text;
+
+  // Replaced wholesale by renderEmpireRows() — sized by data length and
+  // height-clamped, so the count varies between calls.
+  private empireRowObjects: Phaser.GameObjects.GameObject[] = [];
+
+  constructor(scene: Phaser.Scene, config: GalaxySidebarPanelConfig) {
+    super(scene, config.x, config.y);
+    this.panelHeight = config.height;
+
+    const theme = getTheme();
+
+    this.bg = scene.add
+      .rectangle(0, 0, config.width, config.height, theme.colors.panelBg, 0.55)
+      .setStrokeStyle(1, theme.colors.panelBorder, 0.4)
+      .setOrigin(0, 0);
+    this.add(this.bg);
+
+    this.titleText = scene.add.text(
+      SWATCH_X,
+      HEADER_OFFSET_Y,
+      "Galaxy Overview",
+      {
+        fontSize: `${theme.fonts.heading.size}px`,
+        fontFamily: theme.fonts.heading.family,
+        color: colorToString(theme.colors.accent),
+      },
+    );
+    this.add(this.titleText);
+
+    // Stat label slots are kept fixed so setSidebarData() can call setText()
+    // instead of recreating them on every state tick.
+    for (let i = 0; i < 4; i++) {
+      const t = scene.add.text(
+        SWATCH_X,
+        STATS_OFFSET_Y + i * STAT_LINE_HEIGHT,
+        "",
+        {
+          fontSize: `${theme.fonts.caption.size}px`,
+          fontFamily: theme.fonts.caption.family,
+          color: colorToString(theme.colors.text),
+        },
+      );
+      this.statLabels.push(t);
+      this.add(t);
+    }
+
+    this.empiresHeader = scene.add.text(
+      SWATCH_X,
+      this.empiresHeaderY(),
+      "EMPIRES",
+      {
+        fontSize: `${theme.fonts.caption.size}px`,
+        fontFamily: theme.fonts.caption.family,
+        color: colorToString(theme.colors.accent),
+      },
+    );
+    this.add(this.empiresHeader);
+
+    scene.add.existing(this);
+  }
+
+  override setSize(width: number, height: number): this {
+    super.setSize(width, height);
+    this.panelHeight = height;
+    this.bg.setSize(width, height);
+    this.empiresHeader.setPosition(SWATCH_X, this.empiresHeaderY());
+    // Re-flow the empire roster against the new height (per-row count is
+    // height-clamped so resizing can show or hide rows).
+    if (this.currentData) {
+      this.renderEmpireRows(this.currentData);
+    }
+    return this;
+  }
+
+  /** Populate the panel with the latest galaxy state. */
+  setSidebarData(data: GalaxySidebarData): this {
+    this.currentData = data;
+    const stats = [
+      `Systems: ${data.systemCount}`,
+      `Empires: ${data.empireCount}`,
+      `Hyperlanes: ${data.hyperlaneCount}`,
+      `Player Empire: ${data.playerEmpireName}`,
+    ];
+    for (let i = 0; i < this.statLabels.length; i++) {
+      this.statLabels[i].setText(stats[i] ?? "");
+    }
+    this.renderEmpireRows(data);
+    return this;
+  }
+
+  private empiresHeaderY(): number {
+    return (
+      STATS_OFFSET_Y +
+      this.statLabels.length * STAT_LINE_HEIGHT +
+      STATS_TO_EMPIRES_GAP
+    );
+  }
+
+  private renderEmpireRows(data: GalaxySidebarData): void {
+    for (const o of this.empireRowObjects) o.destroy();
+    this.empireRowObjects = [];
+
+    const theme = getTheme();
+    const startY = this.empiresHeaderY() + EMPIRES_HEADER_TO_ROWS_GAP;
+    const maxY = this.panelHeight - ROW_BOTTOM_PADDING;
+    let cy = startY;
+
+    for (const emp of data.empires) {
+      if (cy > maxY) break;
+
+      const swatch = this.scene.add
+        .rectangle(SWATCH_X, cy + 6, SWATCH_SIZE, SWATCH_SIZE, emp.color)
+        .setOrigin(0, 0.5);
+      this.add(swatch);
+      this.empireRowObjects.push(swatch);
+
+      const lockSuffix = emp.accessible ? "" : " 🔒";
+      const text = this.scene.add
+        .text(
+          ROW_LABEL_X,
+          cy,
+          `${emp.name}${lockSuffix}\n${emp.systemCount} systems · ${Math.round(emp.tariffRate * 100)}% tariff`,
+          {
+            fontSize: `${theme.fonts.caption.size}px`,
+            fontFamily: theme.fonts.caption.family,
+            color: colorToString(
+              emp.accessible ? theme.colors.text : theme.colors.textDim,
+            ),
+          },
+        )
+        .setAlpha(emp.accessible ? 1 : 0.6);
+      this.add(text);
+      this.empireRowObjects.push(text);
+
+      cy += EMPIRE_ROW_HEIGHT;
+    }
+  }
+}

--- a/src/ui/__tests__/GalaxySidebarPanel.test.ts
+++ b/src/ui/__tests__/GalaxySidebarPanel.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mountComponent } from "../../../packages/spacebiz-ui/src/__tests__/_harness/index.ts";
+import type { MountedComponent } from "../../../packages/spacebiz-ui/src/__tests__/_harness/index.ts";
+import { GalaxySidebarPanel } from "../GalaxySidebarPanel.ts";
+import type { GalaxySidebarData } from "../GalaxySidebarPanel.ts";
+
+function makeData(
+  overrides: Partial<GalaxySidebarData> = {},
+): GalaxySidebarData {
+  return {
+    systemCount: 12,
+    empireCount: 3,
+    hyperlaneCount: 18,
+    playerEmpireName: "Player Empire",
+    empires: [
+      {
+        id: "e1",
+        name: "Solaris",
+        color: 0xff0000,
+        systemCount: 5,
+        tariffRate: 0.12,
+        accessible: true,
+      },
+      {
+        id: "e2",
+        name: "Drax",
+        color: 0x00ff00,
+        systemCount: 4,
+        tariffRate: 0.18,
+        accessible: false,
+      },
+      {
+        id: "e3",
+        name: "Zenthari",
+        color: 0x0000ff,
+        systemCount: 3,
+        tariffRate: 0.05,
+        accessible: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("GalaxySidebarPanel", () => {
+  let mounted: MountedComponent<GalaxySidebarPanel> | undefined;
+
+  afterEach(() => {
+    mounted?.destroy();
+    mounted = undefined;
+  });
+
+  it("populates stat lines and one row per empire when setData is called", async () => {
+    mounted = await mountComponent(
+      (scene) =>
+        new GalaxySidebarPanel(scene, { x: 0, y: 0, width: 240, height: 600 }),
+    );
+    const panel = mounted.component;
+    panel.setSidebarData(makeData());
+
+    // The container holds: bg + title + 4 stat labels + empires header
+    // + (1 swatch + 1 text) per visible empire row.
+    const childCount = panel.list.length;
+    // 1 (bg) + 1 (title) + 4 (stats) + 1 (empires header) = 7 chrome
+    // 3 empires * 2 row objects = 6 dynamic
+    expect(childCount).toBe(7 + 6);
+  }, 15000);
+
+  it("setSize re-flows the row clamp so a small height shows fewer rows", async () => {
+    mounted = await mountComponent(
+      (scene) =>
+        new GalaxySidebarPanel(scene, { x: 0, y: 0, width: 240, height: 600 }),
+    );
+    const panel = mounted.component;
+    panel.setSidebarData(makeData());
+    const fullChildCount = panel.list.length;
+
+    // Shrink to a height that only fits one or two empire rows.
+    panel.setSize(240, 160);
+    const shrunkChildCount = panel.list.length;
+
+    expect(shrunkChildCount).toBeLessThan(fullChildCount);
+  }, 15000);
+
+  it("setData replaces previous empire rows in place", async () => {
+    mounted = await mountComponent(
+      (scene) =>
+        new GalaxySidebarPanel(scene, { x: 0, y: 0, width: 240, height: 600 }),
+    );
+    const panel = mounted.component;
+    panel.setSidebarData(makeData());
+    const beforeCount = panel.list.length;
+
+    // Replace with a single-empire dataset.
+    panel.setSidebarData(
+      makeData({
+        empireCount: 1,
+        empires: [
+          {
+            id: "e1",
+            name: "Solo",
+            color: 0xffffff,
+            systemCount: 12,
+            tariffRate: 0.1,
+            accessible: true,
+          },
+        ],
+      }),
+    );
+    const afterCount = panel.list.length;
+
+    expect(afterCount).toBeLessThan(beforeCount);
+    // 7 chrome + 2 dynamic for the single row = 9
+    expect(afterCount).toBe(9);
+  }, 15000);
+
+  it("setSize updates the background rectangle dimensions", async () => {
+    mounted = await mountComponent(
+      (scene) =>
+        new GalaxySidebarPanel(scene, { x: 0, y: 0, width: 240, height: 600 }),
+    );
+    const panel = mounted.component;
+    panel.setSize(320, 400);
+    const bg = panel.list[0] as unknown as { width: number; height: number };
+    expect(bg.width).toBe(320);
+    expect(bg.height).toBe(400);
+  }, 15000);
+});

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -29,3 +29,10 @@ export type {
   StationBuilderGridData,
   CellEventPayload,
 } from "./StationBuilderGrid.ts";
+
+export { GalaxySidebarPanel } from "./GalaxySidebarPanel.ts";
+export type {
+  GalaxySidebarData,
+  GalaxySidebarEmpireRow,
+  GalaxySidebarPanelConfig,
+} from "./GalaxySidebarPanel.ts";


### PR DESCRIPTION
## Summary

Clears two deferred reflow follow-ups from the fluid-layout rollout (the `// destroy/rebuild on resize` notes left in `GalaxyMapScene.relayout()` and `TurnReportScene.relayout()`).

### Part A — `GalaxySidebarPanel`

- New widget at `src/ui/GalaxySidebarPanel.ts` (extends `Phaser.GameObjects.Container`).
- Public API: `setSize(width, height)` + `setSidebarData(data)`.
  - `setSize` reflows everything in place — the empires header repositions and the row roster reruns its height clamp against the new bounds.
  - `setSidebarData` re-populates the empire roster + stat lines while keeping the static chrome (background, title, headers) intact.
  - The setter is named `setSidebarData` (not `setData`) to avoid clashing with Phaser's built-in `Container.setData(key, value)` from its DataManager.
- `GalaxyMapScene` now holds a single `sidebar` reference instead of a `sidebarObjects[]` array. `rebuildSidebar()` is gone; `relayout()` calls `sidebar.setSize(...) + setSidebarData(gatherSidebarData(state))` directly.
- New unit test at `src/ui/__tests__/GalaxySidebarPanel.test.ts` covering the constructor, `setSidebarData` (replacing rows in place), `setSize` (height clamp shows fewer rows), and the background rectangle resize.

### Part B — Starfield reflow (Option 2)

`createStarfield()` already used regular `Image` + `Container` + tweens (not particle emitters — the deferred comment in `TurnReportScene` was misleading on that point), so an in-place setSize is feasible without ripping into Phaser's particle API. Picked Option 2:

- `createStarfield()` now returns a `StarfieldHandle` exposing `setSize(width, height)` and `destroy()`. The handle internally tracks every container + tween it created.
- `setSize` tears down the existing field and rebuilds with the new bounds. Stars are randomly placed, so regenerating with the same config produces a visually equivalent field at the new size — cheaper in code than remembering each star's normalised position + drift origin. Mirrors the StandingsGraph rebuild precedent.
- Backwards compatible: every other scene currently ignores the return value, so the API change is opt-in. Only `TurnReportScene` wires the handle into its `relayout()`.
- Existing Starfield test updated; new tests cover the `setSize`/`destroy` paths.

Why Option 2 over Option 1: `createStarfield` is called from 16 scenes. A single helper-side handle gives all of them a future opt-in path; doing scene-local rebuild plumbing only in `TurnReportScene` would have left the same hidden trap for the next 15.

## Test plan

- [x] `npm run check` — typecheck + 1487 tests + production build all pass
- [x] New `GalaxySidebarPanel` tests cover setSize + setSidebarData behaviour
- [x] Updated Starfield tests cover handle.setSize (rebuilds with new bounds) + handle.destroy (tears down containers and stops perpetual tweens)
- [ ] Manual: resize the window while on Galaxy Map — sidebar should reflow without flicker
- [ ] Manual: resize the window while on TurnReport — starfield density should adapt to the new viewport

## Screenshots

Screenshots not applicable: this PR is a behavioural refactor (resize-time reflow). Visual output at any single static size is unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)