### PR TITLE
fix(scenes): drop scene.restart() in TechTreeScene research + SandboxSetupScene delete-save

### DIFF
--- a/src/scenes/SandboxSetupScene.ts
+++ b/src/scenes/SandboxSetupScene.ts
@@ -390,18 +390,52 @@ export class SandboxSetupScene extends Phaser.Scene {
         itemHeight: 36,
       });
 
-      // Use a placeholder row width for now; relayout() uses scene.restart() when
-      // dimensions actually change saved-row layout, so initial geometry is fine.
-      const initialRowWidth = getLayout().maxContentWidth - PADDING * 2;
-      for (const slot of saves) {
-        const itemContainer = this.add.container(0, 0);
-        this.buildSaveSlotRow(itemContainer, slot, initialRowWidth);
-        this.saveList.addItem(itemContainer);
-      }
+      this.populateSaveList(saves);
     }
 
     this.relayout();
     attachReflowHandler(this, () => this.relayout());
+  }
+
+  /**
+   * Rebuild the saved-sandbox rows from the given snapshot. Existing rows
+   * are destroyed in place; relayout() handles re-anchoring.
+   */
+  private populateSaveList(saves: SaveSlotMeta[]): void {
+    if (!this.saveList) return;
+    this.saveList.clearItems();
+    // Row width is re-applied via relayout()/setSize on the list, but each
+    // row's load/delete buttons are positioned relative to this width.
+    const rowWidth = getLayout().maxContentWidth - PADDING * 2;
+    for (const slot of saves) {
+      const itemContainer = this.add.container(0, 0);
+      this.buildSaveSlotRow(itemContainer, slot, rowWidth);
+      this.saveList.addItem(itemContainer);
+    }
+  }
+
+  /**
+   * In-place refresh of the saved-sandbox list after a delete. Hides the
+   * panel entirely once the last save is removed.
+   */
+  private refreshSaveList(): void {
+    const saves = listSandboxSaves();
+    this.hasSaves = saves.length > 0;
+
+    if (!this.hasSaves) {
+      // Last save removed — tear down the panel; relayout() will skip it.
+      this.savePanel?.destroy();
+      this.savePanelTitle?.destroy();
+      this.saveList?.destroy();
+      this.savePanel = null;
+      this.savePanelTitle = null;
+      this.saveList = null;
+      this.relayout();
+      return;
+    }
+
+    this.populateSaveList(saves);
+    this.relayout();
   }
 
   private relayout(): void {
@@ -567,7 +601,7 @@ export class SandboxSetupScene extends Phaser.Scene {
       label: "Delete",
       onClick: () => {
         deleteSandboxSave(slot.id);
-        this.scene.restart();
+        this.refreshSaveList();
       },
     });
     container.add(delBtn);

--- a/src/scenes/TechTreeScene.ts
+++ b/src/scenes/TechTreeScene.ts
@@ -299,8 +299,58 @@ export class TechTreeScene extends Phaser.Scene {
     const newTech = setResearchTarget(techId, state.tech);
     if (newTech) {
       gameStore.setState({ ...state, tech: newTech });
-      // Refresh scene
-      this.scene.restart();
+      this.refreshUi();
     }
+  }
+
+  private refreshUi(): void {
+    const theme = getTheme();
+    const state = gameStore.getState();
+    const rpPerTurn = calculateRPPerTurn(state);
+    const currentResearch = getCurrentResearch(state.tech);
+
+    // RP totals + tech-count summary.
+    this.rpStatusText.setText(
+      `Total RP: ${state.tech.researchPoints} • +${rpPerTurn} RP/turn • Techs: ${state.tech.completedTechIds.length}/20`,
+    );
+
+    // Current-research line.
+    this.currentResearchText.setText(
+      currentResearch
+        ? `⚙ Researching: ${currentResearch.name}`
+        : "⚙ No research in progress",
+    );
+    this.currentResearchText.setColor(
+      colorToString(
+        currentResearch ? theme.colors.accent : theme.colors.textDim,
+      ),
+    );
+
+    // Progress bar.
+    this.progressBar.setValue(getResearchProgress(state.tech));
+
+    // Progress label — created lazily on first active research.
+    if (currentResearch) {
+      const progressText = `${state.tech.researchProgress}/${currentResearch.rpCost} RP`;
+      if (this.progressLabel) {
+        this.progressLabel.setText(progressText).setVisible(true);
+      } else {
+        this.progressLabel = this.add
+          .text(0, 0, progressText, {
+            fontSize: `${theme.fonts.caption.size}px`,
+            fontFamily: theme.fonts.caption.family,
+            color: colorToString(theme.colors.textDim),
+          })
+          .setOrigin(1, 0);
+      }
+    } else if (this.progressLabel) {
+      this.progressLabel.setVisible(false);
+    }
+
+    this.grid.setGridState(this.buildGridState());
+
+    // relayout() repositions any lazily created label and refreshes button enablement.
+    this.relayout();
+    this.updateSelectedPortrait();
   }
 }


### PR DESCRIPTION
## Summary

Two leftover `scene.restart()` calls from before the fluid-layout rollout were tearing down and rebuilding entire scenes to refresh local UI state. Both now mutate existing children in place, matching the locked "scene builds children once, mutates them on data changes" pattern used everywhere else.

### TechTreeScene.applyResearch

Was calling `this.scene.restart()` after writing the new tech state to the store. Now calls a new `refreshUi()` that:

- Updates `rpStatusText`, `currentResearchText`, and the progress bar via existing field references.
- Lazily creates the `progressLabel` if research just started, and hides it when there is no current research.
- Calls `TechTreeGrid.setGridState(...)` (the API added in PR #287 for exactly this case) so node colors / glow / connectors reflect the new state.
- Calls `relayout()` to re-anchor any newly created label and `updateSelectedPortrait()` to refresh the right-panel summary.

### SandboxSetupScene delete button

Was calling `this.scene.restart()` after `deleteSandboxSave(slot.id)`. Replaced with a new `refreshSaveList()` helper:

- Re-reads `listSandboxSaves()`.
- If empty, destroys the saved-sandbox panel children and nulls the refs (so `relayout()`'s existing guard skips the panel) and re-runs `relayout()`.
- Otherwise calls `populateSaveList(saves)`, which clears the `ScrollableList` via `clearItems()` and re-adds rebuilt rows, then `relayout()`.

The initial population in `create()` was also factored out into the new `populateSaveList(saves)` helper to avoid duplication.

Also removed the stale comment at the previous `populateSaveList` site that still referenced the old `scene.restart()` flow.

## Test plan

- [x] `npm run check` (typecheck + 1513 tests + production build) passes locally.
- [ ] Manual: Research a tech in TechTreeScene — verify RP totals, current-research line, progress bar, progress label, and tech-tree node states all update without a scene flash.
- [ ] Manual: Switch research mid-progress via the Modal — verify the in-place refresh applies after confirm.
- [ ] Manual: Delete a saved sandbox in SandboxSetupScene with multiple saves — verify the deleted row disappears and remaining rows stay.
- [ ] Manual: Delete the last saved sandbox — verify the entire saved-games panel disappears (no empty panel, no scene flash).

## Screenshots

Screenshots not applicable: both changes are in operational refresh paths whose visual output is identical to the previous (post-restart) state. The behavior change is the absence of the scene flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)