### PR TITLE
fix(ui): align group-tab strip with content area and seed initial contracts

### DIFF
--- a/packages/spacebiz-ui/src/Layout.ts
+++ b/packages/spacebiz-ui/src/Layout.ts
@@ -119,3 +119,9 @@ export const MAIN_CONTENT_WIDTH =
   MAX_CONTENT_WIDTH - SIDEBAR_WIDTH - CONTENT_GAP;
 export const FULL_CONTENT_LEFT = CONTENT_LEFT;
 export const FULL_CONTENT_WIDTH = MAX_CONTENT_WIDTH;
+
+/** Height of the horizontal group-tab strip shown in GameHUDScene when the
+ *  active content scene belongs to a multi-scene NavGroup (Empire, Ops).
+ *  Grouped scenes must offset their content by this amount so panels don't
+ *  render behind the strip. */
+export const GROUP_TAB_STRIP_HEIGHT = 28;

--- a/src/game/NewGameSetup.ts
+++ b/src/game/NewGameSetup.ts
@@ -44,6 +44,7 @@ import {
   initializeHubWithTerminal,
 } from "./hub/HubManager.ts";
 import { generateAmbassadors } from "./diplomacy/AmbassadorGenerator.ts";
+import { generateContracts } from "./contracts/ContractGenerator.ts";
 
 export interface NewGameResult {
   state: GameState;
@@ -484,5 +485,6 @@ export function createNewGame(
     diplomacy,
   };
 
-  return { state, startingSystemOptions };
+  const contracts = generateContracts(state, rng);
+  return { state: { ...state, contracts }, startingSystemOptions };
 }

--- a/src/scenes/CompetitionScene.ts
+++ b/src/scenes/CompetitionScene.ts
@@ -12,6 +12,7 @@ import {
   createStarfield,
   getLayout,
   attachReflowHandler,
+  GROUP_TAB_STRIP_HEIGHT,
 } from "../ui/index.ts";
 import {
   getIntelTier,
@@ -231,19 +232,21 @@ export class CompetitionScene extends Phaser.Scene {
   private relayout(): void {
     const theme = getTheme();
     const L = getLayout();
+    const contentTop = L.contentTop + GROUP_TAB_STRIP_HEIGHT;
+    const contentHeight = L.contentHeight - GROUP_TAB_STRIP_HEIGHT;
 
     // PortraitPanel: setPosition triggers mask refresh, then setSize.
-    this.portrait.setPosition(L.sidebarLeft, L.contentTop);
-    this.portrait.setSize(L.sidebarWidth, L.contentHeight);
+    this.portrait.setPosition(L.sidebarLeft, contentTop);
+    this.portrait.setSize(L.sidebarWidth, contentHeight);
 
     // Content panel.
-    this.contentPanel.setPosition(L.mainContentLeft, L.contentTop);
-    this.contentPanel.setSize(L.mainContentWidth, L.contentHeight);
+    this.contentPanel.setPosition(L.mainContentLeft, contentTop);
+    this.contentPanel.setSize(L.mainContentWidth, contentHeight);
 
     // Re-read content area after panel resize to get fresh inset coords.
     const content = this.contentPanel.getContentArea();
     const absX = L.mainContentLeft + content.x;
-    const absY = L.contentTop + content.y;
+    const absY = contentTop + content.y;
 
     // Tab strip.
     this.tabGroup.setPosition(absX, absY);

--- a/src/scenes/ContractsScene.ts
+++ b/src/scenes/ContractsScene.ts
@@ -22,6 +22,7 @@ import {
   getCargoIconKey,
   getCargoColor,
   attachReflowHandler,
+  GROUP_TAB_STRIP_HEIGHT,
 } from "../ui/index.ts";
 import {
   acceptContract,
@@ -380,19 +381,22 @@ export class ContractsScene extends Phaser.Scene {
 
   private relayout(): void {
     const L = getLayout();
+    const tabH = GROUP_TAB_STRIP_HEIGHT;
+    const contentTop = L.contentTop + tabH;
+    const contentHeight = L.contentHeight - tabH;
 
     // PortraitPanel: setPosition before setSize.
-    this.portrait.setPosition(L.sidebarLeft, L.contentTop);
-    this.portrait.setSize(L.sidebarWidth, L.contentHeight);
+    this.portrait.setPosition(L.sidebarLeft, contentTop);
+    this.portrait.setSize(L.sidebarWidth, contentHeight);
 
     // Main panel.
-    this.mainPanel.setPosition(L.mainContentLeft, L.contentTop);
-    this.mainPanel.setSize(L.mainContentWidth, L.contentHeight);
+    this.mainPanel.setPosition(L.mainContentLeft, contentTop);
+    this.mainPanel.setSize(L.mainContentWidth, contentHeight);
 
     // Tab strip below panel title.
     this.tabGroup.setPosition(
       L.mainContentLeft,
-      L.contentTop + PANEL_TITLE_HEIGHT,
+      contentTop + PANEL_TITLE_HEIGHT,
     );
     this.tabGroup.setSize(L.mainContentWidth, this.tabGroup.height);
 
@@ -400,7 +404,7 @@ export class ContractsScene extends Phaser.Scene {
     // containers are relative to the container origin (set by TabGroup).
     const contentInnerW = L.mainContentWidth - CONTENT_INNER_INSET * 2;
     const tableHeight =
-      L.contentHeight -
+      contentHeight -
       PANEL_TITLE_HEIGHT -
       TAB_BAR_HEIGHT -
       SUMMARY_HEIGHT -

--- a/src/scenes/DiplomacyScene.ts
+++ b/src/scenes/DiplomacyScene.ts
@@ -21,6 +21,7 @@ import {
   createStarfield,
   getLayout,
   getTheme,
+  GROUP_TAB_STRIP_HEIGHT,
 } from "../ui/index.ts";
 import type { StandingTierName } from "../game/diplomacy/StandingTiers.ts";
 import {
@@ -190,21 +191,23 @@ export class DiplomacyScene extends Phaser.Scene {
 
   private relayout(): void {
     const L = getLayout();
+    const contentTop = L.contentTop + GROUP_TAB_STRIP_HEIGHT;
+    const contentHeight = L.contentHeight - GROUP_TAB_STRIP_HEIGHT;
 
-    // Header heading + counter.
-    this.headingLabel.setPosition(L.mainContentLeft, L.contentTop - 28);
+    // Header heading + counter sit just above the panels.
+    this.headingLabel.setPosition(L.mainContentLeft, contentTop - 28);
     this.headerCounter.setPosition(
       L.mainContentLeft + L.mainContentWidth - 8,
-      L.contentTop - 28,
+      contentTop - 28,
     );
 
     // Target table panel.
     const tableW = Math.floor(L.mainContentWidth * 0.55);
-    this.targetTablePanel.setPosition(L.mainContentLeft, L.contentTop);
-    this.targetTablePanel.setSize(tableW, L.contentHeight);
+    this.targetTablePanel.setPosition(L.mainContentLeft, contentTop);
+    this.targetTablePanel.setSize(tableW, contentHeight);
     const tableContent = this.targetTablePanel.getContentArea();
     const tableAbsX = L.mainContentLeft + tableContent.x;
-    const tableAbsY = L.contentTop + tableContent.y;
+    const tableAbsY = contentTop + tableContent.y;
     this.targetTableFrame.setPosition(tableAbsX, tableAbsY);
     this.targetTableFrame.setSize(tableContent.width, tableContent.height - 16);
     this.targetTable.setSize(tableContent.width, tableContent.height - 16);
@@ -212,11 +215,11 @@ export class DiplomacyScene extends Phaser.Scene {
     // Action panel.
     const panelX = L.mainContentLeft + tableW + 8;
     const panelW = L.mainContentWidth - tableW - 8;
-    this.actionPanel.setPosition(panelX, L.contentTop);
-    this.actionPanel.setSize(panelW, L.contentHeight);
+    this.actionPanel.setPosition(panelX, contentTop);
+    this.actionPanel.setSize(panelW, contentHeight);
     const actionContent = this.actionPanel.getContentArea();
     const actionAbsX = panelX + actionContent.x;
-    const actionAbsY = L.contentTop + actionContent.y;
+    const actionAbsY = contentTop + actionContent.y;
     this.actionStatusLabel.setPosition(actionAbsX, actionAbsY);
     this.actionStatusLabel.setSize(actionContent.width, 24);
     this.queuedSummary.setPosition(

--- a/src/scenes/EmpireScene.ts
+++ b/src/scenes/EmpireScene.ts
@@ -12,6 +12,7 @@ import {
   createStarfield,
   getLayout,
   attachReflowHandler,
+  GROUP_TAB_STRIP_HEIGHT,
 } from "../ui/index.ts";
 import { TARIFF_DIPLOMATIC_MULTIPLIER } from "../data/constants.ts";
 
@@ -159,19 +160,21 @@ export class EmpireScene extends Phaser.Scene {
 
   private relayout(): void {
     const L = getLayout();
+    const contentTop = L.contentTop + GROUP_TAB_STRIP_HEIGHT;
+    const contentHeight = L.contentHeight - GROUP_TAB_STRIP_HEIGHT;
 
     // PortraitPanel: setPosition before setSize.
-    this.portrait.setPosition(L.sidebarLeft, L.contentTop);
-    this.portrait.setSize(L.sidebarWidth, L.contentHeight);
+    this.portrait.setPosition(L.sidebarLeft, contentTop);
+    this.portrait.setSize(L.sidebarWidth, contentHeight);
 
     // Content panel.
-    this.contentPanel.setPosition(L.mainContentLeft, L.contentTop);
-    this.contentPanel.setSize(L.mainContentWidth, L.contentHeight);
+    this.contentPanel.setPosition(L.mainContentLeft, contentTop);
+    this.contentPanel.setSize(L.mainContentWidth, contentHeight);
 
     // Re-read content area after panel resize.
     const content = this.contentPanel.getContentArea();
     const absX = L.mainContentLeft + content.x;
-    const absY = L.contentTop + content.y;
+    const absY = contentTop + content.y;
 
     const toolbarH = 32;
 

--- a/src/scenes/GameHUDScene.ts
+++ b/src/scenes/GameHUDScene.ts
@@ -9,6 +9,7 @@ import {
   FloatingText,
   AdviserPanel,
   attachReflowHandler,
+  GROUP_TAB_STRIP_HEIGHT,
 } from "../ui/index.ts";
 import { colorToString } from "@spacebiz/ui";
 import { SettingsPanel } from "../ui/SettingsPanel.ts";
@@ -1148,10 +1149,10 @@ export class GameHUDScene extends Phaser.Scene {
     }
     this.tabStrip.setVisible(true);
 
-    const stripHeight = 28;
+    const stripHeight = GROUP_TAB_STRIP_HEIGHT;
     const stripTop = L.hudTopBarHeight;
-    const stripLeft = L.navSidebarWidth + 12;
-    const stripWidth = L.gameWidth - stripLeft - 12;
+    const stripLeft = L.sidebarLeft;
+    const stripWidth = L.maxContentWidth;
 
     // Translucent background — keeps scene content visible behind tabs but
     // creates a clear "this is chrome" affordance.

--- a/src/scenes/StationBuilderScene.ts
+++ b/src/scenes/StationBuilderScene.ts
@@ -14,6 +14,7 @@ import {
   attachReflowHandler,
   StationBuilderGrid,
   ROOM_COLORS,
+  GROUP_TAB_STRIP_HEIGHT,
 } from "../ui/index.ts";
 import type { CellEventPayload } from "../ui/StationBuilderGrid.ts";
 import {
@@ -285,30 +286,29 @@ export class StationBuilderScene extends Phaser.Scene {
    */
   private relayout(): void {
     const L = getLayout();
+    const contentTop = L.contentTop + GROUP_TAB_STRIP_HEIGHT;
+    const contentHeight = L.contentHeight - GROUP_TAB_STRIP_HEIGHT;
 
     // PortraitPanel: setPosition before setSize.
-    this.portrait.setPosition(L.sidebarLeft, L.contentTop);
-    this.portrait.setSize(L.sidebarWidth, L.contentHeight);
+    this.portrait.setPosition(L.sidebarLeft, contentTop);
+    this.portrait.setSize(L.sidebarWidth, contentHeight);
 
     // Grid panel + grid widget.
-    this.gridPanel.setPosition(L.mainContentLeft, L.contentTop);
+    this.gridPanel.setPosition(L.mainContentLeft, contentTop);
     this.gridPanel.setSize(L.mainContentWidth, GRID_PANEL_HEIGHT);
     const gridArea = this.getGridArea();
     this.grid.setPosition(gridArea.x, gridArea.y);
     this.grid.setSize(gridArea.width, gridArea.height);
 
     // Palette panel.
-    const paletteY = L.contentTop + GRID_PANEL_HEIGHT + PANEL_GAP;
+    const paletteY = contentTop + GRID_PANEL_HEIGHT + PANEL_GAP;
     this.palettePanel.setPosition(L.mainContentLeft, paletteY);
     this.palettePanel.setSize(L.mainContentWidth, PALETTE_PANEL_HEIGHT);
 
     // Info panel.
     const infoY = paletteY + PALETTE_PANEL_HEIGHT + PANEL_GAP;
     const infoH =
-      L.contentHeight -
-      GRID_PANEL_HEIGHT -
-      PALETTE_PANEL_HEIGHT -
-      PANEL_GAP * 2;
+      contentHeight - GRID_PANEL_HEIGHT - PALETTE_PANEL_HEIGHT - PANEL_GAP * 2;
     this.infoPanel.setPosition(L.mainContentLeft, infoY);
     this.infoPanel.setSize(L.mainContentWidth, Math.max(infoH, 120));
 

--- a/src/scenes/TechTreeScene.ts
+++ b/src/scenes/TechTreeScene.ts
@@ -13,6 +13,7 @@ import {
   ProgressBar,
   Modal,
   attachReflowHandler,
+  GROUP_TAB_STRIP_HEIGHT,
 } from "../ui/index.ts";
 import { TechTreeGrid, BRANCH_LABELS } from "../ui/TechTreeGrid.ts";
 import {
@@ -167,19 +168,21 @@ export class TechTreeScene extends Phaser.Scene {
 
   private relayout(): void {
     const L = getLayout();
+    const contentTop = L.contentTop + GROUP_TAB_STRIP_HEIGHT;
+    const contentHeight = L.contentHeight - GROUP_TAB_STRIP_HEIGHT;
 
     // PortraitPanel: setPosition before setSize.
-    this.portrait.setPosition(L.sidebarLeft, L.contentTop);
-    this.portrait.setSize(L.sidebarWidth, L.contentHeight);
+    this.portrait.setPosition(L.sidebarLeft, contentTop);
+    this.portrait.setSize(L.sidebarWidth, contentHeight);
 
     // Main panel.
-    this.mainPanel.setPosition(L.mainContentLeft, L.contentTop);
-    this.mainPanel.setSize(L.mainContentWidth, L.contentHeight);
+    this.mainPanel.setPosition(L.mainContentLeft, contentTop);
+    this.mainPanel.setSize(L.mainContentWidth, contentHeight);
 
     const panelX = L.mainContentLeft;
-    const panelY = L.contentTop;
+    const panelY = contentTop;
     const panelW = L.mainContentWidth;
-    const panelH = L.contentHeight;
+    const panelH = contentHeight;
 
     // Status / current-research text — reposition only.
     this.rpStatusText.setPosition(panelX + 16, panelY + 44);


### PR DESCRIPTION
## Summary

- Fix group-tab strip alignment: was 22px left of content area (`navSidebarWidth+12=68`) — now uses `sidebarLeft` and `maxContentWidth` so tabs align with the panel edges
- Apply `GROUP_TAB_STRIP_HEIGHT` (28px) offset in all grouped scenes (ContractsScene, EmpireScene, CompetitionScene, DiplomacyScene, TechTreeScene, StationBuilderScene) so panels don't render behind the strip
- Seed initial contracts in `NewGameSetup.createNewGame()` so ContractsScene shows offers on turn 0 (Empire group is always visible because DiplomacyScene is always unlocked)
- Extract `GROUP_TAB_STRIP_HEIGHT = 28` constant to `packages/spacebiz-ui/src/Layout.ts` so strip height is a single source of truth across HUD and content scenes

## Test plan

- [ ] New game: open Contracts tab immediately — contracts should be visible in the grid
- [ ] Group-tab strip should align horizontally with the left edge of the main content area
- [ ] All grouped scenes (Empire, Diplomacy, Competition, Contracts, Tech Tree, Station Builder) should have their panels start below the strip with no overlap
- [ ] Resize window — panels should reflow correctly and stay below the strip

🤖 Generated with [Claude Code](https://claude.com/claude-code)