### PR TITLE
feat(ui): TechTreeGrid class with setSize

### DIFF
--- a/packages/spacebiz-ui/src/__tests__/_harness/mockPhaser.ts
+++ b/packages/spacebiz-ui/src/__tests__/_harness/mockPhaser.ts
@@ -223,6 +223,52 @@ class Rectangle extends GameObject {
   }
 }
 
+class Line extends GameObject {
+  type = "Line";
+  geomX1 = 0;
+  geomY1 = 0;
+  geomX2 = 0;
+  geomY2 = 0;
+  strokeColor = 0;
+  strokeAlpha = 1;
+  lineWidth = 1;
+  constructor(
+    scene: MockScene,
+    x: number,
+    y: number,
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    strokeColor = 0,
+    strokeAlpha = 1,
+  ) {
+    super(scene, x, y);
+    this.geomX1 = x1;
+    this.geomY1 = y1;
+    this.geomX2 = x2;
+    this.geomY2 = y2;
+    this.strokeColor = strokeColor;
+    this.strokeAlpha = strokeAlpha;
+  }
+  setTo(x1: number, y1: number, x2: number, y2: number): this {
+    this.geomX1 = x1;
+    this.geomY1 = y1;
+    this.geomX2 = x2;
+    this.geomY2 = y2;
+    return this;
+  }
+  setStrokeStyle(lineWidth: number, color = 0, alpha = 1): this {
+    this.lineWidth = lineWidth;
+    this.strokeColor = color;
+    this.strokeAlpha = alpha;
+    return this;
+  }
+  setOrigin(_x: number, _y?: number): this {
+    return this;
+  }
+}
+
 class TextObject extends GameObject {
   text: string;
   style: Record<string, unknown>;
@@ -465,6 +511,20 @@ class GameObjectFactory {
       new Rectangle(this.scene, x, y, w, h, fillColor, fillAlpha),
     );
   }
+  line(
+    x: number,
+    y: number,
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    strokeColor = 0,
+    strokeAlpha = 1,
+  ): Line {
+    return this.scene._track(
+      new Line(this.scene, x, y, x1, y1, x2, y2, strokeColor, strokeAlpha),
+    );
+  }
   image(x: number, y: number, key: string): ImageObject {
     return this.scene._track(new ImageObject(this.scene, x, y, key));
   }
@@ -535,6 +595,24 @@ class TimeManager {
   }
 }
 
+class TweenStub {
+  isPlaying = true;
+  stop(): this {
+    this.isPlaying = false;
+    return this;
+  }
+}
+
+class TweenManager {
+  scene: MockScene;
+  constructor(scene: MockScene) {
+    this.scene = scene;
+  }
+  add(_config: Record<string, unknown>): TweenStub {
+    return new TweenStub();
+  }
+}
+
 class KeyboardManager extends EventEmitter {}
 
 class InputManager {
@@ -593,6 +671,7 @@ export class MockScene extends EventEmitter {
   game: GameMock;
   input: InputManager;
   time: TimeManager;
+  tweens: TweenManager;
   children: ChildrenManager;
   cameras: { main: { width: number; height: number } };
   _tracked: GameObject[] = [];
@@ -607,6 +686,7 @@ export class MockScene extends EventEmitter {
     this.game = new GameMock();
     this.input = new InputManager();
     this.time = new TimeManager(this);
+    this.tweens = new TweenManager(this);
     this.children = new ChildrenManager(this);
     this.cameras = { main: { width: 1280, height: 720 } };
   }
@@ -661,12 +741,17 @@ const GameObjectsEvents = {
 export const GameObjects = {
   Container,
   Rectangle,
+  Line,
   Text: TextObject,
   Image: ImageObject,
   Graphics,
   NineSlice,
   GameObject,
   Events: GameObjectsEvents,
+};
+
+export const Tweens = {
+  Tween: TweenStub,
 };
 
 export const Input = {

--- a/src/scenes/TechTreeScene.ts
+++ b/src/scenes/TechTreeScene.ts
@@ -1,10 +1,5 @@
 import * as Phaser from "phaser";
 import { gameStore } from "../data/GameStore.ts";
-import { TechBranch } from "../data/types.ts";
-import type {
-  Technology,
-  TechBranch as TechBranchValue,
-} from "../data/types.ts";
 import { TECH_TREE } from "../data/constants.ts";
 import {
   getTheme,
@@ -19,6 +14,7 @@ import {
   Modal,
   attachReflowHandler,
 } from "../ui/index.ts";
+import { TechTreeGrid, BRANCH_LABELS } from "../ui/TechTreeGrid.ts";
 import {
   isTechAvailable,
   setResearchTarget,
@@ -28,57 +24,13 @@ import {
 } from "../game/tech/TechTree.ts";
 
 // ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const BRANCH_ORDER: TechBranchValue[] = [
-  TechBranch.Logistics,
-  TechBranch.Diplomacy,
-  TechBranch.Engineering,
-  TechBranch.Intelligence,
-  TechBranch.Crisis,
-];
-
-const BRANCH_LABELS: Record<TechBranchValue, string> = {
-  [TechBranch.Logistics]: "Logistics",
-  [TechBranch.Diplomacy]: "Diplomacy",
-  [TechBranch.Engineering]: "Engineering",
-  [TechBranch.Intelligence]: "Intelligence",
-  [TechBranch.Crisis]: "Crisis Mgmt",
-};
-
-const BRANCH_COLORS: Record<TechBranchValue, number> = {
-  [TechBranch.Logistics]: 0x4fc3f7,
-  [TechBranch.Diplomacy]: 0xffd54f,
-  [TechBranch.Engineering]: 0xff8a65,
-  [TechBranch.Intelligence]: 0xce93d8,
-  [TechBranch.Crisis]: 0xef5350,
-};
-
-type NodeState = "locked" | "available" | "researching" | "completed";
-
-interface TechNode {
-  tech: Technology;
-  state: NodeState;
-  x: number;
-  y: number;
-  bg: Phaser.GameObjects.Rectangle;
-  label: Phaser.GameObjects.Text;
-  costLabel: Phaser.GameObjects.Text;
-  hitArea: Phaser.GameObjects.Rectangle;
-  glow?: Phaser.GameObjects.Rectangle;
-  checkmark?: Phaser.GameObjects.Text;
-}
-
-// ---------------------------------------------------------------------------
 // Scene
 // ---------------------------------------------------------------------------
 
 export class TechTreeScene extends Phaser.Scene {
   private portrait!: PortraitPanel;
   private mainPanel!: Panel;
-  private nodes: TechNode[] = [];
-  private gridObjects: Phaser.GameObjects.GameObject[] = [];
+  private grid!: TechTreeGrid;
   private rpStatusText!: Phaser.GameObjects.Text;
   private currentResearchText!: Phaser.GameObjects.Text;
   private progressBar!: ProgressBar;
@@ -92,8 +44,6 @@ export class TechTreeScene extends Phaser.Scene {
 
   create(): void {
     this.selectedTechId = null;
-    this.nodes = [];
-    this.gridObjects = [];
     new SceneUiDirector(this);
     const L = getLayout();
     const theme = getTheme();
@@ -130,7 +80,7 @@ export class TechTreeScene extends Phaser.Scene {
     this.rpStatusText = this.add.text(
       0,
       0,
-      `Total RP: ${state.tech.researchPoints} \u2022 +${rpPerTurn} RP/turn \u2022 Techs: ${state.tech.completedTechIds.length}/20`,
+      `Total RP: ${state.tech.researchPoints} • +${rpPerTurn} RP/turn • Techs: ${state.tech.completedTechIds.length}/20`,
       {
         fontSize: `${theme.fonts.caption.size}px`,
         fontFamily: theme.fonts.caption.family,
@@ -143,8 +93,8 @@ export class TechTreeScene extends Phaser.Scene {
       0,
       0,
       currentResearch
-        ? `\u2699 Researching: ${currentResearch.name}`
-        : "\u2699 No research in progress",
+        ? `⚙ Researching: ${currentResearch.name}`
+        : "⚙ No research in progress",
       {
         fontSize: `${theme.fonts.body.size}px`,
         fontFamily: theme.fonts.body.family,
@@ -179,6 +129,20 @@ export class TechTreeScene extends Phaser.Scene {
         )
         .setOrigin(1, 0);
     }
+
+    // Tech tree grid (sized in relayout)
+    this.grid = new TechTreeGrid(this, {
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      onSelect: (techId) => {
+        this.selectedTechId = techId;
+        this.updateSelectedPortrait();
+        this.updateResearchButton();
+      },
+    });
+    this.grid.setGridState(this.buildGridState());
 
     // ── Research button ──
     this.researchButton = new Button(this, {
@@ -225,275 +189,33 @@ export class TechTreeScene extends Phaser.Scene {
       this.progressLabel.setPosition(panelX + panelW - 16, researchY + 22);
     }
 
-    // Tech-tree grid: deliberately rebuilt on every relayout. Lifting
-    // this into a TechTreeGrid widget with setSize requires extracting
-    // ~250 lines of node/edge/glow-tween bookkeeping that's tightly
-    // coupled to the scene's gridObjects/nodes state. Deferred — the
-    // destroy + rebuild is cheap (≤ ~30 nodes) and only fires on
-    // resize, not per-frame.
-    this.rebuildTechGrid(panelX, panelY, panelW, panelH, researchY);
+    // Tech-tree grid: reflow in place via setSize/setPosition (no rebuild).
+    const gridLeft = panelX + 16;
+    const gridTop = researchY + 46;
+    const gridWidth = panelW - 32;
+    const gridHeight = panelH - (gridTop - panelY) - 60;
+    this.grid.setPosition(gridLeft, gridTop);
+    this.grid.setSize(gridWidth, gridHeight);
 
     // Research button (bottom-left of panel).
     const buttonY = panelY + panelH - 52;
     this.researchButton.setPosition(panelX + 16, buttonY);
 
-    // Sync selection-driven UI (rebuilt nodes lose hover-bound state otherwise).
     this.updateResearchButton();
   }
 
-  // ════════════════════════════════════════════════════════════════
-  // Tech grid build / rebuild
-  // ════════════════════════════════════════════════════════════════
-
-  private rebuildTechGrid(
-    panelX: number,
-    panelY: number,
-    panelW: number,
-    panelH: number,
-    researchY: number,
-  ): void {
-    // Tear down previous grid objects (rectangles, text, lines, glow tweens).
-    for (const obj of this.gridObjects) {
-      obj.destroy();
-    }
-    this.gridObjects = [];
-    this.nodes = [];
-
-    const theme = getTheme();
+  private buildGridState(): {
+    completedTechIds: string[];
+    currentResearchId: string | null;
+    researchProgress: number;
+    isAvailable: (techId: string) => boolean;
+  } {
     const state = gameStore.getState();
-
-    const treeTop = researchY + 46;
-    const treeLeft = panelX + 16;
-    const treeWidth = panelW - 32;
-    const branchCount = BRANCH_ORDER.length;
-    const tiersCount = 4;
-    const rowHeight = Math.min(
-      68,
-      (panelH - (treeTop - panelY) - 60) / branchCount,
-    );
-    const labelColumnWidth = 90;
-    const nodeAreaWidth = treeWidth - labelColumnWidth;
-    const nodeGapX = 8;
-    const nodeWidth = Math.max(
-      60,
-      (nodeAreaWidth - nodeGapX * (tiersCount - 1)) / tiersCount,
-    );
-    const nodeHeight = rowHeight - 12;
-
-    for (let bIdx = 0; bIdx < branchCount; bIdx++) {
-      const branch = BRANCH_ORDER[bIdx];
-      const branchY = treeTop + bIdx * rowHeight;
-      const branchColor = BRANCH_COLORS[branch];
-
-      // Branch label
-      const branchLabel = this.add
-        .text(treeLeft, branchY + nodeHeight / 2, BRANCH_LABELS[branch], {
-          fontSize: `${theme.fonts.caption.size}px`,
-          fontFamily: theme.fonts.caption.family,
-          color: colorToString(branchColor),
-        })
-        .setOrigin(0, 0.5);
-      this.gridObjects.push(branchLabel);
-
-      const branchTechs = TECH_TREE.filter((t) => t.branch === branch).sort(
-        (a, b) => a.tier - b.tier,
-      );
-
-      for (let tIdx = 0; tIdx < branchTechs.length; tIdx++) {
-        const tech = branchTechs[tIdx];
-        const nodeX =
-          treeLeft + labelColumnWidth + tIdx * (nodeWidth + nodeGapX);
-        const nodeY = branchY;
-
-        // Determine state
-        let nodeState: NodeState = "locked";
-        if (state.tech.completedTechIds.includes(tech.id)) {
-          nodeState = "completed";
-        } else if (state.tech.currentResearchId === tech.id) {
-          nodeState = "researching";
-        } else if (isTechAvailable(tech.id, state.tech)) {
-          nodeState = "available";
-        }
-
-        const node = this.createNode(
-          tech,
-          nodeState,
-          nodeX,
-          nodeY,
-          nodeWidth,
-          nodeHeight,
-          branchColor,
-        );
-        this.nodes.push(node);
-        this.gridObjects.push(
-          node.bg,
-          node.label,
-          node.costLabel,
-          node.hitArea,
-        );
-        if (node.glow) this.gridObjects.push(node.glow);
-        if (node.checkmark) this.gridObjects.push(node.checkmark);
-
-        // Connection line to previous tier
-        if (tIdx > 0) {
-          const prevX =
-            treeLeft +
-            labelColumnWidth +
-            (tIdx - 1) * (nodeWidth + nodeGapX) +
-            nodeWidth;
-          const lineY = branchY + nodeHeight / 2;
-          const lineColor = nodeState === "locked" ? 0x333333 : branchColor;
-          const line = this.add
-            .line(0, 0, prevX + 2, lineY, nodeX - 2, lineY, lineColor, 0.5)
-            .setOrigin(0, 0);
-          this.gridObjects.push(line);
-        }
-      }
-    }
-  }
-
-  // ════════════════════════════════════════════════════════════════
-  // Node rendering
-  // ════════════════════════════════════════════════════════════════
-
-  private createNode(
-    tech: Technology,
-    nodeState: NodeState,
-    x: number,
-    y: number,
-    w: number,
-    h: number,
-    branchColor: number,
-  ): TechNode {
-    const theme = getTheme();
-
-    // Background
-    let bgColor = 0x1a1a2e;
-    let bgAlpha = 0.6;
-    let borderColor = 0x333333;
-
-    if (nodeState === "completed") {
-      bgColor = branchColor;
-      bgAlpha = 0.2;
-      borderColor = branchColor;
-    } else if (nodeState === "researching") {
-      bgColor = branchColor;
-      bgAlpha = 0.15;
-      borderColor = branchColor;
-    } else if (nodeState === "available") {
-      borderColor = branchColor;
-      bgAlpha = 0.4;
-    }
-
-    const bg = this.add.rectangle(x + w / 2, y + h / 2, w, h, bgColor, bgAlpha);
-    bg.setStrokeStyle(
-      nodeState === "locked" ? 1 : 2,
-      borderColor,
-      nodeState === "locked" ? 0.3 : 0.8,
-    );
-
-    // Tech name
-    const nameColor =
-      nodeState === "locked"
-        ? colorToString(0x555555)
-        : nodeState === "completed"
-          ? colorToString(branchColor)
-          : colorToString(theme.colors.text);
-
-    const label = this.add.text(x + 4, y + 3, tech.name, {
-      fontSize: "10px",
-      fontFamily: theme.fonts.caption.family,
-      color: nameColor,
-      wordWrap: { width: w - 8 },
-    });
-
-    // Cost label
-    const costText =
-      nodeState === "completed"
-        ? "\u2713"
-        : nodeState === "researching"
-          ? `${gameStore.getState().tech.researchProgress}/${tech.rpCost}`
-          : `${tech.rpCost} RP`;
-    const costColor =
-      nodeState === "completed"
-        ? colorToString(theme.colors.profit)
-        : nodeState === "locked"
-          ? colorToString(0x444444)
-          : colorToString(theme.colors.accent);
-
-    const costLabel = this.add.text(x + w - 4, y + h - 4, costText, {
-      fontSize: "9px",
-      fontFamily: theme.fonts.caption.family,
-      color: costColor,
-    });
-    costLabel.setOrigin(1, 1);
-
-    // Hit area for interaction
-    const hitArea = this.add
-      .rectangle(x + w / 2, y + h / 2, w, h, 0x000000, 0)
-      .setInteractive({ useHandCursor: nodeState !== "locked" });
-
-    hitArea.on("pointerup", () => {
-      this.selectedTechId = tech.id;
-      this.updateSelectedPortrait();
-      this.updateResearchButton();
-    });
-
-    hitArea.on("pointerover", () => {
-      if (nodeState !== "locked") {
-        bg.setStrokeStyle(2, 0xffffff, 0.8);
-      }
-    });
-
-    hitArea.on("pointerout", () => {
-      bg.setStrokeStyle(
-        nodeState === "locked" ? 1 : 2,
-        borderColor,
-        nodeState === "locked" ? 0.3 : 0.8,
-      );
-    });
-
-    // Animated glow for researching node
-    let glow: Phaser.GameObjects.Rectangle | undefined;
-    if (nodeState === "researching") {
-      glow = this.add.rectangle(
-        x + w / 2,
-        y + h / 2,
-        w + 4,
-        h + 4,
-        branchColor,
-        0.15,
-      );
-      this.tweens.add({
-        targets: glow,
-        alpha: { from: 0.08, to: 0.25 },
-        duration: 1200,
-        yoyo: true,
-        repeat: -1,
-      });
-    }
-
-    // Checkmark for completed
-    let checkmark: Phaser.GameObjects.Text | undefined;
-    if (nodeState === "completed") {
-      checkmark = this.add.text(x + w - 8, y + 2, "\u2713", {
-        fontSize: "14px",
-        color: colorToString(theme.colors.profit),
-      });
-      checkmark.setOrigin(1, 0);
-    }
-
     return {
-      tech,
-      state: nodeState,
-      x,
-      y,
-      bg,
-      label,
-      costLabel,
-      hitArea,
-      glow,
-      checkmark,
+      completedTechIds: state.tech.completedTechIds,
+      currentResearchId: state.tech.currentResearchId,
+      researchProgress: state.tech.researchProgress,
+      isAvailable: (techId) => isTechAvailable(techId, state.tech),
     };
   }
 
@@ -513,13 +235,13 @@ export class TechTreeScene extends Phaser.Scene {
 
     let statusLine: string;
     if (isCompleted) {
-      statusLine = "\u2713 Completed";
+      statusLine = "✓ Completed";
     } else if (isResearching) {
-      statusLine = `\u2699 Researching (${state.tech.researchProgress}/${tech.rpCost} RP)`;
+      statusLine = `⚙ Researching (${state.tech.researchProgress}/${tech.rpCost} RP)`;
     } else if (available) {
-      statusLine = "\u2605 Available";
+      statusLine = "★ Available";
     } else {
-      statusLine = "\uD83D\uDD12 Locked (complete prior tier)";
+      statusLine = "🔒 Locked (complete prior tier)";
     }
 
     const details: Array<{ label: string; value: string }> = [

--- a/src/ui/TechTreeGrid.ts
+++ b/src/ui/TechTreeGrid.ts
@@ -1,0 +1,434 @@
+import * as Phaser from "phaser";
+import { getTheme, colorToString } from "@spacebiz/ui";
+import type {
+  Technology,
+  TechBranch as TechBranchValue,
+} from "../data/types.ts";
+import { TechBranch } from "../data/types.ts";
+import { TECH_TREE } from "../data/constants.ts";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type TechNodeState =
+  | "locked"
+  | "available"
+  | "researching"
+  | "completed";
+
+export interface TechTreeGridState {
+  completedTechIds: string[];
+  currentResearchId: string | null;
+  researchProgress: number;
+  /** Pre-computed availability lookup for `available` nodes. */
+  isAvailable: (techId: string) => boolean;
+}
+
+export interface TechTreeGridConfig {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  /** Initial tech state. May be supplied later via `setState`. */
+  state?: TechTreeGridState;
+  /** Fired when a node is clicked. */
+  onSelect?: (techId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Private rendering types
+// ---------------------------------------------------------------------------
+
+const BRANCH_ORDER: TechBranchValue[] = [
+  TechBranch.Logistics,
+  TechBranch.Diplomacy,
+  TechBranch.Engineering,
+  TechBranch.Intelligence,
+  TechBranch.Crisis,
+];
+
+export const BRANCH_LABELS: Record<TechBranchValue, string> = {
+  [TechBranch.Logistics]: "Logistics",
+  [TechBranch.Diplomacy]: "Diplomacy",
+  [TechBranch.Engineering]: "Engineering",
+  [TechBranch.Intelligence]: "Intelligence",
+  [TechBranch.Crisis]: "Crisis Mgmt",
+};
+
+const BRANCH_COLORS: Record<TechBranchValue, number> = {
+  [TechBranch.Logistics]: 0x4fc3f7,
+  [TechBranch.Diplomacy]: 0xffd54f,
+  [TechBranch.Engineering]: 0xff8a65,
+  [TechBranch.Intelligence]: 0xce93d8,
+  [TechBranch.Crisis]: 0xef5350,
+};
+
+interface NodeView {
+  tech: Technology;
+  state: TechNodeState;
+  branchColor: number;
+  bg: Phaser.GameObjects.Rectangle;
+  label: Phaser.GameObjects.Text;
+  costLabel: Phaser.GameObjects.Text;
+  hitArea: Phaser.GameObjects.Rectangle;
+  glow: Phaser.GameObjects.Rectangle;
+  glowTween: Phaser.Tweens.Tween | null;
+  checkmark: Phaser.GameObjects.Text;
+}
+
+interface BranchRow {
+  branch: TechBranchValue;
+  label: Phaser.GameObjects.Text;
+  /** Tier-ordered nodes for this branch. */
+  nodes: NodeView[];
+  /** Connectors between consecutive nodes (line[i] connects nodes[i] -> nodes[i+1]). */
+  connectors: Phaser.GameObjects.Line[];
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Self-contained tech-tree grid. Owns its node sprites, edge lines, hit
+ * areas and the researching-glow tween. Reflows in place via `setSize`,
+ * mutating existing children rather than destroying and rebuilding.
+ *
+ * Construction order:
+ *   1. `new TechTreeGrid(scene, { x, y, width, height })`
+ *   2. (optional) `setState(...)` to apply initial gameplay state.
+ *
+ * Subsequent calls to `setSize` and `setState` are idempotent and
+ * preserve children.
+ */
+export class TechTreeGrid extends Phaser.GameObjects.Container {
+  private gridWidth: number;
+  private gridHeight: number;
+
+  private rows: BranchRow[] = [];
+  private nodeIndex = new Map<string, NodeView>();
+
+  private currentState: TechTreeGridState | null = null;
+  private readonly onSelect: ((techId: string) => void) | undefined;
+
+  constructor(scene: Phaser.Scene, config: TechTreeGridConfig) {
+    super(scene, config.x, config.y);
+    this.gridWidth = config.width;
+    this.gridHeight = config.height;
+    this.onSelect = config.onSelect;
+
+    this.buildSkeleton();
+
+    if (config.state) {
+      this.setGridState(config.state);
+    } else {
+      this.layout();
+    }
+
+    scene.add.existing(this);
+  }
+
+  // ── Public API ─────────────────────────────────────────────
+
+  public setSize(width: number, height: number): this {
+    super.setSize(width, height);
+    this.gridWidth = width;
+    this.gridHeight = height;
+    this.layout();
+    return this;
+  }
+
+  /**
+   * Update visual state of every node based on the current research
+   * progress. Mutates existing children — does not allocate new ones.
+   */
+  public setGridState(state: TechTreeGridState): this {
+    this.currentState = state;
+    for (const node of this.nodeIndex.values()) {
+      const nodeState = this.computeNodeState(node.tech, state);
+      this.applyNodeState(node, nodeState);
+    }
+    // Connector colors depend on node state
+    this.refreshConnectorColors();
+    return this;
+  }
+
+  // ── Skeleton construction (one-time, in constructor) ──────
+
+  private buildSkeleton(): void {
+    const theme = getTheme();
+
+    for (const branch of BRANCH_ORDER) {
+      const branchColor = BRANCH_COLORS[branch];
+
+      const branchLabel = this.scene.add
+        .text(0, 0, BRANCH_LABELS[branch], {
+          fontSize: `${theme.fonts.caption.size}px`,
+          fontFamily: theme.fonts.caption.family,
+          color: colorToString(branchColor),
+        })
+        .setOrigin(0, 0.5);
+      this.add(branchLabel);
+
+      const branchTechs = TECH_TREE.filter((t) => t.branch === branch).sort(
+        (a, b) => a.tier - b.tier,
+      );
+
+      const nodes: NodeView[] = [];
+      const connectors: Phaser.GameObjects.Line[] = [];
+
+      for (let i = 0; i < branchTechs.length; i++) {
+        const tech = branchTechs[i];
+
+        const glow = this.scene.add
+          .rectangle(0, 0, 1, 1, branchColor, 0.15)
+          .setVisible(false);
+        this.add(glow);
+
+        const bg = this.scene.add.rectangle(0, 0, 1, 1, 0x1a1a2e, 0.6);
+        this.add(bg);
+
+        const label = this.scene.add.text(0, 0, tech.name, {
+          fontSize: "10px",
+          fontFamily: theme.fonts.caption.family,
+          color: colorToString(0x555555),
+          wordWrap: { width: 1 },
+        });
+        this.add(label);
+
+        const costLabel = this.scene.add
+          .text(0, 0, `${tech.rpCost} RP`, {
+            fontSize: "9px",
+            fontFamily: theme.fonts.caption.family,
+            color: colorToString(0x444444),
+          })
+          .setOrigin(1, 1);
+        this.add(costLabel);
+
+        const checkmark = this.scene.add
+          .text(0, 0, "✓", {
+            fontSize: "14px",
+            color: colorToString(theme.colors.profit),
+          })
+          .setOrigin(1, 0)
+          .setVisible(false);
+        this.add(checkmark);
+
+        const hitArea = this.scene.add
+          .rectangle(0, 0, 1, 1, 0x000000, 0)
+          .setInteractive({ useHandCursor: false });
+        this.add(hitArea);
+
+        const node: NodeView = {
+          tech,
+          state: "locked",
+          branchColor,
+          bg,
+          label,
+          costLabel,
+          hitArea,
+          glow,
+          glowTween: null,
+          checkmark,
+        };
+
+        hitArea.on("pointerup", () => {
+          if (this.onSelect) this.onSelect(tech.id);
+        });
+        hitArea.on("pointerover", () => {
+          if (node.state !== "locked") {
+            bg.setStrokeStyle(2, 0xffffff, 0.8);
+          }
+        });
+        hitArea.on("pointerout", () => {
+          this.applyNodeStrokeStyle(node);
+        });
+
+        nodes.push(node);
+        this.nodeIndex.set(tech.id, node);
+
+        if (i > 0) {
+          const line = this.scene.add
+            .line(0, 0, 0, 0, 0, 0, 0x333333, 0.5)
+            .setOrigin(0, 0);
+          this.add(line);
+          connectors.push(line);
+        }
+      }
+
+      this.rows.push({ branch, label: branchLabel, nodes, connectors });
+    }
+  }
+
+  // ── Layout / reflow ───────────────────────────────────────
+
+  private layout(): void {
+    const branchCount = BRANCH_ORDER.length;
+    const tiersCount = 4;
+    const rowHeight = Math.min(68, this.gridHeight / branchCount);
+    const labelColumnWidth = 90;
+    const nodeAreaWidth = this.gridWidth - labelColumnWidth;
+    const nodeGapX = 8;
+    const nodeWidth = Math.max(
+      60,
+      (nodeAreaWidth - nodeGapX * (tiersCount - 1)) / tiersCount,
+    );
+    const nodeHeight = rowHeight - 12;
+
+    for (let bIdx = 0; bIdx < this.rows.length; bIdx++) {
+      const row = this.rows[bIdx];
+      const branchY = bIdx * rowHeight;
+
+      row.label.setPosition(0, branchY + nodeHeight / 2);
+
+      for (let tIdx = 0; tIdx < row.nodes.length; tIdx++) {
+        const node = row.nodes[tIdx];
+        const nodeX = labelColumnWidth + tIdx * (nodeWidth + nodeGapX);
+        const nodeY = branchY;
+
+        const cx = nodeX + nodeWidth / 2;
+        const cy = nodeY + nodeHeight / 2;
+
+        node.bg.setPosition(cx, cy);
+        node.bg.setSize(nodeWidth, nodeHeight);
+
+        node.glow.setPosition(cx, cy);
+        node.glow.setSize(nodeWidth + 4, nodeHeight + 4);
+
+        node.label.setPosition(nodeX + 4, nodeY + 3);
+        node.label.setWordWrapWidth(nodeWidth - 8);
+
+        node.costLabel.setPosition(
+          nodeX + nodeWidth - 4,
+          nodeY + nodeHeight - 4,
+        );
+
+        node.checkmark.setPosition(nodeX + nodeWidth - 8, nodeY + 2);
+
+        node.hitArea.setPosition(cx, cy);
+        node.hitArea.setSize(nodeWidth, nodeHeight);
+
+        if (tIdx > 0) {
+          const connector = row.connectors[tIdx - 1];
+          const prevX =
+            labelColumnWidth + (tIdx - 1) * (nodeWidth + nodeGapX) + nodeWidth;
+          const lineY = branchY + nodeHeight / 2;
+          connector.setTo(prevX + 2, lineY, nodeX - 2, lineY);
+        }
+      }
+    }
+  }
+
+  // ── Node state styling ────────────────────────────────────
+
+  private computeNodeState(
+    tech: Technology,
+    state: TechTreeGridState,
+  ): TechNodeState {
+    if (state.completedTechIds.includes(tech.id)) return "completed";
+    if (state.currentResearchId === tech.id) return "researching";
+    if (state.isAvailable(tech.id)) return "available";
+    return "locked";
+  }
+
+  private applyNodeState(node: NodeView, nextState: TechNodeState): void {
+    node.state = nextState;
+    const theme = getTheme();
+    const branchColor = node.branchColor;
+
+    // Background + border
+    let bgColor = 0x1a1a2e;
+    let bgAlpha = 0.6;
+    if (nextState === "completed") {
+      bgColor = branchColor;
+      bgAlpha = 0.2;
+    } else if (nextState === "researching") {
+      bgColor = branchColor;
+      bgAlpha = 0.15;
+    } else if (nextState === "available") {
+      bgAlpha = 0.4;
+    }
+    node.bg.setFillStyle(bgColor, bgAlpha);
+    this.applyNodeStrokeStyle(node);
+
+    // Label color
+    const nameColor =
+      nextState === "locked"
+        ? colorToString(0x555555)
+        : nextState === "completed"
+          ? colorToString(branchColor)
+          : colorToString(theme.colors.text);
+    node.label.setColor(nameColor);
+
+    // Cost label
+    const costText =
+      nextState === "completed"
+        ? "✓"
+        : nextState === "researching"
+          ? `${this.currentState?.researchProgress ?? 0}/${node.tech.rpCost}`
+          : `${node.tech.rpCost} RP`;
+    const costColor =
+      nextState === "completed"
+        ? colorToString(theme.colors.profit)
+        : nextState === "locked"
+          ? colorToString(0x444444)
+          : colorToString(theme.colors.accent);
+    node.costLabel.setText(costText);
+    node.costLabel.setColor(costColor);
+
+    // Hit-area cursor
+    if (node.hitArea.input) {
+      node.hitArea.input.cursor =
+        nextState === "locked" ? "default" : "pointer";
+    }
+
+    // Glow / checkmark visibility
+    node.checkmark.setVisible(nextState === "completed");
+    if (nextState === "researching") {
+      node.glow.setVisible(true);
+      if (!node.glowTween) {
+        node.glowTween = this.scene.tweens.add({
+          targets: node.glow,
+          alpha: { from: 0.08, to: 0.25 },
+          duration: 1200,
+          yoyo: true,
+          repeat: -1,
+        });
+      }
+    } else {
+      node.glow.setVisible(false);
+      if (node.glowTween) {
+        node.glowTween.stop();
+        node.glowTween = null;
+      }
+    }
+  }
+
+  private applyNodeStrokeStyle(node: NodeView): void {
+    const locked = node.state === "locked";
+    const borderColor = locked ? 0x333333 : node.branchColor;
+    node.bg.setStrokeStyle(locked ? 1 : 2, borderColor, locked ? 0.3 : 0.8);
+  }
+
+  private refreshConnectorColors(): void {
+    for (const row of this.rows) {
+      for (let i = 0; i < row.connectors.length; i++) {
+        const targetNode = row.nodes[i + 1];
+        const color =
+          targetNode.state === "locked" ? 0x333333 : row.nodes[0].branchColor;
+        row.connectors[i].setStrokeStyle(1, color, 0.5);
+      }
+    }
+  }
+
+  override destroy(fromScene?: boolean): void {
+    for (const node of this.nodeIndex.values()) {
+      if (node.glowTween) {
+        node.glowTween.stop();
+        node.glowTween = null;
+      }
+    }
+    super.destroy(fromScene);
+  }
+}

--- a/src/ui/__tests__/TechTreeGrid.test.ts
+++ b/src/ui/__tests__/TechTreeGrid.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createMockScene,
+  type MockScene,
+} from "../../../packages/spacebiz-ui/src/__tests__/_harness/mockPhaser.ts";
+
+vi.mock(
+  "phaser",
+  () =>
+    import("../../../packages/spacebiz-ui/src/__tests__/_harness/mockPhaser.ts"),
+);
+
+import { TechTreeGrid } from "../TechTreeGrid.ts";
+import { TECH_TREE } from "../../data/constants.ts";
+import { TechBranch } from "../../data/types.ts";
+
+let scene: MockScene;
+
+beforeEach(() => {
+  scene = createMockScene();
+});
+
+function makeGrid(width = 600, height = 300): TechTreeGrid {
+  return new TechTreeGrid(scene as never, {
+    x: 10,
+    y: 20,
+    width,
+    height,
+  });
+}
+
+function tier1Logistics(): string {
+  const t = TECH_TREE.find(
+    (t) => t.branch === TechBranch.Logistics && t.tier === 1,
+  );
+  if (!t) throw new Error("expected tier-1 logistics tech in TECH_TREE");
+  return t.id;
+}
+
+describe("TechTreeGrid construction", () => {
+  it("creates a container at the configured position", () => {
+    const grid = makeGrid();
+    expect(grid.x).toBe(10);
+    expect(grid.y).toBe(20);
+  });
+
+  it("creates one child per tech node plus connectors and labels", () => {
+    const grid = makeGrid();
+    // Children include: 5 branch labels + 5 nodes × (bg, glow, label, cost, checkmark, hitArea) + connectors.
+    expect(grid.list.length).toBeGreaterThan(0);
+  });
+});
+
+describe("TechTreeGrid.setSize", () => {
+  it("returns the grid instance for chaining", () => {
+    const grid = makeGrid();
+    expect(grid.setSize(800, 400)).toBe(grid);
+  });
+
+  it("syncs inherited width and height", () => {
+    const grid = makeGrid(600, 300);
+    grid.setSize(900, 500);
+    expect(grid.width).toBe(900);
+    expect(grid.height).toBe(500);
+  });
+
+  it("does not add new children to the container", () => {
+    const grid = makeGrid(600, 300);
+    const before = grid.list.length;
+    grid.setSize(900, 500);
+    expect(grid.list.length).toBe(before);
+  });
+
+  it("does not destroy any existing children", () => {
+    const grid = makeGrid(600, 300);
+    const childrenBefore = [...grid.list];
+    grid.setSize(900, 500);
+    for (const c of childrenBefore) {
+      expect((c as unknown as { destroyed: boolean }).destroyed).toBe(false);
+    }
+  });
+});
+
+describe("TechTreeGrid.setState", () => {
+  it("marks completed techs with a visible checkmark", () => {
+    const grid = makeGrid();
+    const techId = tier1Logistics();
+
+    grid.setGridState({
+      completedTechIds: [techId],
+      currentResearchId: null,
+      researchProgress: 0,
+      isAvailable: () => false,
+    });
+
+    // The completed node's checkmark should be visible.
+    // Walk the index via the private map by reflection.
+    const node = (
+      grid as unknown as {
+        nodeIndex: Map<
+          string,
+          {
+            checkmark: { visible: boolean; text?: string };
+            costLabel: { text: string };
+          }
+        >;
+      }
+    ).nodeIndex.get(techId);
+    expect(node).toBeDefined();
+    expect(node!.checkmark.visible).toBe(true);
+    expect(node!.costLabel.text).toBe("✓");
+  });
+
+  it("shows progress on the researching node and hides checkmarks elsewhere", () => {
+    const grid = makeGrid();
+    const techId = tier1Logistics();
+
+    grid.setGridState({
+      completedTechIds: [],
+      currentResearchId: techId,
+      researchProgress: 7,
+      isAvailable: () => false,
+    });
+
+    const node = (
+      grid as unknown as {
+        nodeIndex: Map<
+          string,
+          {
+            checkmark: { visible: boolean };
+            costLabel: { text: string };
+            glow: { visible: boolean };
+            state: string;
+          }
+        >;
+      }
+    ).nodeIndex.get(techId);
+    expect(node).toBeDefined();
+    expect(node!.state).toBe("researching");
+    expect(node!.checkmark.visible).toBe(false);
+    expect(node!.glow.visible).toBe(true);
+    expect(node!.costLabel.text).toContain("/");
+    expect(node!.costLabel.text.startsWith("7/")).toBe(true);
+  });
+
+  it("re-applies state without growing the child list", () => {
+    const grid = makeGrid();
+    const techId = tier1Logistics();
+    const before = grid.list.length;
+
+    grid.setGridState({
+      completedTechIds: [techId],
+      currentResearchId: null,
+      researchProgress: 0,
+      isAvailable: () => false,
+    });
+    grid.setGridState({
+      completedTechIds: [],
+      currentResearchId: techId,
+      researchProgress: 4,
+      isAvailable: () => false,
+    });
+    grid.setGridState({
+      completedTechIds: [],
+      currentResearchId: null,
+      researchProgress: 0,
+      isAvailable: () => true,
+    });
+
+    expect(grid.list.length).toBe(before);
+  });
+});
+
+describe("TechTreeGrid.onSelect", () => {
+  it("invokes the callback with the clicked tech id", () => {
+    const onSelect = vi.fn();
+    const grid = new TechTreeGrid(scene as never, {
+      x: 0,
+      y: 0,
+      width: 600,
+      height: 300,
+      onSelect,
+    });
+    const techId = tier1Logistics();
+
+    const node = (
+      grid as unknown as {
+        nodeIndex: Map<
+          string,
+          {
+            hitArea: { emit: (event: string, ...args: unknown[]) => boolean };
+          }
+        >;
+      }
+    ).nodeIndex.get(techId);
+    expect(node).toBeDefined();
+    node!.hitArea.emit("pointerup");
+
+    expect(onSelect).toHaveBeenCalledWith(techId);
+  });
+});

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -15,3 +15,10 @@ export {
 
 export { StandingsGraph } from "./StandingsGraph.ts";
 export type { StandingsGraphConfig } from "./StandingsGraph.ts";
+
+export { TechTreeGrid } from "./TechTreeGrid.ts";
+export type {
+  TechTreeGridConfig,
+  TechTreeGridState,
+  TechNodeState,
+} from "./TechTreeGrid.ts";


### PR DESCRIPTION
## Summary

Lifts the inline tech-tree grid out of `TechTreeScene` into a dedicated
`TechTreeGrid` widget under `src/ui/TechTreeGrid.ts`. The grid now reflows
in place on resize via `setSize`/`setPosition` instead of the previous
destroy + rebuild path that PR #285 left as a deferred TODO.

- New `TechTreeGrid extends Phaser.GameObjects.Container` owns its node
  sprites, edge lines, hit areas, checkmarks, and the researching-glow
  tween.
- Public surface: `setSize(width, height): this` (mutates existing
  children, no allocation), `setGridState(state): this` (recolors nodes
  from research state), `onSelect` callback.
- `TechTreeScene` instantiates the grid once in `create()` and drives it
  via `setPosition`/`setSize`/`setGridState` from `relayout()`. The
  `gridObjects` array, the destroy loop, and the inline
  `createNode`/`rebuildTechGrid` helpers are gone.
- Re-exported from `src/ui/index.ts` so other scenes can use it.

## New file

- `src/ui/TechTreeGrid.ts` — the extracted widget (~290 LoC including
  layout math, state-driven styling, glow tween lifecycle).

## Test

`src/ui/__tests__/TechTreeGrid.test.ts` mirrors the `Panel.test.ts` shape
and covers:

- Construction — container position, child population.
- `setSize` — chainable, syncs `width`/`height`, does not add or destroy
  children.
- `setGridState` — completed nodes get a visible checkmark and `✓` cost
  text, researching nodes show progress + visible glow, repeat calls
  don't grow the child list.
- `onSelect` — `pointerup` on a node's hit area invokes the callback
  with the tech id.

The `mockPhaser` harness gained a `Line` shape stub, a `line` factory,
and a `TweenManager` so the grid can boot in jsdom-only tests.

## Test plan

- [x] `npm run check` passes (typecheck + tests + build, 1491 tests).
- [ ] QA: open the Research scene at multiple resolutions and resize the
  window — nodes should reflow without flicker, click handlers and the
  researching-glow tween should keep firing.

## Screenshots

screenshots not applicable: pure refactor, no visible behavior change vs
the pre-PR scene at any single resolution. Resize-fluid behavior was
already exercised by the e2e fluid-layout suite (PR #284).

🤖 Generated with [Claude Code](https://claude.com/claude-code)