### PR TITLE
feat(ui): StationBuilderGrid class with setSize

### DIFF
--- a/packages/spacebiz-ui/src/Panel.ts
+++ b/packages/spacebiz-ui/src/Panel.ts
@@ -187,6 +187,17 @@ export class Panel extends Phaser.GameObjects.Container {
     return this.contentY;
   }
 
+  /**
+   * Update the panel title text in place. No-op for panels constructed
+   * without a `title` (no title bar exists to mutate).
+   */
+  public setTitle(title: string): this {
+    if (this.titleText) {
+      this.titleText.setText(title);
+    }
+    return this;
+  }
+
   getContentArea(): { x: number; y: number; width: number; height: number } {
     const theme = getTheme();
     return {

--- a/src/scenes/StationBuilderScene.ts
+++ b/src/scenes/StationBuilderScene.ts
@@ -12,14 +12,15 @@ import {
   Label,
   Modal,
   attachReflowHandler,
+  StationBuilderGrid,
+  ROOM_COLORS,
 } from "../ui/index.ts";
+import type { CellEventPayload } from "../ui/StationBuilderGrid.ts";
 import {
   HUB_ROOM_DEFINITIONS,
   HUB_UPGRADE_COSTS,
   HUB_LEVEL_SLOTS,
   HUB_MAX_LEVEL,
-  HUB_GRID_DECKS,
-  HUB_GRID_SLOTS_PER_DECK,
   HUB_DEMOLISH_REFUND_RATIO,
   HUB_UPGRADE_ONLY_ROOMS,
 } from "../data/constants.ts";
@@ -41,28 +42,6 @@ function formatCash(n: number): string {
   const abs = Math.abs(Math.round(n));
   return sign + "\u00A7" + abs.toLocaleString("en-US");
 }
-
-/** Color each room type consistently */
-const ROOM_COLORS: Record<string, number> = {
-  simpleTerminal: 0x00eeff,
-  improvedTerminal: 0x00ccff,
-  advancedTerminal: 0x00aaff,
-  tradeOffice: 0x00ccaa,
-  passengerLounge: 0xaa66ff,
-  oreProcessing: 0xcc8844,
-  foodTerminal: 0x66cc44,
-  techTerminal: 0x44ddff,
-  luxuryTerminal: 0xffcc00,
-  hazmatTerminal: 0xff6644,
-  medicalTerminal: 0xff66aa,
-  fuelDepot: 0x44aaff,
-  marketExchange: 0xffcc00,
-  customsBureau: 0x88cc44,
-  repairBay: 0xff4488,
-  researchLab: 0x44ddff,
-  cargoWarehouse: 0xcc8844,
-  securityOffice: 0xdd4444,
-};
 
 /** Deterministic seed for procedural portraits per room type */
 function roomPortraitSeed(roomType: string): number {
@@ -115,7 +94,6 @@ export class StationBuilderScene extends Phaser.Scene {
   private portrait!: PortraitPanel;
   private selectedRoomType: HubRoomType | null = null;
   private selectedRoomId: string | null = null;
-  private gridCells: Phaser.GameObjects.Rectangle[][] = [];
   private roomCardWidth = 110;
   private roomCardHeight = 50;
   private gridPanel!: Panel;
@@ -125,12 +103,7 @@ export class StationBuilderScene extends Phaser.Scene {
   private infoElements: Phaser.GameObjects.GameObject[] = [];
   private dragGhost: Phaser.GameObjects.Container | null = null;
   private dragRoomType: HubRoomType | null = null;
-  private gridSlotBounds: Array<{
-    gx: number;
-    gy: number;
-    bounds: Phaser.Geom.Rectangle;
-    valid: boolean;
-  }> = [];
+  private grid!: StationBuilderGrid;
   private handlePointerMove = (p: Phaser.Input.Pointer): void => {
     this.onDragMove(p);
   };
@@ -150,7 +123,6 @@ export class StationBuilderScene extends Phaser.Scene {
     this.infoElements = [];
     this.dragGhost = null;
     this.dragRoomType = null;
-    this.gridSlotBounds = [];
 
     createStarfield(this);
 
@@ -173,18 +145,26 @@ export class StationBuilderScene extends Phaser.Scene {
       y: L.contentTop,
       width: L.mainContentWidth,
       height: gridH,
-      title: hub
-        ? `Station Grid — Level ${hub.level} (${hub.rooms.length}/${HUB_LEVEL_SLOTS[hub.level]} slots)`
-        : "No Hub Station",
+      title: this.gridTitle(hub),
     });
 
-    const gridMetrics = this.getGridMetrics();
-    this.roomCardWidth = Math.floor(gridMetrics.cellW);
-    this.roomCardHeight = Math.floor(gridMetrics.cellH);
+    // ── Placement grid widget (overlays the panel content area) ──
+    const gridArea = this.getGridArea();
+    this.grid = new StationBuilderGrid(this, {
+      x: gridArea.x,
+      y: gridArea.y,
+      width: gridArea.width,
+      height: gridArea.height,
+    });
+    this.grid.setRooms({
+      rooms: hub ? hub.rooms : [],
+      maxSlots: hub ? HUB_LEVEL_SLOTS[hub.level] : 0,
+    });
+    this.grid.on("cell:click", (e: CellEventPayload) => this.onCellClick(e));
 
-    if (hub) {
-      this.buildGrid(hub);
-    }
+    const cellSize = this.grid.getCellSize();
+    this.roomCardWidth = Math.floor(cellSize.cellW);
+    this.roomCardHeight = Math.floor(cellSize.cellH);
 
     // ── Room Palette / Build Panel (middle) ──
     const paletteY = L.contentTop + gridH + PANEL_GAP;
@@ -296,17 +276,12 @@ export class StationBuilderScene extends Phaser.Scene {
   /**
    * Reflow panel positions/sizes on resize.
    *
-   * The grid cells, palette cards, and info-panel children are built procedurally
-   * inside the panels and don't have a `setSize` path — we resize the outer
-   * panels here, but the inner content stays at its initial layout until the
-   * scene is restarted (e.g. after a build/demolish/upgrade action).
-   *
-   * Lifting the grid/palette/info contents into a reusable widget with
-   * setSize requires extracting ~400 lines of cell/card/info-row state
-   * (placement validation, hover preview, build/demolish handlers). The
-   * initial layout already covers all current viewport sizes; resizing
-   * mid-session leaves the inner cells frozen until the next user action
-   * triggers a scene restart. Deferred — flagged as future work.
+   * The placement grid is now driven by `StationBuilderGrid.setSize` so it
+   * reflows in place — no scene restart needed. Palette cards and info-panel
+   * children are still rebuilt only on user action (build/demolish/upgrade);
+   * the outer panels are sized here so the inner content keeps its initial
+   * layout until the next action. That's a known limitation tracked
+   * separately from the grid lift.
    */
   private relayout(): void {
     const L = getLayout();
@@ -315,9 +290,12 @@ export class StationBuilderScene extends Phaser.Scene {
     this.portrait.setPosition(L.sidebarLeft, L.contentTop);
     this.portrait.setSize(L.sidebarWidth, L.contentHeight);
 
-    // Grid panel.
+    // Grid panel + grid widget.
     this.gridPanel.setPosition(L.mainContentLeft, L.contentTop);
     this.gridPanel.setSize(L.mainContentWidth, GRID_PANEL_HEIGHT);
+    const gridArea = this.getGridArea();
+    this.grid.setPosition(gridArea.x, gridArea.y);
+    this.grid.setSize(gridArea.width, gridArea.height);
 
     // Palette panel.
     const paletteY = L.contentTop + GRID_PANEL_HEIGHT + PANEL_GAP;
@@ -338,116 +316,80 @@ export class StationBuilderScene extends Phaser.Scene {
     this.infoContent = this.infoPanel.getContentArea();
   }
 
-  // ── Grid rendering ──
+  /**
+   * Title text for the grid panel. Reflects current hub level + slot usage,
+   * or a "no hub" placeholder when the player hasn't established a station.
+   */
+  private gridTitle(hub: StationHub | null): string {
+    return hub
+      ? `Station Grid — Level ${hub.level} (${hub.rooms.length}/${HUB_LEVEL_SLOTS[hub.level]} slots)`
+      : "No Hub Station";
+  }
 
-  private buildGrid(hub: StationHub): void {
-    const theme = getTheme();
-    const { content, cellW, cellH } = this.getGridMetrics();
-    const maxSlots = HUB_LEVEL_SLOTS[hub.level];
+  /**
+   * World-space rectangle the placement grid widget should occupy. Derived
+   * from the grid panel's content area so the widget stays inside the panel
+   * border at every viewport size.
+   */
+  private getGridArea(): {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } {
+    const c = this.gridPanel.getContentArea();
+    return {
+      x: this.gridPanel.x + c.x,
+      y: this.gridPanel.y + c.y,
+      width: c.width,
+      height: c.height,
+    };
+  }
 
-    this.gridCells = [];
-    let slotIndex = 0;
-    for (let gy = 0; gy < HUB_GRID_DECKS; gy++) {
-      this.gridCells[gy] = [];
-      for (let gx = 0; gx < HUB_GRID_SLOTS_PER_DECK; gx++) {
-        const cx = content.x + gx * (cellW + 4) + cellW / 2;
-        const cy = content.y + gy * (cellH + 4) + cellH / 2;
-        const locked = slotIndex >= maxSlots;
-        const room = hub.rooms.find((r) => r.gridX === gx && r.gridY === gy);
+  /**
+   * Refresh the grid widget + panel title after a state change (build /
+   * demolish / upgrade) — replaces the previous `scene.restart()` path for
+   * the grid view. The palette + info panels are still updated by their own
+   * code paths.
+   */
+  private refreshGrid(): void {
+    const hub = gameStore.getState().stationHub;
+    this.gridPanel.setTitle(this.gridTitle(hub));
+    this.grid.setRooms({
+      rooms: hub ? hub.rooms : [],
+      maxSlots: hub ? HUB_LEVEL_SLOTS[hub.level] : 0,
+    });
+  }
 
-        let fillColor = theme.colors.panelBg;
-        let fillAlpha = 0.4;
-        if (locked) {
-          fillColor = 0x222222;
-          fillAlpha = 0.6;
-        } else if (room) {
-          fillColor = ROOM_COLORS[room.type] ?? 0x555555;
-          fillAlpha = 0.26;
-        }
+  /**
+   * Common post-action refresh: grid + sidebar portrait + default info panel.
+   * Read state once so all three observers see the same snapshot.
+   */
+  private refreshAfterAction(): void {
+    this.refreshGrid();
+    const next = gameStore.getState();
+    this.showHubPortrait(next.stationHub);
+    this.showDefaultInfo(next.stationHub, next.cash);
+  }
 
-        const cell = this.add
-          .rectangle(cx, cy, cellW, cellH, fillColor, fillAlpha)
-          .setStrokeStyle(1, locked ? 0x333333 : theme.colors.panelBorder);
-        this.gridPanel.add(cell);
-        this.gridCells[gy][gx] = cell;
-
-        if (room) {
-          const card = this.createRoomCardVisual({
-            x: cx,
-            y: cy,
-            width: cellW,
-            height: cellH,
-            roomType: room.type,
-            enabled: true,
-            showCost: false,
-            selected: false,
-          });
-          this.gridPanel.add(card.bg);
-          this.gridPanel.add(card.iconText);
-          this.gridPanel.add(card.nameText);
-
-          cell.setInteractive({ useHandCursor: true });
-          cell.on("pointerup", () => {
-            if (this.dragGhost) return;
-            this.selectedRoomType = null;
-            this.selectedRoomId = room.id;
-            this.showBuiltRoomInfo(hub, room);
-          });
-
-          cell.on("pointerover", () => {
-            cell.setStrokeStyle(
-              2,
-              ROOM_COLORS[room.type] ?? theme.colors.accent,
-            );
-          });
-          cell.on("pointerout", () => {
-            cell.setStrokeStyle(1, theme.colors.panelBorder);
-          });
-        } else if (!locked) {
-          cell.setInteractive({ useHandCursor: true });
-          cell.on("pointerup", () => {
-            if (this.dragGhost) return;
-            this.handleGridClick(gx, gy);
-          });
-          cell.on("pointerover", () => {
-            if (this.selectedRoomType) {
-              cell.setStrokeStyle(2, theme.colors.accent);
-            }
-          });
-          cell.on("pointerout", () => {
-            cell.setStrokeStyle(1, theme.colors.panelBorder);
-          });
-        }
-
-        // Locked overlay text
-        if (locked) {
-          const lockText = this.add
-            .text(cx, cy, "🔒", {
-              fontSize: "12px",
-              align: "center",
-            })
-            .setOrigin(0.5, 0.5)
-            .setAlpha(0.5);
-          this.gridPanel.add(lockText);
-        }
-
-        // Store world bounds for drag-drop hit testing
-        this.gridSlotBounds.push({
-          gx,
-          gy,
-          bounds: new Phaser.Geom.Rectangle(
-            this.gridPanel.x + cx - cellW / 2,
-            this.gridPanel.y + cy - cellH / 2,
-            cellW,
-            cellH,
-          ),
-          valid: !locked && !room,
-        });
-
-        slotIndex++;
-      }
+  /**
+   * Translate a `cell:click` event from the grid widget into the scene's
+   * existing select / build / demolish flows.
+   */
+  private onCellClick(e: CellEventPayload): void {
+    if (this.dragGhost) return;
+    const hub = gameStore.getState().stationHub;
+    if (!hub) return;
+    if (e.room) {
+      this.selectedRoomType = null;
+      this.selectedRoomId = e.room.id;
+      this.showBuiltRoomInfo(hub, e.room);
+    } else {
+      this.handleGridClick(e.gx, e.gy);
     }
   }
+
+  // ── Grid interaction (widget owns rendering / hit testing) ──
 
   private handleGridClick(gx: number, gy: number): void {
     if (this.selectedRoomId) {
@@ -478,7 +420,7 @@ export class StationBuilderScene extends Phaser.Scene {
         cash: state.cash - result.cost,
       });
       this.selectedRoomType = null;
-      this.scene.restart();
+      this.refreshAfterAction();
     }
   }
 
@@ -510,31 +452,19 @@ export class StationBuilderScene extends Phaser.Scene {
     ghost.setDepth(1000);
     this.dragGhost = ghost;
     this.dragRoomType = rt;
+    this.grid.setSelectedTool(rt);
   }
 
   private onDragMove(pointer: Phaser.Input.Pointer): void {
     if (!this.dragGhost) return;
     this.dragGhost.setPosition(pointer.worldX, pointer.worldY);
-
-    // Highlight valid drop target
-    const target = this.getDropCell(pointer.worldX, pointer.worldY);
-    const theme = getTheme();
-    for (const slot of this.gridSlotBounds) {
-      if (!slot.valid) continue;
-      const cell = this.gridCells[slot.gy]?.[slot.gx];
-      if (!cell) continue;
-      if (target && target.gx === slot.gx && target.gy === slot.gy) {
-        cell.setStrokeStyle(2, theme.colors.accent);
-      } else {
-        cell.setStrokeStyle(1, theme.colors.panelBorder);
-      }
-    }
+    this.grid.updateDragHighlight(pointer.worldX, pointer.worldY);
   }
 
   private onDragEnd(pointer: Phaser.Input.Pointer): void {
     if (!this.dragGhost || !this.dragRoomType) return;
 
-    const target = this.getDropCell(pointer.worldX, pointer.worldY);
+    const target = this.grid.getDropCell(pointer.worldX, pointer.worldY);
 
     if (target) {
       const state = gameStore.getState();
@@ -556,7 +486,8 @@ export class StationBuilderScene extends Phaser.Scene {
           this.dragGhost.destroy();
           this.dragGhost = null;
           this.dragRoomType = null;
-          this.scene.restart();
+          this.grid.setSelectedTool(null);
+          this.refreshAfterAction();
           return;
         }
       }
@@ -566,40 +497,8 @@ export class StationBuilderScene extends Phaser.Scene {
     this.dragGhost.destroy();
     this.dragGhost = null;
     this.dragRoomType = null;
-    const theme = getTheme();
-    for (const slot of this.gridSlotBounds) {
-      if (!slot.valid) continue;
-      const cell = this.gridCells[slot.gy]?.[slot.gx];
-      if (cell) {
-        cell.setStrokeStyle(1, theme.colors.panelBorder);
-      }
-    }
-  }
-
-  private getDropCell(
-    worldX: number,
-    worldY: number,
-  ): { gx: number; gy: number } | null {
-    for (const slot of this.gridSlotBounds) {
-      if (!slot.valid) continue;
-      if (slot.bounds.contains(worldX, worldY)) {
-        return { gx: slot.gx, gy: slot.gy };
-      }
-    }
-    return null;
-  }
-
-  private getGridMetrics(): {
-    content: { x: number; y: number; width: number; height: number };
-    cellW: number;
-    cellH: number;
-  } {
-    const content = this.gridPanel.getContentArea();
-    const cellW =
-      (content.width - (HUB_GRID_SLOTS_PER_DECK - 1) * 4) /
-      HUB_GRID_SLOTS_PER_DECK;
-    const cellH = (content.height - (HUB_GRID_DECKS - 1) * 4) / HUB_GRID_DECKS;
-    return { content, cellW, cellH };
+    this.grid.setSelectedTool(null);
+    this.grid.clearDragHighlight();
   }
 
   private createRoomCardVisual(params: {
@@ -725,7 +624,8 @@ export class StationBuilderScene extends Phaser.Scene {
             cash: state.cash + result.refund,
           });
         }
-        this.scene.restart();
+        this.selectedRoomId = null;
+        this.refreshAfterAction();
       },
       onCancel: () => {},
     });
@@ -749,7 +649,7 @@ export class StationBuilderScene extends Phaser.Scene {
             cash: state.cash - result.cost,
           });
         }
-        this.scene.restart();
+        this.refreshAfterAction();
       },
       onCancel: () => {},
     });
@@ -1010,7 +910,8 @@ export class StationBuilderScene extends Phaser.Scene {
             cash: state.cash - result.cost,
           });
         }
-        this.scene.restart();
+        this.selectedRoomId = null;
+        this.refreshAfterAction();
       },
       onCancel: () => {},
     });

--- a/src/ui/StationBuilderGrid.ts
+++ b/src/ui/StationBuilderGrid.ts
@@ -1,0 +1,379 @@
+import * as Phaser from "phaser";
+import { getTheme, colorToString } from "@spacebiz/ui";
+import {
+  HUB_GRID_DECKS,
+  HUB_GRID_SLOTS_PER_DECK,
+  HUB_ROOM_DEFINITIONS,
+} from "../data/constants.ts";
+import type { HubRoom, HubRoomType } from "../data/types.ts";
+
+/**
+ * Color palette for each room type. Mirrors the lookup that lived inline in
+ * `StationBuilderScene` before this widget was lifted out — kept here so the
+ * grid is self-contained.
+ */
+export const ROOM_COLORS: Record<string, number> = {
+  simpleTerminal: 0x00eeff,
+  improvedTerminal: 0x00ccff,
+  advancedTerminal: 0x00aaff,
+  tradeOffice: 0x00ccaa,
+  passengerLounge: 0xaa66ff,
+  oreProcessing: 0xcc8844,
+  foodTerminal: 0x66cc44,
+  techTerminal: 0x44ddff,
+  luxuryTerminal: 0xffcc00,
+  hazmatTerminal: 0xff6644,
+  medicalTerminal: 0xff66aa,
+  fuelDepot: 0x44aaff,
+  marketExchange: 0xffcc00,
+  customsBureau: 0x88cc44,
+  repairBay: 0xff4488,
+  researchLab: 0x44ddff,
+  cargoWarehouse: 0xcc8844,
+  securityOffice: 0xdd4444,
+};
+
+const CELL_GAP = 4;
+
+export interface StationBuilderGridConfig {
+  /** World-space top-left X of the grid container. */
+  x: number;
+  /** World-space top-left Y of the grid container. */
+  y: number;
+  /** Outer width allocated to the grid. Cell pixel width is derived from `width / cols`. */
+  width: number;
+  /** Outer height allocated to the grid. Cell pixel height is derived from `height / rows`. */
+  height: number;
+  /** Columns (slots per deck). Defaults to `HUB_GRID_SLOTS_PER_DECK`. */
+  cols?: number;
+  /** Rows (decks). Defaults to `HUB_GRID_DECKS`. */
+  rows?: number;
+}
+
+export interface StationBuilderGridData {
+  rooms: HubRoom[];
+  /** How many of `cols * rows` slots are unlocked at the current hub level. */
+  maxSlots: number;
+}
+
+export interface CellEventPayload {
+  gx: number;
+  gy: number;
+  room: HubRoom | null;
+  pointer?: Phaser.Input.Pointer;
+}
+
+/**
+ * Self-contained placement grid for the station builder. Owns its cell
+ * graphics, occupant room cards, hover highlights and drag-drop hit testing.
+ *
+ * The scene drives this widget by calling `setData(...)` after every game-state
+ * mutation (build / demolish / upgrade / hub-level change). Resizing on window
+ * resize is `setSize(width, height)` — no scene restart required.
+ *
+ * Events emitted on `this`:
+ *   - `'cell:click'`  ({ gx, gy, room, pointer })
+ *   - `'cell:hover'`  ({ gx, gy, room })  // pointerover, fired once per enter
+ */
+export class StationBuilderGrid extends Phaser.GameObjects.Container {
+  private readonly cols: number;
+  private readonly rows: number;
+  private gridWidth: number;
+  private gridHeight: number;
+
+  private rooms: HubRoom[] = [];
+  private maxSlots = 0;
+  private dragRoomType: HubRoomType | null = null;
+
+  private cellNodes: Phaser.GameObjects.Rectangle[][] = [];
+  private decorations: Phaser.GameObjects.GameObject[] = [];
+
+  /**
+   * World-space hit bounds for each playable (non-locked) cell. Maintained in
+   * sync with cellNodes so drag-drop hit tests don't need a full traversal.
+   */
+  private slotBounds: Array<{
+    gx: number;
+    gy: number;
+    bounds: Phaser.Geom.Rectangle;
+    occupied: boolean;
+    locked: boolean;
+  }> = [];
+
+  constructor(scene: Phaser.Scene, config: StationBuilderGridConfig) {
+    super(scene, config.x, config.y);
+    this.cols = config.cols ?? HUB_GRID_SLOTS_PER_DECK;
+    this.rows = config.rows ?? HUB_GRID_DECKS;
+    this.gridWidth = config.width;
+    this.gridHeight = config.height;
+    super.setSize(this.gridWidth, this.gridHeight);
+    scene.add.existing(this);
+  }
+
+  /**
+   * Cell pixel size derived from the current outer dimensions. Cells are
+   * separated by `CELL_GAP` px so the inner area is `(N - 1) * GAP` smaller
+   * than the outer.
+   */
+  private getCellMetrics(): { cellW: number; cellH: number } {
+    const cellW = (this.gridWidth - (this.cols - 1) * CELL_GAP) / this.cols;
+    const cellH = (this.gridHeight - (this.rows - 1) * CELL_GAP) / this.rows;
+    return { cellW, cellH };
+  }
+
+  /**
+   * Resize the grid in place. Calls `super.setSize` so Phaser's hit-area
+   * tracking stays consistent, then rebuilds cell graphics at the new
+   * dimensions. The placed-rooms data is preserved.
+   */
+  public setSize(width: number, height: number): this {
+    super.setSize(width, height);
+    this.gridWidth = width;
+    this.gridHeight = height;
+    this.rebuild();
+    return this;
+  }
+
+  /**
+   * Replace the placed rooms + slot count and rebuild. Use this after every
+   * gameplay action (build / demolish / upgrade) instead of restarting the
+   * scene. Named `setRooms` rather than `setData` to avoid colliding with
+   * `Phaser.GameObjects.Container.setData(key, value)` which is the engine's
+   * generic data-manager API.
+   */
+  public setRooms(data: StationBuilderGridData): this {
+    this.rooms = data.rooms;
+    this.maxSlots = data.maxSlots;
+    this.rebuild();
+    return this;
+  }
+
+  /**
+   * Tell the grid that the user is mid-drag with `roomType` as the candidate
+   * placement. Pass `null` to clear. The grid uses this to decide which cells
+   * should highlight on `updateDragHighlight`.
+   */
+  public setSelectedTool(roomType: HubRoomType | null): this {
+    this.dragRoomType = roomType;
+    return this;
+  }
+
+  /** Convenience accessor for tests / callers that need to know the cell size. */
+  public getCellSize(): { cellW: number; cellH: number } {
+    return this.getCellMetrics();
+  }
+
+  /**
+   * Update drop-target highlighting during a drag. `worldX/worldY` are pointer
+   * world coordinates. The cell directly under the pointer (if valid) gets the
+   * accent stroke; all other cells reset to the panel border.
+   */
+  public updateDragHighlight(worldX: number, worldY: number): void {
+    const target = this.getDropCell(worldX, worldY);
+    const theme = getTheme();
+    for (const slot of this.slotBounds) {
+      if (slot.locked || slot.occupied) continue;
+      const cell = this.cellNodes[slot.gy]?.[slot.gx];
+      if (!cell) continue;
+      if (target && target.gx === slot.gx && target.gy === slot.gy) {
+        cell.setStrokeStyle(2, theme.colors.accent);
+      } else {
+        cell.setStrokeStyle(1, theme.colors.panelBorder);
+      }
+    }
+  }
+
+  /** Reset every playable cell's stroke to the default panel border. */
+  public clearDragHighlight(): void {
+    const theme = getTheme();
+    for (const slot of this.slotBounds) {
+      if (slot.locked || slot.occupied) continue;
+      const cell = this.cellNodes[slot.gy]?.[slot.gx];
+      if (cell) cell.setStrokeStyle(1, theme.colors.panelBorder);
+    }
+  }
+
+  /**
+   * Hit-test a world coordinate against playable empty cells. Returns the
+   * grid coordinates of the cell under the point, or null. Locked or occupied
+   * cells are not valid drop targets.
+   */
+  public getDropCell(
+    worldX: number,
+    worldY: number,
+  ): { gx: number; gy: number } | null {
+    for (const slot of this.slotBounds) {
+      if (slot.locked || slot.occupied) continue;
+      if (slot.bounds.contains(worldX, worldY)) {
+        return { gx: slot.gx, gy: slot.gy };
+      }
+    }
+    return null;
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────
+
+  /**
+   * Tear down all cell graphics + decorations and rebuild from the current
+   * `(gridWidth, gridHeight, rooms, maxSlots)` snapshot. This is the only
+   * mutation path — `setSize` and `setData` both delegate to it.
+   */
+  private rebuild(): void {
+    // Destroy previous children so we can recreate at fresh dimensions.
+    for (const row of this.cellNodes) {
+      for (const cell of row) cell.destroy();
+    }
+    for (const obj of this.decorations) obj.destroy();
+    this.cellNodes = [];
+    this.decorations = [];
+    this.slotBounds = [];
+
+    const theme = getTheme();
+    const { cellW, cellH } = this.getCellMetrics();
+    let slotIndex = 0;
+
+    for (let gy = 0; gy < this.rows; gy++) {
+      this.cellNodes[gy] = [];
+      for (let gx = 0; gx < this.cols; gx++) {
+        // Local-space center inside this Container.
+        const cx = gx * (cellW + CELL_GAP) + cellW / 2;
+        const cy = gy * (cellH + CELL_GAP) + cellH / 2;
+        const locked = slotIndex >= this.maxSlots;
+        const room = this.rooms.find((r) => r.gridX === gx && r.gridY === gy);
+
+        let fillColor = theme.colors.panelBg;
+        let fillAlpha = 0.4;
+        if (locked) {
+          fillColor = 0x222222;
+          fillAlpha = 0.6;
+        } else if (room) {
+          fillColor = ROOM_COLORS[room.type] ?? 0x555555;
+          fillAlpha = 0.26;
+        }
+
+        const cell = this.scene.add
+          .rectangle(cx, cy, cellW, cellH, fillColor, fillAlpha)
+          .setStrokeStyle(1, locked ? 0x333333 : theme.colors.panelBorder);
+        this.add(cell);
+        this.cellNodes[gy][gx] = cell;
+
+        if (room) {
+          this.addRoomCard(cx, cy, cellW, cellH, room.type);
+          this.attachOccupiedHandlers(cell, gx, gy, room);
+        } else if (!locked) {
+          this.attachEmptyHandlers(cell, gx, gy);
+        }
+
+        if (locked) {
+          const lockText = this.scene.add
+            .text(cx, cy, "🔒", { fontSize: "12px", align: "center" })
+            .setOrigin(0.5, 0.5)
+            .setAlpha(0.5);
+          this.add(lockText);
+          this.decorations.push(lockText);
+        }
+
+        // World-space bounds for drag-drop hit testing.
+        this.slotBounds.push({
+          gx,
+          gy,
+          bounds: new Phaser.Geom.Rectangle(
+            this.x + cx - cellW / 2,
+            this.y + cy - cellH / 2,
+            cellW,
+            cellH,
+          ),
+          occupied: !!room,
+          locked,
+        });
+
+        slotIndex++;
+      }
+    }
+  }
+
+  private addRoomCard(
+    cx: number,
+    cy: number,
+    cellW: number,
+    cellH: number,
+    roomType: HubRoomType,
+  ): void {
+    const theme = getTheme();
+    const def = HUB_ROOM_DEFINITIONS[roomType];
+    const roomColor = ROOM_COLORS[roomType] ?? 0x555555;
+
+    const bg = this.scene.add
+      .rectangle(cx, cy, cellW, cellH, roomColor, 0.22)
+      .setStrokeStyle(1, roomColor);
+    const iconText = this.scene.add
+      .text(cx - cellW / 2 + 10, cy - cellH / 2 + 8, def.icon, {
+        fontSize: "10px",
+        fontFamily: theme.fonts.body.family,
+        color: colorToString(theme.colors.text),
+      })
+      .setOrigin(0, 0);
+    const nameText = this.scene.add
+      .text(cx - cellW / 2 + 24, cy - cellH / 2 + 8, def.name, {
+        fontSize: "9px",
+        fontFamily: theme.fonts.caption.family,
+        color: "#ffffff",
+        align: "left",
+        wordWrap: { width: cellW - 30 },
+        shadow: {
+          offsetX: 1,
+          offsetY: 1,
+          color: "#000000",
+          blur: 2,
+          fill: true,
+        },
+      })
+      .setOrigin(0, 0);
+
+    this.add(bg);
+    this.add(iconText);
+    this.add(nameText);
+    this.decorations.push(bg, iconText, nameText);
+  }
+
+  private attachOccupiedHandlers(
+    cell: Phaser.GameObjects.Rectangle,
+    gx: number,
+    gy: number,
+    room: HubRoom,
+  ): void {
+    const theme = getTheme();
+    cell.setInteractive({ useHandCursor: true });
+    cell.on("pointerup", (pointer: Phaser.Input.Pointer) => {
+      this.emit("cell:click", { gx, gy, room, pointer });
+    });
+    cell.on("pointerover", () => {
+      cell.setStrokeStyle(2, ROOM_COLORS[room.type] ?? theme.colors.accent);
+      this.emit("cell:hover", { gx, gy, room });
+    });
+    cell.on("pointerout", () => {
+      cell.setStrokeStyle(1, theme.colors.panelBorder);
+    });
+  }
+
+  private attachEmptyHandlers(
+    cell: Phaser.GameObjects.Rectangle,
+    gx: number,
+    gy: number,
+  ): void {
+    const theme = getTheme();
+    cell.setInteractive({ useHandCursor: true });
+    cell.on("pointerup", (pointer: Phaser.Input.Pointer) => {
+      this.emit("cell:click", { gx, gy, room: null, pointer });
+    });
+    cell.on("pointerover", () => {
+      if (this.dragRoomType) {
+        cell.setStrokeStyle(2, theme.colors.accent);
+      }
+      this.emit("cell:hover", { gx, gy, room: null });
+    });
+    cell.on("pointerout", () => {
+      cell.setStrokeStyle(1, theme.colors.panelBorder);
+    });
+  }
+}

--- a/src/ui/__tests__/StationBuilderGrid.test.ts
+++ b/src/ui/__tests__/StationBuilderGrid.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { StationBuilderGrid } from "../StationBuilderGrid.ts";
+import type { CellEventPayload } from "../StationBuilderGrid.ts";
+import { HubRoomType, type HubRoom } from "../../data/types.ts";
+import {
+  mountComponent,
+  type MountedComponent,
+} from "../../../packages/spacebiz-ui/src/__tests__/_harness/mountComponent.ts";
+import {
+  HUB_GRID_DECKS,
+  HUB_GRID_SLOTS_PER_DECK,
+} from "../../data/constants.ts";
+
+describe("StationBuilderGrid", () => {
+  let mounted: MountedComponent<StationBuilderGrid> | undefined;
+
+  afterEach(() => {
+    mounted?.destroy();
+    mounted = undefined;
+  });
+
+  it("setSize updates cell pixel dimensions in place", async () => {
+    mounted = await mountComponent(
+      (scene) =>
+        new StationBuilderGrid(scene, {
+          x: 0,
+          y: 0,
+          width: 600,
+          height: 200,
+        }),
+    );
+    const grid = mounted.component;
+
+    const before = grid.getCellSize();
+    expect(before.cellW).toBeCloseTo(
+      (600 - (HUB_GRID_SLOTS_PER_DECK - 1) * 4) / HUB_GRID_SLOTS_PER_DECK,
+    );
+    expect(before.cellH).toBeCloseTo(
+      (200 - (HUB_GRID_DECKS - 1) * 4) / HUB_GRID_DECKS,
+    );
+
+    grid.setSize(900, 300);
+    const after = grid.getCellSize();
+    expect(after.cellW).toBeGreaterThan(before.cellW);
+    expect(after.cellH).toBeGreaterThan(before.cellH);
+    expect(after.cellW).toBeCloseTo(
+      (900 - (HUB_GRID_SLOTS_PER_DECK - 1) * 4) / HUB_GRID_SLOTS_PER_DECK,
+    );
+  }, 15000);
+
+  it("setRooms renders one cell per slot and rebuilds on subsequent calls", async () => {
+    const room: HubRoom = {
+      id: "r1",
+      type: HubRoomType.TradeOffice,
+      gridX: 0,
+      gridY: 0,
+    };
+
+    mounted = await mountComponent(
+      (scene) =>
+        new StationBuilderGrid(scene, {
+          x: 0,
+          y: 0,
+          width: 600,
+          height: 200,
+        }),
+    );
+    const grid = mounted.component;
+
+    grid.setRooms({ rooms: [], maxSlots: 4 });
+    const childCountEmpty = grid.list.length;
+    // 24 cells in the default 4x6 grid + 20 lock icons (24 - 4 unlocked).
+    expect(childCountEmpty).toBe(
+      HUB_GRID_DECKS * HUB_GRID_SLOTS_PER_DECK +
+        (HUB_GRID_DECKS * HUB_GRID_SLOTS_PER_DECK - 4),
+    );
+
+    grid.setRooms({ rooms: [room], maxSlots: 4 });
+    // One occupied cell adds bg + iconText + nameText (3 extras), and removes
+    // one lock icon (the room sits in an unlocked slot).
+    const childCountWithRoom = grid.list.length;
+    expect(childCountWithRoom).toBe(childCountEmpty + 3);
+  }, 15000);
+
+  it("emits cell:click with payload when an empty cell is clicked", async () => {
+    mounted = await mountComponent(
+      (scene) =>
+        new StationBuilderGrid(scene, {
+          x: 0,
+          y: 0,
+          width: 600,
+          height: 200,
+        }),
+    );
+    const grid = mounted.component;
+    grid.setRooms({ rooms: [], maxSlots: 4 });
+
+    const handler = vi.fn();
+    grid.on("cell:click", handler);
+
+    // The first child is the (0, 0) cell rectangle.
+    const firstCell = grid.list[0] as Phaser.GameObjects.Rectangle;
+    firstCell.emit("pointerup", {} as Phaser.Input.Pointer);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const payload = handler.mock.calls[0][0] as CellEventPayload;
+    expect(payload.gx).toBe(0);
+    expect(payload.gy).toBe(0);
+    expect(payload.room).toBeNull();
+  }, 15000);
+});

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -22,3 +22,10 @@ export type {
   TechTreeGridState,
   TechNodeState,
 } from "./TechTreeGrid.ts";
+
+export { StationBuilderGrid, ROOM_COLORS } from "./StationBuilderGrid.ts";
+export type {
+  StationBuilderGridConfig,
+  StationBuilderGridData,
+  CellEventPayload,
+} from "./StationBuilderGrid.ts";


### PR DESCRIPTION
## Summary

- Lifts the ~400-LoC inline placement grid out of `StationBuilderScene` into a dedicated `StationBuilderGrid` widget (`Phaser.GameObjects.Container`) at `src/ui/StationBuilderGrid.ts`.
- Adds `setSize(width, height): this` so window resize reflows the grid in place. The previous fluid-layout pass (PR #270) had to leave the grid frozen at its initial layout because the inner cells, occupant cards, and lock icons had no `setSize` path — that limitation is now gone.
- Removes `scene.restart()` from build / demolish / hub-upgrade / terminal-upgrade paths. The scene now calls `gameStore.update(...)` and then `this.grid.setRooms(...)` to re-render. Preserves all gameplay semantics (placement, validation, demolish, terminal upgrade chain).
- Adds `Panel.setTitle(...)` so the scene can refresh the `"Station Grid — Level X (Y/Z slots)"` header without a restart.
- Adds a `refreshAfterAction()` scene helper that consolidates the post-action grid + portrait + info-panel refresh.

## Widget API

- `new StationBuilderGrid(scene, { x, y, width, height, cols?, rows? })`
- `setSize(width, height)` — recompute cell pixel size and rebuild in place.
- `setRooms({ rooms, maxSlots })` — replace placed modules and re-render. (Renamed from `setData` to avoid colliding with `Phaser.GameObjects.Container.setData(key, value)`.)
- `setSelectedTool(roomType | null)` — track the currently-dragged tool for hover highlighting.
- `getDropCell(worldX, worldY)`, `updateDragHighlight`, `clearDragHighlight`.
- Emits `cell:click` and `cell:hover` with `{ gx, gy, room, pointer? }`.

## Scene-restart removal for resize

`StationBuilderScene.relayout()` now calls `this.grid.setPosition(...)` + `this.grid.setSize(...)` instead of leaving the grid frozen. Build / demolish / upgrade flows route through `refreshAfterAction()` so the grid view updates without rebooting the scene. The palette + info panels still rebuild only on user action; that is unchanged from before this PR.

## Test plan

- [x] `npm run check` — typecheck + lint + format + tests + build all pass locally.
- [x] New unit test `src/ui/__tests__/StationBuilderGrid.test.ts` covers `setSize`, `setRooms`, and `cell:click` event emission via the headless Phaser harness.
- [ ] Manual smoke: open `StationBuilderScene`, build / demolish / upgrade rooms, verify grid + title update without flicker, resize the window and confirm the grid reflows in place.

## Screenshots

Screenshots not applicable: this PR is a refactor that preserves the existing visual layout — same cells, same room cards, same palette/info panels. The reflow behavior on resize is the only user-observable change and is exercised by the existing fluid-layout e2e suite (`e2e/visual/fluid-layout/...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)