### PR TITLE
fix(ui): fill viewport height, flush canvas edges, and fix contracts table

### DIFF
--- a/src/scenes/ContractsScene.ts
+++ b/src/scenes/ContractsScene.ts
@@ -460,7 +460,7 @@ export class ContractsScene extends Phaser.Scene {
         reward: rewardSummary(c),
       };
     });
-    this.availableTable.setData(rows);
+    this.availableTable.setRows(rows);
     this.updateAcceptButton();
   }
 
@@ -632,7 +632,7 @@ export class ContractsScene extends Phaser.Scene {
         reward: rewardSummary(c),
       };
     });
-    this.activeTable.setData(rows);
+    this.activeTable.setRows(rows);
     this.updateAbandonButton();
   }
 

--- a/src/site.css
+++ b/src/site.css
@@ -615,9 +615,9 @@ canvas {
 }
 
 .game-frame--hero {
-  /* Fill available viewport height, leave room for thin nav */
-  height: calc(100vh - var(--nav-height) - 2rem);
-  height: calc(100dvh - var(--nav-height) - 2rem);
+  /* Fill the full viewport below the nav — no bottom gap */
+  height: calc(100vh - var(--nav-height));
+  height: calc(100dvh - var(--nav-height));
   min-height: 360px;
 }
 
@@ -1047,7 +1047,7 @@ canvas {
 }
 
 .game-frame__screen--hero {
-  padding: clamp(0.3rem, 0.8vw, 0.5rem);
+  padding: 0;
 }
 
 .game-frame__screen::before,
@@ -1091,6 +1091,10 @@ canvas {
 .viewport--hero {
   height: 100%;
   aspect-ratio: auto;
+  border-radius: 0;
+  border: none;
+  background: none;
+  box-shadow: none;
 }
 
 .viewport::before {
@@ -1112,9 +1116,6 @@ canvas {
 #game-container {
   position: absolute;
   inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 #game-container canvas {
@@ -1482,7 +1483,7 @@ details[open] summary::after {
   }
 
   .game-frame__screen--hero {
-    padding: 0.25rem;
+    padding: 0;
   }
 
   .viewport--hero {
@@ -1494,7 +1495,6 @@ details[open] summary::after {
      */
     aspect-ratio: 4 / 3;
     max-height: calc(100dvh - var(--nav-height) - 5rem);
-    border-radius: 14px;
   }
 
   .site-header {
@@ -1585,7 +1585,7 @@ details[open] summary::after {
   }
 
   .game-frame__screen--hero {
-    padding: 0.15rem;
+    padding: 0;
   }
 
   .frame-caption--hero {


### PR DESCRIPTION
## Summary

- **Vertical fill**: `game-frame--hero` removed the `2rem` bottom gap — frame now fills the full viewport height below the nav bar
- **Flush canvas**: `game-frame__screen--hero` padding zeroed at all breakpoints; `viewport--hero` clears its own border-radius/border/shadow so the outer game-frame provides the only chrome — canvas fills edge-to-edge
- **Horizontal centering**: Removed `display:flex; align-items/justify-content:center` from `#game-container` — it was double-offsetting the canvas against Phaser's own `CENTER_BOTH` margin-based centering
- **Contracts empty grid bug**: `availableTable.setData(rows)` and `activeTable.setData(rows)` were calling Phaser's base `GameObject.setData()` key-value store instead of `DataTable.setRows()`. The summary ("4 contracts available") computed correctly because it reads from state, but the table grid never received any rows. Fixed both call sites to `setRows(rows)`.

## Test plan

- [ ] Game frame fills the full viewport below the nav with no bottom gap
- [ ] Canvas fills edge-to-edge inside the frame (no inner padding gaps)
- [ ] Canvas is horizontally centered (not shifted left or right)
- [ ] Contracts → Available tab shows contract rows in the grid (not empty)
- [ ] Contracts → Active tab shows active contract rows after accepting one
- [ ] Resize window — canvas reflowss correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)