### PR TITLE
feat(ui): DataTable flex columns — distribute surplus width on resize

### DIFF
--- a/packages/spacebiz-ui/src/DataTable.ts
+++ b/packages/spacebiz-ui/src/DataTable.ts
@@ -6,7 +6,15 @@ import { applyClippingMask } from "./MaskUtils.ts";
 export interface ColumnDef {
   key: string;
   label: string;
+  /** Base / minimum width in pixels. Always required. */
   width: number;
+  /**
+   * Optional grow factor. When the table's outer width exceeds the sum of
+   * configured `width`s, the surplus is distributed across columns with
+   * `flex > 0` proportionally to their flex value. Columns with no `flex`
+   * (or `flex: 0`) keep their pixel `width`. Default: 0 (fixed).
+   */
+  flex?: number;
   align?: "left" | "center" | "right";
   sortable?: boolean;
   format?: (value: unknown) => string;
@@ -208,14 +216,56 @@ export class DataTable extends Phaser.GameObjects.Container {
     return true;
   }
 
-  /** Expand column widths proportionally to fill the available table width. */
+  /**
+   * Expand column widths proportionally to fill the available table width.
+   *
+   * When any column declares `flex`, this proportional scaling is skipped:
+   * configured widths are treated as the base/minimum and `computeEffective
+   * Widths` distributes the surplus to flex columns instead.
+   */
   private expandColumns(columns: ColumnDef[], tableWidth: number): ColumnDef[] {
+    const hasFlex = columns.some((c) => (c.flex ?? 0) > 0);
+    if (hasFlex) return columns;
     const scrollBarWidth = 4;
     const usableWidth = tableWidth - scrollBarWidth;
     const totalDefined = columns.reduce((sum, c) => sum + c.width, 0);
     if (totalDefined === 0 || totalDefined === usableWidth) return columns;
     const scale = usableWidth / totalDefined;
     return columns.map((c) => ({ ...c, width: Math.floor(c.width * scale) }));
+  }
+
+  /**
+   * Compute effective per-column widths for the current table outer width.
+   *
+   * Columns with `flex > 0` absorb any surplus (outer width minus sum of
+   * base widths) proportionally to their flex value. Columns with no flex
+   * keep their configured `width` exactly. The returned array is the same
+   * length and order as `this.columns`.
+   *
+   * If outer width is at or below the sum of base widths, every column is
+   * returned at its base width — flex never shrinks below `width`.
+   */
+  private computeEffectiveWidths(): number[] {
+    const widths = this.columns.map((c) => c.width);
+    const totalBase = widths.reduce((sum, w) => sum + w, 0);
+    let surplus = this.tableConfig.width - totalBase;
+    if (surplus <= 0) return widths;
+
+    let remainingFlex = this.columns.reduce((sum, c) => sum + (c.flex ?? 0), 0);
+    if (remainingFlex <= 0) return widths;
+
+    // Walk the columns once. Each flex column takes a floor()'d share of the
+    // remaining surplus, and the last flex column absorbs whatever is left
+    // so the total matches the outer width exactly (no pixel-rounding gap).
+    for (let i = 0; i < this.columns.length; i++) {
+      const flex = this.columns[i].flex ?? 0;
+      if (flex <= 0) continue;
+      const share = Math.floor((surplus * flex) / remainingFlex);
+      widths[i] += share;
+      surplus -= share;
+      remainingFlex -= flex;
+    }
+    return widths;
   }
 
   /**
@@ -327,8 +377,11 @@ export class DataTable extends Phaser.GameObjects.Container {
       .setAlpha(0.6);
     this.headerContainer.add(headerBorderLine);
 
+    const effectiveWidths = this.computeEffectiveWidths();
     let x = 0;
-    for (const col of this.columns) {
+    for (let ci = 0; ci < this.columns.length; ci++) {
+      const col = this.columns[ci];
+      const colWidth = effectiveWidths[ci];
       let textX = x + 8;
 
       // Optional header icon (left of label text)
@@ -350,10 +403,10 @@ export class DataTable extends Phaser.GameObjects.Container {
 
       if (col.sortable) {
         const hitArea = this.scene.add
-          .rectangle(x, 0, col.width, this.headerHeight, 0x000000, 0)
+          .rectangle(x, 0, colWidth, this.headerHeight, 0x000000, 0)
           .setOrigin(0, 0)
           .setInteractive(
-            new Phaser.Geom.Rectangle(0, 0, col.width, this.headerHeight),
+            new Phaser.Geom.Rectangle(0, 0, colWidth, this.headerHeight),
             Phaser.Geom.Rectangle.Contains,
           );
         hitArea.setData("consumesWheel", true);
@@ -385,7 +438,7 @@ export class DataTable extends Phaser.GameObjects.Container {
       }
 
       this.headerContainer.add(text);
-      x += col.width;
+      x += colWidth;
     }
   }
 
@@ -481,6 +534,7 @@ export class DataTable extends Phaser.GameObjects.Container {
     }
 
     let yCursor = 0;
+    const effectiveWidths = this.computeEffectiveWidths();
 
     sortedRows.forEach((row, i) => {
       const rowTop = yCursor;
@@ -492,7 +546,9 @@ export class DataTable extends Phaser.GameObjects.Container {
       let maxTextHeight = theme.fonts.body.size;
 
       let x = 0;
-      for (const col of this.columns) {
+      for (let ci = 0; ci < this.columns.length; ci++) {
+        const col = this.columns[ci];
+        const colWidth = effectiveWidths[ci];
         const raw = row[col.key];
         const display = col.format ? col.format(raw) : String(raw ?? "");
         const color = col.colorFn ? col.colorFn(raw) : theme.colors.text;
@@ -521,24 +577,24 @@ export class DataTable extends Phaser.GameObjects.Container {
           fontSize: `${theme.fonts.body.size}px`,
           fontFamily: theme.fonts.body.family,
           color: colorToString(color ?? theme.colors.text),
-          wordWrap: { width: col.width - 16 - (cellTextX - (x + 8)) },
+          wordWrap: { width: colWidth - 16 - (cellTextX - (x + 8)) },
           maxLines: 1,
         });
 
         if (col.align === "right") {
-          text.setOrigin(1, 0).setX(x + col.width - 8);
+          text.setOrigin(1, 0).setX(x + colWidth - 8);
         } else if (col.align === "center") {
-          text.setOrigin(0.5, 0).setX(x + col.width / 2);
+          text.setOrigin(0.5, 0).setX(x + colWidth / 2);
         }
 
         // Crop text to column bounds to prevent overflow into adjacent columns
         const textLeft =
           col.align === "right"
-            ? x + col.width - 8 - text.width
+            ? x + colWidth - 8 - text.width
             : col.align === "center"
-              ? x + col.width / 2 - text.width / 2
+              ? x + colWidth / 2 - text.width / 2
               : cellTextX;
-        const colRight = x + col.width;
+        const colRight = x + colWidth;
         const overflow = textLeft + text.width - colRight;
         if (overflow > 0) {
           text.setCrop(0, 0, text.width - overflow, text.height);
@@ -546,7 +602,7 @@ export class DataTable extends Phaser.GameObjects.Container {
 
         maxTextHeight = Math.max(maxTextHeight, text.height);
         rowTexts.push(text);
-        x += col.width;
+        x += colWidth;
       }
 
       const rowHeightPx = Math.max(this.rowHeight, maxTextHeight + 14);
@@ -653,9 +709,9 @@ export class DataTable extends Phaser.GameObjects.Container {
   /**
    * Resize the table chrome to a new width/height.
    *
-   * Width: updates the header background and divider line to the new width.
-   *        Column widths stay at their configured (proportionally expanded)
-   *        values — only the chrome that spans the full table width is reflowed.
+   * Width: updates the header background and divider line to the new width
+   *        and re-renders header + rows so any flex columns absorb the new
+   *        surplus. Columns with no `flex` keep their pixel width.
    *
    * Height: ignored when `contentSized: true` (height is row-driven in that
    *         mode). In scrollable mode the new height becomes the visible
@@ -663,11 +719,21 @@ export class DataTable extends Phaser.GameObjects.Container {
    */
   public setSize(width: number, height: number): this {
     super.setSize(width, height);
+    const widthChanged = this.tableConfig.width !== width;
     this.tableConfig.width = width;
     if (!this.contentSized) {
       this.tableConfig.height = height;
     }
     this.redrawChrome();
+    // Re-render rows so flex columns pick up the new widths. Header alone
+    // is not enough — column borders shift, right-aligned cells need to
+    // reposition, and the row background spans the table width.
+    if (widthChanged && this.rows.length > 0) {
+      this.renderBody();
+      if (this.contentSized) {
+        this.emit("contentResize", { height: this._contentHeight });
+      }
+    }
     return this;
   }
 

--- a/packages/spacebiz-ui/src/__tests__/composites/DataTable.test.ts
+++ b/packages/spacebiz-ui/src/__tests__/composites/DataTable.test.ts
@@ -313,7 +313,141 @@ describe("DataTable", () => {
       expect(table.contentHeight).toBe(contentHeightBefore);
     });
   });
+
+  describe("flex columns", () => {
+    it("with no flex columns and outer width at base sum + scrollbar, widths are unchanged", () => {
+      // Outer width = base sum + 4px scrollbar reserve, so the legacy
+      // expandColumns scaling is a no-op AND there's no surplus for flex
+      // to distribute. Effective widths should equal the configured widths.
+      const table = new DataTable(scene as never, {
+        x: 0,
+        y: 0,
+        width: 204,
+        height: 400,
+        columns: [
+          { key: "a", label: "A", width: 100 },
+          { key: "b", label: "B", width: 100 },
+        ],
+      });
+      const widths = computeEffectiveWidths(table);
+      expect(widths).toEqual([100, 100]);
+    });
+
+    it("single flex column absorbs the entire surplus", () => {
+      const table = new DataTable(scene as never, {
+        x: 0,
+        y: 0,
+        // base sum = 300, outer = 600 → 300 surplus
+        width: 600,
+        height: 400,
+        columns: [
+          { key: "a", label: "A", width: 100, flex: 1 },
+          { key: "b", label: "B", width: 100 },
+          { key: "c", label: "C", width: 100 },
+        ],
+      });
+      const widths = computeEffectiveWidths(table);
+      expect(widths).toEqual([400, 100, 100]);
+      expect(widths.reduce((s, w) => s + w, 0)).toBe(600);
+    });
+
+    it("multiple flex columns split surplus proportionally", () => {
+      const table = new DataTable(scene as never, {
+        x: 0,
+        y: 0,
+        // base sum = 300, outer = 600 → 300 surplus.
+        // flex 1 + 2 = 3 → col A gets 100, col B gets 200.
+        width: 600,
+        height: 400,
+        columns: [
+          { key: "a", label: "A", width: 100, flex: 1 },
+          { key: "b", label: "B", width: 100, flex: 2 },
+          { key: "c", label: "C", width: 100 },
+        ],
+      });
+      const widths = computeEffectiveWidths(table);
+      expect(widths[0]).toBe(200); // 100 base + 100 surplus share
+      expect(widths[1]).toBe(300); // 100 base + 200 surplus share
+      expect(widths[2]).toBe(100);
+      expect(widths.reduce((s, w) => s + w, 0)).toBe(600);
+    });
+
+    it("sum of effective widths equals max(outer width, sum of base widths)", () => {
+      // outer wider than base sum → flex distributes
+      const wide = new DataTable(scene as never, {
+        x: 0,
+        y: 0,
+        width: 700,
+        height: 400,
+        columns: [
+          { key: "a", label: "A", width: 100, flex: 1 },
+          { key: "b", label: "B", width: 100 },
+        ],
+      });
+      expect(computeEffectiveWidths(wide).reduce((s, w) => s + w, 0)).toBe(700);
+
+      // outer narrower than base sum → effective widths == base widths
+      const narrow = new DataTable(scene as never, {
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 400,
+        columns: [
+          { key: "a", label: "A", width: 100, flex: 1 },
+          { key: "b", label: "B", width: 100 },
+        ],
+      });
+      expect(computeEffectiveWidths(narrow).reduce((s, w) => s + w, 0)).toBe(
+        200,
+      );
+    });
+
+    it("setSize re-flows: right-aligned cell text repositions when its column grows", () => {
+      const table = new DataTable(scene as never, {
+        x: 0,
+        y: 0,
+        // base sum = 200 = outer width: no surplus, so no flex distribution yet.
+        width: 200,
+        height: 400,
+        columns: [
+          { key: "name", label: "Name", width: 100, flex: 1 },
+          { key: "value", label: "Value", width: 100, align: "right" },
+        ],
+      });
+      table.setRows([{ name: "Alpha", value: 42 }]);
+
+      // Right-aligned text origin sits at (col-x + col-width - 8). With name flexed
+      // from 100 → 200, the value column shifts from x=100 to x=200, so the text
+      // should sit at x = 200 + 100 - 8 = 292.
+      const valueTextBefore = findRightAlignedValueText(table);
+      expect(valueTextBefore.x).toBe(100 + 100 - 8);
+
+      table.setSize(400, 400); // surplus = 200, all goes to flex column 'name'
+      const widths = computeEffectiveWidths(table);
+      expect(widths).toEqual([300, 100]);
+
+      const valueTextAfter = findRightAlignedValueText(table);
+      expect(valueTextAfter.x).toBe(300 + 100 - 8);
+    });
+  });
 });
+
+function computeEffectiveWidths(table: DataTable): number[] {
+  return asMock<{ computeEffectiveWidths: () => number[] }>(
+    table,
+  ).computeEffectiveWidths();
+}
+
+function findRightAlignedValueText(table: DataTable) {
+  const body = asMock<{ bodyContainer: MockContainerLike }>(
+    table,
+  ).bodyContainer;
+  // The "value" cell is the last text rendered in the row.
+  const allTexts = body.list.filter(
+    (child) => (child as { type?: string }).type === "Text",
+  );
+  return asMock<{ x: number; text: string }>(allTexts[allTexts.length - 1]);
+}
 
 // ─────────────────────────────────────────────────────────────────────────
 // DataTable-specific helpers (row backgrounds keyed off table width).

--- a/src/scenes/FleetScene.ts
+++ b/src/scenes/FleetScene.ts
@@ -102,7 +102,8 @@ export class FleetScene extends Phaser.Scene {
       height: content.height - 80,
       contentSized: true,
       columns: [
-        { key: "name", label: "Name", width: 110, sortable: true },
+        // 'name' and 'route' flex so they absorb extra width on wide displays.
+        { key: "name", label: "Name", width: 110, flex: 1, sortable: true },
         {
           key: "class",
           label: "Class",
@@ -142,7 +143,7 @@ export class FleetScene extends Phaser.Scene {
           format: (v) => `${Math.round(v as number)}%`,
           colorFn: conditionColor,
         },
-        { key: "route", label: "Route", width: 130, sortable: true },
+        { key: "route", label: "Route", width: 130, flex: 1, sortable: true },
         {
           key: "maintenance",
           label: "Maint.",

--- a/src/scenes/RoutesScene.ts
+++ b/src/scenes/RoutesScene.ts
@@ -561,7 +561,8 @@ export class RoutesScene extends Phaser.Scene {
       height: tableHeight,
       contentSized: true,
       columns: [
-        { key: "origin", label: "Origin", width: 110, sortable: true },
+        // origin flexes to absorb extra width on wide displays.
+        { key: "origin", label: "Origin", width: 110, flex: 1, sortable: true },
         {
           key: "destination",
           label: "Destination",


### PR DESCRIPTION
## Summary

- Adds an optional `flex?: number` field to `DataTable`'s `ColumnDef`. The existing `width` becomes the base/min width; when the table's outer width exceeds the sum of base widths, the surplus is distributed across columns with `flex > 0` proportionally to their flex value. Columns without `flex` keep their pixel width.
- `setSize` now re-renders the body in addition to the chrome so flex columns reflow and right/center-aligned cells reposition correctly. API is purely additive — existing callers (no `flex`) keep their previous behavior, and the legacy proportional `expandColumns` scaling is bypassed only when at least one column declares `flex`.
- Two consumer scenes opt in to demonstrate the API: `FleetScene` marks `name` and `route` as `flex: 1`; `RoutesScene`'s active-routes table marks `origin` as `flex: 1`. Other tables can opt in incrementally.

## Test plan

- [x] `npm run check` (typecheck + 1518 tests + build) all green
- [x] New `flex columns` describe block in `DataTable.test.ts` covers:
  - no-flex columns at exact base sum keep configured widths
  - single flex column absorbs the entire surplus
  - multiple flex columns split surplus proportionally to their flex values
  - sum of effective widths equals max(outer width, sum of base widths)
  - `setSize` re-flows: right-aligned cell text repositions when its column grows
- [ ] Visual screenshots not regenerated for this PR — the e2e fluid-layout spec covers the resolutions PR #264 touched and any visible improvement on wide displays will show up in the next CI run of those baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)