### PR TITLE
feat(ui): setSize on RouteBuilderPanel and ScrollableList

### DIFF
--- a/packages/spacebiz-ui/src/ScrollableList.ts
+++ b/packages/spacebiz-ui/src/ScrollableList.ts
@@ -36,29 +36,26 @@ export class ScrollableList extends Phaser.GameObjects.Container {
 
   constructor(scene: Phaser.Scene, config: ScrollableListConfig) {
     super(scene, config.x, config.y);
-    this.listConfig = config;
+    this.listConfig = { ...config };
     this.keyboardNavigationEnabled = config.keyboardNavigation ?? false;
 
-    // Clipping mask (Phaser 4 Mask filter)
+    // Clipping mask (Phaser 4 Mask filter). Filled in redraw().
     this.maskGraphics = scene.make.graphics({});
-    this.maskGraphics.fillStyle(0xffffff);
-    this.maskGraphics.fillRect(0, 0, config.width, config.height);
     this.maskGraphics.setPosition(config.x, config.y);
 
     this.contentContainer = scene.add.container(0, 0);
     applyClippingMask(this.contentContainer, this.maskGraphics);
     this.add(this.contentContainer);
 
-    // Wheel capture area (kept behind list content so it doesn't block row clicks)
+    // Wheel capture area (kept behind list content so it doesn't block row
+    // clicks). Sized in redraw().
     this.wheelCapture = scene.add
       .rectangle(0, 0, config.width, config.height, 0x000000, 0)
-      .setOrigin(0, 0)
-      .setInteractive(
-        new Phaser.Geom.Rectangle(0, 0, config.width, config.height),
-        Phaser.Geom.Rectangle.Contains,
-      );
+      .setOrigin(0, 0);
     this.addAt(this.wheelCapture, 0);
     this.wheelCapture.setData("consumesWheel", true);
+
+    this.redraw();
 
     this.wheelCapture.on(
       "wheel",
@@ -400,6 +397,58 @@ export class ScrollableList extends Phaser.GameObjects.Container {
       this.hoverIndicator = null;
       this.currentHoverContainer = null;
     }
+  }
+
+  /**
+   * Resize the viewport. Updates internal dimensions, redraws the mask shape
+   * and wheel hit-area in place, refreshes the scrollbar, and clamps the
+   * current scroll offset to the new bounds.
+   *
+   * Item rows are positioned by `index × itemHeight`, so they don't need
+   * recomputation here — only the viewport-level geometry changes.
+   */
+  public setSize(width: number, height: number): this {
+    super.setSize(width, height);
+    this.listConfig.width = width;
+    this.listConfig.height = height;
+    this.redraw();
+    return this;
+  }
+
+  /**
+   * Mutate existing game objects to match the current viewport width/height.
+   * Called from the constructor and from `setSize()`. Never creates new
+   * children (other than the optional scrollbar elements that
+   * `updateScrollbar()` itself manages).
+   */
+  private redraw(): void {
+    const w = this.listConfig.width;
+    const h = this.listConfig.height;
+
+    // Mask shape — clear + re-fill in place so the same mask object
+    // continues to clip the content container.
+    this.maskGraphics.clear();
+    this.maskGraphics.fillStyle(0xffffff);
+    this.maskGraphics.fillRect(0, 0, w, h);
+
+    // Wheel capture hit-area.
+    this.wheelCapture.width = w;
+    this.wheelCapture.height = h;
+    this.wheelCapture.setInteractive(
+      new Phaser.Geom.Rectangle(0, 0, w, h),
+      Phaser.Geom.Rectangle.Contains,
+    );
+
+    // Recompute scroll bounds for the new viewport, then clamp scrollY.
+    this.maxScroll = Math.max(
+      0,
+      this.items.length * this.listConfig.itemHeight - h,
+    );
+    this.scrollY = Phaser.Math.Clamp(this.scrollY, 0, this.maxScroll);
+    this.contentContainer.y = -this.scrollY;
+
+    // Rebuild scrollbar (track + thumb) for the new dimensions.
+    this.updateScrollbar();
   }
 
   private updateScrollbar(): void {

--- a/packages/spacebiz-ui/src/__tests__/composites/ScrollableList.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/composites/ScrollableList.test.ts
@@ -272,3 +272,120 @@ describe("ScrollableList", () => {
     expect(() => list.destroy()).not.toThrow();
   });
 });
+
+describe("ScrollableList.setSize", () => {
+  let scene: MockScene;
+
+  beforeEach(() => {
+    scene = createMockScene();
+  });
+
+  it("returns the ScrollableList instance for chaining", () => {
+    const list = new ScrollableList(scene as never, {
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 200,
+      itemHeight: 40,
+    });
+    expect(list.setSize(400, 250)).toBe(list);
+  });
+
+  it("syncs inherited width and height", () => {
+    const list = new ScrollableList(scene as never, {
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 200,
+      itemHeight: 40,
+    });
+    list.setSize(450, 350);
+    expect(list.width).toBe(450);
+    expect(list.height).toBe(350);
+  });
+
+  it("updates the wheel capture hit-area to the new dimensions", () => {
+    const list = new ScrollableList(scene as never, {
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 200,
+      itemHeight: 40,
+    });
+    const wheelCapture = list.list[0] as unknown as {
+      width: number;
+      height: number;
+    };
+    list.setSize(500, 300);
+    expect(wheelCapture.width).toBe(500);
+    expect(wheelCapture.height).toBe(300);
+  });
+
+  it("redraws the mask shape in place (no new mask object)", () => {
+    const list = new ScrollableList(scene as never, {
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 200,
+      itemHeight: 40,
+    });
+    const before = (list as unknown as { maskGraphics: object }).maskGraphics;
+    list.setSize(400, 250);
+    const after = (list as unknown as { maskGraphics: object }).maskGraphics;
+    expect(after).toBe(before);
+  });
+
+  it("clamps scrollY when growing the viewport so content no longer overflows", () => {
+    const list = new ScrollableList(scene as never, {
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 100,
+      itemHeight: 40,
+    });
+    // 4 items × 40 = 160 > 100 viewport → maxScroll = 60.
+    for (let i = 0; i < 4; i++) {
+      list.addItem(makeRow(scene, "i") as unknown as never);
+    }
+
+    // Grow the viewport so all content fits — maxScroll becomes 0.
+    list.setSize(300, 400);
+    const internal = list as unknown as {
+      maxScroll: number;
+      scrollY: number;
+      contentContainer: { y: number };
+    };
+    expect(internal.maxScroll).toBe(0);
+    expect(internal.scrollY).toBe(0);
+    // -0 and +0 are both acceptable here.
+    expect(Math.abs(internal.contentContainer.y)).toBe(0);
+  });
+
+  it("does not add new top-level children when content fits both before and after", () => {
+    const list = new ScrollableList(scene as never, {
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 200,
+      itemHeight: 40,
+    });
+    list.addItem(makeRow(scene, "a") as unknown as never);
+    const before = list.list.length;
+    list.setSize(400, 300);
+    expect(list.list.length).toBe(before);
+  });
+
+  it("destroy still works cleanly after a setSize call", () => {
+    const list = new ScrollableList(scene as never, {
+      x: 0,
+      y: 0,
+      width: 300,
+      height: 200,
+      itemHeight: 40,
+      keyboardNavigation: true,
+    });
+    list.addItem(makeRow(scene, "a") as unknown as never);
+    list.setSize(500, 400);
+    expect(() => list.destroy()).not.toThrow();
+  });
+});

--- a/src/scenes/AISandboxScene.ts
+++ b/src/scenes/AISandboxScene.ts
@@ -476,8 +476,8 @@ export class AISandboxScene extends Phaser.Scene {
 
     this.activityHeading.setPosition(leftW + padding, topBarH + 8);
 
-    // ScrollableList width/height are configured at construction; reposition only.
     this.activityList.setPosition(leftW + padding, topBarH + 32);
+    this.activityList.setSize(rightW - padding * 2, contentH - 48);
 
     // Bottom bar.
     this.bottomBarPanel.setPosition(0, L.gameHeight - bottomBarH);

--- a/src/scenes/SandboxSetupScene.ts
+++ b/src/scenes/SandboxSetupScene.ts
@@ -488,10 +488,8 @@ export class SandboxSetupScene extends Phaser.Scene {
 
       this.savePanelTitle.setPosition(panelX + PADDING, savePanelY + 8);
 
-      // ScrollableList width/height are baked at construction; reposition
-      // only. Lifting it into a setSize-aware widget is future work, out
-      // of scope for the sub-widget pass.
       this.saveList.setPosition(panelX + PADDING, savePanelY + 32);
+      this.saveList.setSize(panelW - PADDING * 2, savePanelH - 40);
     }
   }
 

--- a/src/ui/RouteBuilderPanel.ts
+++ b/src/ui/RouteBuilderPanel.ts
@@ -106,24 +106,28 @@ export function openRouteBuilder(
  * directly to the scene's display list via layer.track(). This avoids
  * Phaser Container nesting issues where Button hitZones end up at wrong
  * coordinates and child objects may not render.
+ *
+ * Exported for unit testing of `setSize` reflow behaviour. Production code
+ * should construct it via `openRouteBuilder()`.
  */
-class RouteBuilderPanel {
+export class RouteBuilderPanel {
   private readonly scene: Phaser.Scene;
   private readonly layer: SceneUiLayer;
   private readonly options: RouteBuilderOptions;
   private readonly planets: Planet[];
   private readonly fieldOrder: FieldKey[];
   private readonly keyHandler: (event: KeyboardEvent) => void;
-  private readonly panelX: number;
-  private readonly panelY: number;
-  private readonly panelWidth: number;
-  private readonly panelHeight: number;
+  private panelX: number;
+  private panelY: number;
+  private panelWidth: number;
+  private panelHeight: number;
   private originIndex: number;
   private destinationIndex: number;
   private cargoIndex: number;
   private shipOptionIndex = 0;
   private focusedFieldIndex = 0;
   private autoBuy: boolean;
+  private panel!: Panel;
   private titleValue!: Label;
   private originValue!: Label;
   private destinationValue!: Label;
@@ -140,6 +144,13 @@ class RouteBuilderPanel {
   private cargoIcon!: Phaser.GameObjects.Image;
   private fieldLabels = new Map<FieldKey, Label>();
   private fieldValues = new Map<FieldKey, Label>();
+  private fieldArrows = new Map<FieldKey, { left: Button; right: Button }>();
+  private statsTitle!: Label;
+  private mktTitle!: Label;
+  private pickerHint!: Label;
+  private confirmButton!: Button;
+  private cancelButton!: Button;
+  private closeButton!: Button;
   private pickerMap: RoutePickerMap | null = null;
   private nextClickSlot: "origin" | "destination" = "origin";
   private hoveredPlanetId: string | null = null;
@@ -179,17 +190,17 @@ class RouteBuilderPanel {
       ? ["destination", "cargo", "ship", "autoBuy"]
       : ["origin", "destination", "cargo", "ship", "autoBuy"];
 
-    const panel = new Panel(scene, {
+    this.panel = new Panel(scene, {
       x: this.panelX,
       y: this.panelY,
       width: this.panelWidth,
       height: this.panelHeight,
       title: options.title ?? "Route Builder",
     });
-    panel.setDepth(DEPTH_MODAL);
-    layer.track(panel);
+    this.panel.setDepth(DEPTH_MODAL);
+    layer.track(this.panel);
 
-    const content = panel.getContentArea();
+    const content = this.panel.getContentArea();
 
     this.titleValue = new Label(scene, {
       x: this.panelX + content.x,
@@ -252,15 +263,15 @@ class RouteBuilderPanel {
 
     rowY += 58;
 
-    const statsTitle = new Label(scene, {
+    this.statsTitle = new Label(scene, {
       x: this.panelX + content.x,
       y: this.panelY + rowY,
       text: "Route preview",
       style: "body",
       color: getTheme().colors.accent,
     });
-    statsTitle.setDepth(DEPTH_MODAL);
-    layer.track(statsTitle);
+    this.statsTitle.setDepth(DEPTH_MODAL);
+    layer.track(this.statsTitle);
 
     rowY += 30;
     this.distanceValue = this.createSummaryLabel(content.x, rowY);
@@ -281,15 +292,15 @@ class RouteBuilderPanel {
     rowY += 36;
 
     // ── Market Intel section ──────────────────────────────────
-    const mktTitle = new Label(scene, {
+    this.mktTitle = new Label(scene, {
       x: this.panelX + content.x,
       y: this.panelY + rowY,
       text: "Market Intel",
       style: "body",
       color: getTheme().colors.accent,
     });
-    mktTitle.setDepth(DEPTH_MODAL);
-    layer.track(mktTitle);
+    this.mktTitle.setDepth(DEPTH_MODAL);
+    layer.track(this.mktTitle);
     rowY += 26;
 
     this.mktOriginPriceValue = this.createSummaryLabel(content.x, rowY);
@@ -332,7 +343,7 @@ class RouteBuilderPanel {
     for (const obj of this.pickerMap.getGameObjects()) {
       layer.track(obj);
     }
-    const pickerHint = new Label(scene, {
+    this.pickerHint = new Label(scene, {
       x: pickerMapX,
       y: pickerMapY - 18,
       text: "Click a planet to set origin → click another for destination",
@@ -340,10 +351,10 @@ class RouteBuilderPanel {
       color: getTheme().colors.textDim,
       maxWidth: pickerMapWidth,
     });
-    pickerHint.setDepth(DEPTH_MODAL);
-    layer.track(pickerHint);
+    this.pickerHint.setDepth(DEPTH_MODAL);
+    layer.track(this.pickerHint);
 
-    const confirmButton = new Button(scene, {
+    this.confirmButton = new Button(scene, {
       x: this.panelX + content.x,
       y: this.panelY + this.panelHeight - 54,
       width: 180,
@@ -352,10 +363,10 @@ class RouteBuilderPanel {
         this.confirm();
       },
     });
-    confirmButton.setDepth(DEPTH_MODAL);
-    layer.track(confirmButton);
+    this.confirmButton.setDepth(DEPTH_MODAL);
+    layer.track(this.confirmButton);
 
-    const cancelButton = new Button(scene, {
+    this.cancelButton = new Button(scene, {
       x: this.panelX + this.panelWidth - content.x - 130,
       y: this.panelY + this.panelHeight - 54,
       width: 130,
@@ -364,10 +375,10 @@ class RouteBuilderPanel {
         this.cancel();
       },
     });
-    cancelButton.setDepth(DEPTH_MODAL);
-    layer.track(cancelButton);
+    this.cancelButton.setDepth(DEPTH_MODAL);
+    layer.track(this.cancelButton);
 
-    const closeButton = new Button(scene, {
+    this.closeButton = new Button(scene, {
       x: this.panelX + this.panelWidth - 58,
       y: this.panelY + 8,
       width: 42,
@@ -377,8 +388,8 @@ class RouteBuilderPanel {
         this.cancel();
       },
     });
-    closeButton.setDepth(DEPTH_MODAL);
-    layer.track(closeButton);
+    this.closeButton.setDepth(DEPTH_MODAL);
+    layer.track(this.closeButton);
 
     this.keyHandler = (event: KeyboardEvent) => {
       this.handleKeyDown(event);
@@ -387,6 +398,128 @@ class RouteBuilderPanel {
     layer.onDestroy(() => this.destroy());
 
     this.refreshUi();
+  }
+
+  /**
+   * Resize the route-builder panel and reflow all of its children. Delegates
+   * the size update to the inner `Panel`, then repositions every tracked
+   * label, button, and the picker map relative to the new bounds.
+   *
+   * The panel is normally a modal that re-instantiates per open, but having
+   * `setSize` available keeps the widget consistent with `Panel`,
+   * `AdviserPanel`, and `PortraitPanel` and lets callers track viewport
+   * resizes while the modal is open.
+   */
+  public setSize(width: number, height: number): this {
+    this.panelWidth = width;
+    this.panelHeight = height;
+    this.panel.setSize(width, height);
+    this.redraw();
+    return this;
+  }
+
+  /**
+   * Reposition every tracked child to match the current panel bounds.
+   * Called from `setSize()`. Mirrors the layout offsets used in the
+   * constructor so changes here must stay in sync there.
+   */
+  private redraw(): void {
+    const content = this.panel.getContentArea();
+    const contentLeft = this.panelX + content.x;
+    const contentTop = (rowY: number): number => this.panelY + rowY;
+    const place = (
+      child: { setPosition: (x: number, y: number) => unknown },
+      rowY: number,
+    ): void => {
+      child.setPosition(contentLeft, contentTop(rowY));
+    };
+
+    place(this.titleValue, content.y);
+    place(this.hintValue, content.y + 26);
+
+    // Field rows (origin/destination/cargo/ship). The rowY sequence below
+    // mirrors the constructor's `rowY` accumulator exactly.
+    const rowOffsets: Array<{ field: FieldKey; rowY: number }> = [
+      { field: "origin", rowY: content.y + 66 },
+      { field: "destination", rowY: content.y + 66 + 46 },
+      { field: "cargo", rowY: content.y + 66 + 46 * 2 },
+      { field: "ship", rowY: content.y + 66 + 46 * 3 },
+    ];
+    const contentX = 16;
+    for (const { field, rowY } of rowOffsets) {
+      this.fieldLabels
+        .get(field)
+        ?.setPosition(this.panelX + contentX, contentTop(rowY + 4));
+      this.fieldValues
+        .get(field)
+        ?.setPosition(this.panelX + contentX + 120, contentTop(rowY + 4));
+      const arrows = this.fieldArrows.get(field);
+      arrows?.left.setPosition(this.panelX + 430, contentTop(rowY));
+      arrows?.right.setPosition(this.panelX + 478, contentTop(rowY));
+    }
+
+    // Cargo icon hugs the cargo value label.
+    const cargoRow = this.fieldValues.get("cargo");
+    if (cargoRow) {
+      this.cargoIcon.setPosition(cargoRow.x - 22, cargoRow.y + 8);
+    }
+
+    // Auto-buy / preview / market intel column (left).
+    let rowY = content.y + 66 + 46 * 3 + 56; // ship row + 56 spacer
+    place(this.autoBuyButton, rowY);
+    rowY += 58;
+    place(this.statsTitle, rowY);
+    rowY += 30;
+    place(this.distanceValue, rowY);
+    rowY += 24;
+    place(this.recommendationValue, rowY);
+    rowY += 24;
+    place(this.statusValue, rowY);
+    rowY += 32;
+    place(this.revenueValue, rowY);
+    rowY += 24;
+    place(this.fuelValue, rowY);
+    rowY += 24;
+    place(this.profitValue, rowY);
+    rowY += 36;
+    place(this.mktTitle, rowY);
+    rowY += 26;
+    place(this.mktOriginPriceValue, rowY);
+    rowY += 22;
+    place(this.mktDestPriceValue, rowY);
+    rowY += 22;
+    place(this.mktOriginSupplyValue, rowY);
+    rowY += 22;
+    place(this.mktDestDemandValue, rowY);
+    rowY += 22;
+    place(this.mktTrendValue, rowY);
+    rowY += 22;
+    place(this.mktSaturationValue, rowY);
+
+    // Picker hint anchored to the picker-map column. The picker map itself
+    // currently has no `setBounds` API (it locks `x/y/width/height` at
+    // construction), so its rendered geometry doesn't track `setSize`.
+    // Modal lifecycle keeps the panel re-instantiated per open in practice.
+    const pickerColumnLeft = 540;
+    const pickerMapX = this.panelX + pickerColumnLeft;
+    const pickerMapY = this.panelY + content.y + 70;
+    this.pickerHint.setPosition(pickerMapX, pickerMapY - 18);
+
+    // Action buttons along the bottom edge.
+    this.confirmButton.setPosition(
+      this.panelX + content.x,
+      this.panelY + this.panelHeight - 54,
+    );
+    this.cancelButton.setPosition(
+      this.panelX + this.panelWidth - content.x - 130,
+      this.panelY + this.panelHeight - 54,
+    );
+    this.closeButton.setPosition(
+      this.panelX + this.panelWidth - 58,
+      this.panelY + 8,
+    );
+
+    this.refreshPickerMap();
   }
 
   private createSummaryLabel(x: number, y: number, color?: number): Label {
@@ -461,6 +594,7 @@ class RouteBuilderPanel {
     });
     rightButton.setDepth(DEPTH_MODAL);
     this.layer.track(rightButton);
+    this.fieldArrows.set(field, { left: leftButton, right: rightButton });
   }
 
   private getInitialOriginIndex(): number {

--- a/src/ui/__tests__/RouteBuilderPanel.test.ts
+++ b/src/ui/__tests__/RouteBuilderPanel.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, afterEach } from "vitest";
+import * as Phaser from "phaser";
+import { mountComponent } from "../../../packages/spacebiz-ui/src/__tests__/_harness/mountComponent.ts";
+import type { MountedComponent } from "../../../packages/spacebiz-ui/src/__tests__/_harness/mountComponent.ts";
+import { SceneUiDirector } from "@spacebiz/ui";
+import { RouteBuilderPanel } from "../RouteBuilderPanel.ts";
+
+interface ProbeShape {
+  panelWidth: number;
+  panelHeight: number;
+  panel: {
+    setSize: (w: number, h: number) => unknown;
+    width: number;
+    height: number;
+  };
+  confirmButton: Phaser.GameObjects.Container;
+  cancelButton: Phaser.GameObjects.Container;
+  closeButton: Phaser.GameObjects.Container;
+  hintValue: Phaser.GameObjects.Container;
+  titleValue: Phaser.GameObjects.Container;
+  setSize: (w: number, h: number) => ProbeShape;
+}
+
+/**
+ * RouteBuilderPanel.setSize tests. Boots a real headless Phaser scene per
+ * test and constructs the panel with the default gameStore state (which
+ * includes a galaxy with planets, so route-builder construction succeeds).
+ *
+ * Mirrors the shape of `Panel.setSize` tests in spacebiz-ui: dimensions
+ * update, children reposition, no new objects materialize.
+ */
+describe("RouteBuilderPanel.setSize", () => {
+  let mounted: MountedComponent<RouteBuilderPanel> | undefined;
+
+  afterEach(() => {
+    mounted?.destroy();
+    mounted = undefined;
+  });
+
+  async function mount(): Promise<ProbeShape> {
+    mounted = await mountComponent((scene) => {
+      const ui = new SceneUiDirector(scene);
+      const layer = ui.openLayer({ key: "route-builder-test" });
+      return new RouteBuilderPanel(scene, layer, { ui });
+    });
+    return mounted.component as unknown as ProbeShape;
+  }
+
+  it("returns the panel instance for chaining", async () => {
+    const panel = await mount();
+    expect(panel.setSize(700, 500)).toBe(panel);
+  }, 15000);
+
+  it("updates the stored panelWidth and panelHeight", async () => {
+    const panel = await mount();
+    panel.setSize(700, 500);
+    expect(panel.panelWidth).toBe(700);
+    expect(panel.panelHeight).toBe(500);
+  }, 15000);
+
+  it("delegates the size update to the inner Panel", async () => {
+    const panel = await mount();
+    panel.setSize(700, 500);
+    expect(panel.panel.width).toBe(700);
+    expect(panel.panel.height).toBe(500);
+  }, 15000);
+
+  it("repositions the bottom-row action buttons relative to the new panel height", async () => {
+    const panel = await mount();
+    const before = panel.confirmButton.y;
+    panel.setSize(panel.panelWidth, panel.panelHeight + 200);
+    const after = panel.confirmButton.y;
+    expect(after - before).toBe(200);
+  }, 15000);
+
+  it("repositions the cancel button along the new right edge", async () => {
+    const panel = await mount();
+    const before = panel.cancelButton.x;
+    panel.setSize(panel.panelWidth + 100, panel.panelHeight);
+    const after = panel.cancelButton.x;
+    expect(after - before).toBe(100);
+  }, 15000);
+
+  it("repositions the close button to the new top-right corner", async () => {
+    const panel = await mount();
+    const before = panel.closeButton.x;
+    panel.setSize(panel.panelWidth + 80, panel.panelHeight);
+    const after = panel.closeButton.x;
+    expect(after - before).toBe(80);
+  }, 15000);
+});


### PR DESCRIPTION
## Summary

Closes the two composite widgets explicitly skipped in PR #285's sub-widget `setSize` sweep:

- **`ScrollableList`** — `setSize(width, height)` refreshes the clipping mask, wheel hit-area, scrollbar (track + thumb), and clamps `scrollY` to the new content extent. Item rows stay at `index × itemHeight`, so only the viewport-level geometry changes. Mirrors `ScrollFrame.setSize` precedent (mask redrawn in place via `clear() + fillRect`, no new mask object).
- **`RouteBuilderPanel`** — `setSize` delegates the size update to the inner `Panel`, then reflows every tracked label/button/picker-hint relative to the new bounds. The picker map itself locks `x/y/width/height` at construction (no `setBounds` API), so its rendered geometry doesn't track resizes — documented inline; modal lifecycle keeps the panel re-instantiated per open in practice.
- Consumer scenes updated:
  - `AISandboxScene.relayout()` now calls `activityList.setSize(...)` after positioning, replacing the prior "configured at construction; reposition only" comment.
  - `SandboxSetupScene.relayout()` now calls `saveList.setSize(...)`, removing the prior "future work" TODO comment.

Tests:
- `packages/spacebiz-ui/src/__tests__/composites/ScrollableList.test.ts` adds a `ScrollableList.setSize` block (chaining, dimension sync, wheel-capture resize, mask reuse, scroll clamp on viewport grow).
- `src/ui/__tests__/RouteBuilderPanel.test.ts` (new) boots a real headless Phaser scene via `mountComponent` and asserts `setSize` updates `panelWidth`/`panelHeight`, delegates to the inner Panel, and shifts the bottom action buttons / right-edge close button.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` passes (1494 tests, all 132 → 133 files)
- [x] `npm run build` passes
- [x] `npm run lint` reports only pre-existing warnings (no new ones)
- [x] `npm run format:check` clean

Screenshots: not applicable — this PR adds resize APIs to widgets but the bottom-row action buttons and saveList/activityList reflow already render identically at first paint (their layouts are unchanged at construction). Behaviour change is only observable when the viewport resizes after mount, which is exercised by unit tests rather than visual regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)